### PR TITLE
Move `print_err` macro to a common file

### DIFF
--- a/rust/src/editor.rs
+++ b/rust/src/editor.rs
@@ -25,19 +25,6 @@ use view::View;
 
 use ::send;
 
-macro_rules! print_err {
-    ($($arg:tt)*) => (
-        {
-            use std::io::prelude::*;
-            if let Err(e) = write!(&mut ::std::io::stderr(), "{}\n", format_args!($($arg)*)) {
-                panic!("Failed to write to stderr.\
-                    \nOriginal error output: {}\
-                    \nSecondary error writing to stderr: {}", format!($($arg)*), e);
-            }
-        }
-    )
-}
-
 const MODIFIER_SHIFT: u64 = 2;
 
 pub struct Editor {

--- a/rust/src/linewrap.rs
+++ b/rust/src/linewrap.rs
@@ -16,20 +16,6 @@
 
 use time;
 
-// TODO: figure out how not to duplcate this
-macro_rules! print_err {
-    ($($arg:tt)*) => (
-        {
-            use std::io::prelude::*;
-            if let Err(e) = write!(&mut ::std::io::stderr(), "{}\n", format_args!($($arg)*)) {
-                panic!("Failed to write to stderr.\
-                    \nOriginal error output: {}\
-                    \nSecondary error writing to stderr: {}", format!($($arg)*), e);
-            }
-        }
-    )
-}
-
 use xi_rope::rope::{Rope, RopeInfo};
 use xi_rope::tree::Cursor;
 use xi_rope::interval::Interval;

--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -1,3 +1,17 @@
+/// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 macro_rules! print_err {
     ($($arg:tt)*) => (
         {

--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -1,0 +1,12 @@
+macro_rules! print_err {
+    ($($arg:tt)*) => (
+        {
+            use std::io::prelude::*;
+            if let Err(e) = write!(&mut ::std::io::stderr(), "{}\n", format_args!($($arg)*)) {
+                panic!("Failed to write to stderr.\
+                    \nOriginal error output: {}\
+                    \nSecondary error writing to stderr: {}", format!($($arg)*), e);
+            }
+        }
+    )
+}

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -19,6 +19,9 @@ use std::io;
 use std::io::{Read, Write};
 use serde_json::Value;
 
+#[macro_use]
+mod macros;
+
 mod editor;
 mod view;
 mod linewrap;
@@ -27,19 +30,6 @@ use editor::Editor;
 
 extern crate xi_rope;
 extern crate xi_unicode;
-
-macro_rules! print_err {
-    ($($arg:tt)*) => (
-        {
-            use std::io::prelude::*;
-            if let Err(e) = write!(&mut ::std::io::stderr(), "{}\n", format_args!($($arg)*)) {
-                panic!("Failed to write to stderr.\
-                    \nOriginal error output: {}\
-                    \nSecondary error writing to stderr: {}", format!($($arg)*), e);
-            }
-        }
-    )
-}
 
 // TODO: should provide result
 pub fn send(v: &Value) {

--- a/rust/src/view.rs
+++ b/rust/src/view.rs
@@ -12,20 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO: figure out how not to duplcate this
-macro_rules! print_err {
-    ($($arg:tt)*) => (
-        {
-            use std::io::prelude::*;
-            if let Err(e) = write!(&mut ::std::io::stderr(), "{}\n", format_args!($($arg)*)) {
-                panic!("Failed to write to stderr.\
-                    \nOriginal error output: {}\
-                    \nSecondary error writing to stderr: {}", format!($($arg)*), e);
-            }
-        }
-    )
-}
-
 use std::cmp::{min,max};
 
 use serde_json::Value;


### PR DESCRIPTION
In order to avoid duplicating macros like that, you can simply put them in a module that gets added to your root first, and has a `#[macro_use]` annotation.