### PR TITLE
Remove trailing whitespaces to keep code and docs as clean as possible

### DIFF
--- a/doc/crdt.md
+++ b/doc/crdt.md
@@ -8,7 +8,7 @@ This problem is fundamentally similar to collaborative editing, and there is a l
 
 In addition, should xi ever be extended to collaborative editing, having the model be based on the CRDT abstraction will make implementation much easier, leaving only the small matter of efficient distributed CRDTs themselves.
 
-This document is structured into two main sections. The first presents the model at a conceptual level, and effectively functions as a spec for how out-of-order edits should be merged, as well as the desired semantics for undo. The second details a simple and efficient centralized implementation, which faithfully implements the model but bypasses the complexity of a true distributed environment. 
+This document is structured into two main sections. The first presents the model at a conceptual level, and effectively functions as a spec for how out-of-order edits should be merged, as well as the desired semantics for undo. The second details a simple and efficient centralized implementation, which faithfully implements the model but bypasses the complexity of a true distributed environment.
 
 ## CRDT model
 

--- a/rust/rope/src/tree.rs
+++ b/rust/rope/src/tree.rs
@@ -179,7 +179,7 @@ impl<N: NodeInfo> Node<N> {
     fn height(&self) -> usize {
         self.0.height
     }
-    
+
     fn is_leaf(&self) -> bool {
         self.0.height == 0
     }
@@ -260,10 +260,10 @@ impl<N: NodeInfo> Node<N> {
 
     pub fn concat(rope1: Node<N>, rope2: Node<N>) -> Node<N> {
         use std::cmp::Ordering;
-        
+
         let h1 = rope1.height();
         let h2 = rope2.height();
-        
+
         match h1.cmp(&h2) {
             Ordering::Less => {
                 let children2 = rope2.get_children();
@@ -517,7 +517,7 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
         let result = M::is_boundary(l, l.len());
         let _ = self.next_leaf();
         result
-    } 
+    }
 
     pub fn prev<M: Metric<N>>(&mut self) -> Option<(usize)> {
         if self.position == 0 || self.leaf.is_none() {
@@ -558,7 +558,7 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
                 }
                 if let Some(offset_in_leaf) = M::prev(l, l.len()) {
                     self.position = self.offset_of_leaf + offset_in_leaf;
-                    return Some(self.position);                    
+                    return Some(self.position);
                 } else {
                     panic!("metric is inconsistent, metric > 0 but no boundary");
                 }

--- a/rust/src/editor.rs
+++ b/rust/src/editor.rs
@@ -206,7 +206,7 @@ impl Editor {
 
     fn delete_forward(&mut self) {
         if self.view.sel_start == self.view.sel_end {
-            let offset = 
+            let offset =
                 if let Some(pos) = self.text.next_grapheme_offset(self.view.sel_end) {
                     pos
                 } else {

--- a/rust/src/view.rs
+++ b/rust/src/view.rs
@@ -144,7 +144,7 @@ impl View {
                     builder.push("sel")
                         .push(sel_start_ix)
                         .push(sel_end_ix)
-                );                
+                );
             }
             if line_num == cursor_line {
                 line_builder = line_builder.push_array(|builder|


### PR DESCRIPTION
Hi guys, great work with this editor!

I'm getting in touch with the code base, also, I'm starting in the open source world with contributions, so I just removed the extra spaces of the code and docs as a starting point.

I hope to contribute solving a issue soon.

Thanks =)