### PR TITLE
some hotkey develop

### DIFF
--- a/rust/src/editor.rs
+++ b/rust/src/editor.rs
@@ -345,6 +345,18 @@ impl Editor {
         }
     }
 
+    fn move_to_beginning_of_document(&mut self) {
+        let offset = 0;
+
+        self.set_cursor(offset, true);
+    }
+
+    fn move_to_end_of_document(&mut self) {
+        let offset = self.text.len();
+
+        self.set_cursor(offset, true);
+    }
+
     fn scroll_page_up(&mut self) {
         let scroll = -max(self.view.scroll_height() as isize - 2, 1);
         let old_offset = self.view.sel_end;
@@ -376,7 +388,7 @@ impl Editor {
                     self.move_up();
                 }
                 "\u{F701}" => {  // down arrow
-                    self.   move_down();
+                    self.move_down();
                 }
                 "\u{F702}" => {  // left arrow
                     self.move_left();
@@ -606,6 +618,10 @@ impl Editor {
             "move_to_right_end_of_line_and_modify_selection" => async({ self.modify_selection(); self.move_to_right_end_of_line() }),
             "move_to_beginning_of_paragraph" => async(self.cursor_start()),
             "move_to_end_of_paragraph" => async(self.cursor_end()),
+            "move_to_beginning_of_document" => async(self.move_to_beginning_of_document()),
+            "move_to_beginning_of_document_and_modify_selection" => async({ self.modify_selection(); self.move_to_beginning_of_document() }),
+            "move_to_end_of_document" => async(self.move_to_end_of_document()),
+            "move_to_end_of_document_and_modify_selection" => async({ self.modify_selection(); self.move_to_end_of_document() }),
             "scroll_page_up" |
             "page_up" => async(self.scroll_page_up()),
             "page_up_and_modify_selection" => async({ self.modify_selection(); self.scroll_page_up() }),

--- a/rust/src/editor.rs
+++ b/rust/src/editor.rs
@@ -199,7 +199,25 @@ impl Editor {
         }
     }
 
+    fn delete_forward(&mut self) {
+        if self.view.sel_start == self.view.sel_end {
+            self.move_right(0);
+        }
+
+        self.delete();
+    }
+
     fn delete_backward(&mut self) {
+        self.delete();
+    }
+
+    fn delete_to_beginning_of_line(&mut self) {
+        self.move_left(MODIFIER_SHIFT | MODIFIER_COMMAND);
+
+        self.delete();
+    }
+
+    fn delete(&mut self) {
         let start = if self.view.sel_start != self.view.sel_end {
             self.view.sel_min()
         } else {
@@ -210,6 +228,7 @@ impl Editor {
                 self.view.sel_max()
             }
         };
+
         if start < self.view.sel_max() {
             self.this_edit_type = EditType::Delete;
             let del_interval = Interval::new_closed_open(start, self.view.sel_max());
@@ -429,7 +448,7 @@ impl Editor {
         }
     }
 
-    fn do_scroll(&mut self, args: &Value) {
+    fn do_scroll(&mut self, args: &Value) {    
         self.this_edit_type = self.last_edit_type;  // doesn't break undo group
         if let Some(array) = args.as_array() {
             if let (Some(first), Some(last)) = (array[0].as_i64(), array[1].as_i64()) {
@@ -567,7 +586,9 @@ impl Editor {
             "render_lines" => Some(self.do_render_lines(params)),
             "key" => async(self.do_key(params)),
             "insert" => async(self.do_insert(params)),
+            "delete_forward" => async(self.delete_forward()),
             "delete_backward" => async(self.delete_backward()),
+            "delete_to_beginning_of_line" => async(self.delete_to_beginning_of_line()),
             "delete_to_end_of_paragraph" => async(self.delete_to_end_of_paragraph(kill_ring)),
             "insert_newline" => async(self.insert_newline()),
             "move_up" => async(self.move_up(0)),


### PR DESCRIPTION
I develop below functions.

[move to left end of line]
[move to right end of line]
[move to left end of line and modify selection]
[move to right end of line and modify selection]
[delete forward]
[delete beginning of line]

------------ opinion ----------
I think add function of getting end of line offset to  "view.rs" is better.

Because in move_left() / move_right(),
[calculate end of line] part's source is looks dirty.

I think

    let offset = self.view.offset_to_offset_of_end_of_line(&self.text, self.view.sel_end);

is more beautiful than

        let line_col = self.view.offset_to_line_col(&self.text, self.view.sel_end);
        let mut offset = self.text.len();

        // calculate end of line
        let next_line_offset = self.view.line_col_to_offset(&self.text, line_col.0 + 1, 0);
        if offset > next_line_offset {
            if let Some(prev) = self.text.prev_grapheme_offset(next_line_offset) {
                offset = prev;
            }
        }