### PR TITLE
Changed to use a more reliable path for plugin loading

### DIFF
--- a/rust/src/run_plugin.rs
+++ b/rust/src/run_plugin.rs
@@ -27,14 +27,13 @@ pub type PluginPeer = RpcWriter<ChildStdin>;
 
 pub fn start_plugin<F: 'static + Send + FnOnce(PluginPeer) -> ()>(f: F) {
     thread::spawn(move || {
-        let path = match env::args_os().next() {
-            Some(path) => path,
-            _ => {
-                print_err!("empty args, that's strange");
+        let mut pathbuf: PathBuf = match env::current_exe() {
+            Ok(pathbuf) => pathbuf,
+            Err(e) => {
+                print_err!("Could not get current path: {}", e);
                 return;
             }
         };
-        let mut pathbuf = PathBuf::from(&path);
         pathbuf.pop();
         pathbuf.push("python");
         pathbuf.push("plugin.py");


### PR DESCRIPTION
A better way to acquire the executable's path.

[`pub fn args_os() -> ArgsOs`](https://doc.rust-lang.org/std/env/fn.args_os.html)
> Returns the arguments which this program was started with (normally passed via the command line).
>The first element is traditionally the path of the executable, but it can be set to arbitrary text, and it may not even exist, so this property should not be relied upon for security purposes.

[`pub fn current_exe() -> Result<PathBuf>`](https://doc.rust-lang.org/nightly/std/env/fn.current_exe.html)
Will get the path and provide error message if it fails.

