### PR TITLE
Refactor front-end/back-end protocol to allow tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ recommended and supported). You should have `cargo` in your path.
 Or `open XiEditor.xcodeproj` and hit the Run button.
 
 It will look better if you have [InconsolataGo](http://levien.com/type/myfonts/inconsolata.html)
-installed, a customized version Inconsolata tuned for code editing. To choose other
+installed, a customized version of Inconsolata tuned for code editing. To choose other
 fonts, edit the `CTFontCreateWithName()` call in EditView.swift.
 
 ### Building the core

--- a/XiEditor/AppWindowController.swift
+++ b/XiEditor/AppWindowController.swift
@@ -31,7 +31,9 @@ class AppWindowController: NSWindowController {
     override func windowDidLoad() {
         super.windowDidLoad()
         //window?.backgroundColor = NSColor.whiteColor()
+        let tabName = coreConnection?.sendRpc("new_tab", params: []) as! String
         editView.coreConnection = coreConnection
+        editView.tabName = tabName
 
         // set up autolayout constraints
         let views = ["editView": editView, "clipView": scrollView.contentView]
@@ -41,6 +43,10 @@ class AppWindowController: NSWindowController {
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(AppWindowController.boundsDidChangeNotification(_:)), name: NSViewBoundsDidChangeNotification, object: scrollView.contentView)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(AppWindowController.frameDidChangeNotification(_:)), name: NSViewFrameDidChangeNotification, object: scrollView)
         updateEditViewScroll()
+    }
+
+    func windowWillClose(_: NSNotification) {
+        editView.coreConnection?.sendRpcAsync("delete_tab", params: ["tab": editView.tabName!] as [String : AnyObject])
     }
 
     func boundsDidChangeNotification(notification: NSNotification) {
@@ -60,7 +66,7 @@ class AppWindowController: NSWindowController {
         if filename == nil {
             saveDocumentAs(sender)
         } else {
-            coreConnection?.sendJson(["save", filename!])
+            editView.sendRpcAsync("save", params: ["filename": filename!])
         }
     }
     

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,4 +1,4 @@
-/// Copyright 2016 Google Inc. All rights reserved.
+// Copyright 2016 Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,21 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate serde;
 extern crate serde_json;
 extern crate time;
 
 use std::io;
-use std::io::{Read, Write};
+use std::io::{BufRead, Write};
 use serde_json::Value;
 
 #[macro_use]
 mod macros;
 
+mod tabs;
 mod editor;
 mod view;
 mod linewrap;
 
-use editor::Editor;
+use tabs::Tabs;
 use std::io::Error;
 
 extern crate xi_rope;
@@ -36,39 +38,28 @@ pub fn send(v: &Value) -> Result<(), Error> {
     let mut s = serde_json::to_string(v).unwrap();
     s.push('\n');
     //print_err!("from core: {}", s);
-    let size = s.len();
-    let mut sizebuf = [0; 8];
-    for (i, item) in sizebuf.iter_mut().enumerate() {
-        *item = (((size as u64) >> (i * 8)) & 0xff) as u8;
-    }
-    let stdout = io::stdout();
-    let mut stdout_handle = stdout.lock();
-    if let Err(e) = stdout_handle.write_all(&sizebuf) {
-        return Err(e);
-    }
-    stdout_handle.write_all(s.as_bytes())
-    // flush is not needed because of the LineWriter on stdout
-    //let _ = stdout_handle.flush();
+    io::stdout().write_all(s.as_bytes())
 }
 
 fn main() {
     let stdin = io::stdin();
     let mut stdin_handle = stdin.lock();
-    let mut sizebuf = [0; 8];
-    let mut editor = Editor::new();
-    while stdin_handle.read_exact(&mut sizebuf).is_ok() {
-        // byteorder would be more direct
-        let size = sizebuf.iter().enumerate().fold(0, |s, (i, &b)| s + ((b as u64) << (i * 8)));
-        let mut buf = vec![0; size as usize];
-        if stdin_handle.read_exact(&mut buf).is_ok() {
-            if let Ok(data) = serde_json::from_slice::<Value>(&buf) {
-                print_err!("to core: {:?}", data);
-                if let Some(array) = data.as_array() {
-                    if let Some(cmd) = array[0].as_string() {
-                        editor.do_cmd(cmd, &array[1]);
-                    }
+    let mut buf = String::new();
+    let mut tabs = Tabs::new();
+    while stdin_handle.read_line(&mut buf).is_ok() {
+        if buf.is_empty() {
+            break;
+        }
+        if let Ok(data) = serde_json::from_slice::<Value>(buf.as_bytes()) {
+            print_err!("to core: {:?}", data);
+            if let Some(req) = data.as_object() {
+                if let (Some(method), Some(params)) =
+                        (req.get("method").and_then(|v| v.as_string()), req.get("params")) {
+                    let id = req.get("id");
+                    tabs.handle_rpc(method, params, id);
                 }
             }
         }
+        buf.clear();
     }
 }

--- a/rust/src/tabs.rs
+++ b/rust/src/tabs.rs
@@ -1,0 +1,120 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A container for all the tabs being edited. Also functions as main dispatch for RPC.
+
+use std::collections::BTreeMap;
+use serde_json::Value;
+use serde_json::builder::ObjectBuilder;
+use serde::ser::Serialize;
+
+use editor::Editor;
+use ::send;
+
+pub struct Tabs {
+    tabs: BTreeMap<String, Editor>,
+    id_counter: usize,
+}
+
+impl Tabs {
+    pub fn new() -> Tabs {
+        Tabs {
+            tabs: BTreeMap::new(),
+            id_counter: 0,
+        }
+    }
+
+    // TODO: refactor response in here, rather than explicitly calling "respond"
+    pub fn handle_rpc(&mut self, method: &str, params: &Value, id: Option<&Value>) {
+        match method {
+            "new_tab" => self.do_new_tab(id),
+            "delete_tab" => self.do_delete_tab(params),
+            "edit" => self.do_edit(params, id),
+            _ => print_err!("unknown method {}", method),
+        }
+    }
+
+    pub fn respond<V>(&self, result: V, id: Option<&Value>)
+            where V: Serialize {
+        if let Some(id) = id {
+            if let Err(e) = send(&ObjectBuilder::new()
+                .insert("id", id)
+                .insert("result", result)
+                .unwrap()
+            ) {
+                print_err!("error {} sending response to RPC {:?}", e, id);
+            }
+        } else {
+            print_err!("tried to respond with no id");
+        }
+    }
+
+    fn do_new_tab(&mut self, id: Option<&Value>) {
+        let tabname = self.new_tab();
+        self.respond(&tabname, id);
+    }
+
+    fn do_delete_tab(&mut self, params: &Value) {
+        if let Some(params) = params.as_object() {
+            let tab = params.get("tab").unwrap().as_string().unwrap();
+            self.delete_tab(tab);
+        }
+    }
+
+    fn do_edit(&mut self, params: &Value, id: Option<&Value>) {
+        if let Some(params) = params.as_object() {
+            let tab = params.get("tab").unwrap().as_string().unwrap();
+            let response = {
+                if let Some(editor) = self.tabs.get_mut(tab) {
+                    let method = params.get("method").unwrap().as_string().unwrap();
+                    let params = params.get("params").unwrap();
+                    editor.do_rpc(method, params)
+                } else {
+                    print_err!("tab not found: {}", tab);
+                    None
+                }
+            };
+            if let Some(response) = response {
+                self.respond(response, id);
+            } else if let Some(id) = id {
+                print_err!("rpc with id={:?} not responded", id);
+            }
+        }
+    }
+
+    fn new_tab(&mut self) -> String {
+        let tabname = self.id_counter.to_string();
+        self.id_counter += 1;
+        let editor = Editor::new(&tabname);
+        self.tabs.insert(tabname.clone(), editor);
+        tabname
+    }
+
+    fn delete_tab(&mut self, tabname: &str) {
+        self.tabs.remove(tabname);
+    }
+}
+
+// arguably this should be a method on a newtype for tab. but keep things simple for now
+pub fn update_tab(update: &Value, tab: &str) {
+    if let Err(e) = send(&ObjectBuilder::new()
+        .insert("method", "update")
+        .insert_object("params", |builder|
+            builder.insert("tab", tab)
+                .insert("update", update))
+        .unwrap()
+    ) {
+        print_err!("send error on update_tab: {}", e);
+    }
+}

--- a/rust/src/view.rs
+++ b/rust/src/view.rs
@@ -15,7 +15,7 @@
 use std::cmp::{min,max};
 
 use serde_json::Value;
-use serde_json::builder::ArrayBuilder;
+use serde_json::builder::{ArrayBuilder,ObjectBuilder};
 
 use xi_rope::rope::{Rope, LinesMetric, RopeInfo};
 use xi_rope::delta::{Delta};
@@ -187,21 +187,16 @@ impl View {
         let last_line = self.first_line + self.height + SCROLL_SLOP;
         let lines = self.render_lines(text, first_line, last_line);
         let height = self.offset_to_line_col(text, text.len()).0 + 1;
-        ArrayBuilder::new()
-            .push("settext")
-            .push_object(|builder| {
-                let mut builder = builder
-                    .insert("lines", lines)
-                    .insert("first_line", first_line)
-                    .insert("height", height);
-                if let Some(scrollto) = scroll_to {
-                    let (line, col) = self.offset_to_line_col(text, scrollto);
-                    builder = builder.insert_array("scrollto", |builder|
-                        builder.push(line).push(col));
-                }
-                builder
-            })
-            .unwrap()
+        let mut builder = ObjectBuilder::new()
+            .insert("lines", lines)
+            .insert("first_line", first_line)
+            .insert("height", height);
+        if let Some(scrollto) = scroll_to {
+            let (line, col) = self.offset_to_line_col(text, scrollto);
+            builder = builder.insert_array("scrollto", |builder|
+                builder.push(line).push(col));
+        }
+        builder.unwrap()
     }
 
     // How should we count "column"? Valid choices include:


### PR DESCRIPTION
A significant restructuring, motivated to allow editing of more than
one tab at a time. With this commit, the front-end/back-end protocol
supports multiple tabs, but that functionality is not implemented in
the front-end yet.

The RPC mechanism has been reworked to be much more like JSON-RPC 2.
Thus, this patch closes #29.

This also closes #44, which describes the motivation for these
changes.