### PR TITLE
Add link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You need Xcode 7 and [Rust](https://www.rust-lang.org/). You should have
 `cargo` in your path.
 
 ```
-> git clone <this repo>
+> git clone https://github.com/google/xi-editor
 > cd xi-editor
 > xcodebuild
 > open build/Release/XiEditor.app


### PR DESCRIPTION
Instead of saying "<this repo>" show the location of the repo. Reason being, most people reading the README that want to take action will just want to copy the direction and use it.

Thanks!