### PR TITLE
add id property of null to rpc notifications

### DIFF
--- a/rust/rpc/src/lib.rs
+++ b/rust/rpc/src/lib.rs
@@ -109,7 +109,7 @@ impl<R: BufRead, W:Write + Send> RpcLoop<R, W> {
                             }
                         }
                         None => print_err!("invalid RPC request")
-                    }                
+                    }
                 }
             });
             while let Some(json_result) = self.read_json() {
@@ -154,6 +154,7 @@ impl<W:Write> RpcPeer<W> {
 
     pub fn send_rpc_async(&self, method: &str, params: &Value) {
         if let Err(e) = self.send(&ObjectBuilder::new()
+            .insert("id", Value::Null)
             .insert("method", method)
             .insert("params", params)
             .unwrap()) {
@@ -173,7 +174,7 @@ impl<W:Write> RpcPeer<W> {
             .insert("method", method)
             .insert("params", params)
             .unwrap()) {
-            print_err!("send error on send_rpc_async method {}: {}", method, e);
+            print_err!("send error on send_rpc_sync method {}: {}", method, e);
             panic!("TODO: better error handling");
         }
         rx.recv().unwrap()


### PR DESCRIPTION
Related to #97 but I've created a new PR, because I am not so sure about this change.

During reading the [JSON-RPC 1.0 spec](http://json-rpc.org/wiki/specification) I also found the following about notifications:

>  id - Must be null.

So to my understanding, the `id` should never be omitted. But maybe omitting it is fine and does not lead to problems with JSON-RPC implementations. That being said, I am fine if this PR gets rejected! :-)

Something else, I kinda think that the method names `send_rpc_sync` and `send_rpc_async` are misleading. According to the spec it would be something like `send_rpc_request` and `send_rpc_notification`. What do you think?