### PR TITLE
use arrays for JSON-RPC request params

### DIFF
--- a/rust/src/editor.rs
+++ b/rust/src/editor.rs
@@ -693,7 +693,7 @@ impl Editor {
 
     pub fn on_plugin_connect(&mut self, peer: &PluginPeer) {
         let buf_size = self.text.len();
-        peer.send_rpc_async("ping_from_editor", &Value::U64(buf_size as u64));
+        peer.send_rpc_async("ping_from_editor", &Value::Array(vec![Value::U64(buf_size as u64)]));
     }
 
     // Note: the following are placeholders for prototyping, and are not intended to

--- a/rust/src/run_plugin.rs
+++ b/rust/src/run_plugin.rs
@@ -49,7 +49,7 @@ pub fn start_plugin(editor: Arc<Mutex<Editor>>) {
         let child_stdout = child.stdout.take().unwrap();
         let mut looper = RpcLoop::new(BufReader::new(child_stdout), child_stdin);
         let peer = looper.get_peer();
-        peer.send_rpc_async("ping", &Value::Null);
+        peer.send_rpc_async("ping", &Value::Array(Vec::new()));
         editor.lock().unwrap().on_plugin_connect(&peer);
         looper.mainloop(|method, params| rpc_handler(&editor, method, params));
         let status = child.wait();


### PR DESCRIPTION
I was updating a test plugin to use [golang.org/pkg/net/rpc/jsonrpc](http://golang.org/pkg/net/rpc/jsonrpc). However, Go always dropped the `ping` and `ping_from_editor` messenges without even raising an error. While digging into the Go source I found out that it expects an array for the `params` property. This is also part of the [specification](http://json-rpc.org/wiki/specification):

> *params* - **An Array** of objects to pass as arguments to the method.

That being said, I changed the `ping` param from null to an empty array, and I changed the `ping_from_editor` param from just `buf_size` to an array containing `buf_size`.