### PR TITLE
remove unnecessary lifetime annotation from MainPeer

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -40,9 +40,9 @@ extern crate xi_rpc;
 
 use xi_rpc::{RpcLoop, RpcPeer};
 
-pub type MainPeer<'a> = RpcPeer<io::Stdout>;
+pub type MainPeer = RpcPeer<io::Stdout>;
 
-fn handle_req<'a>(request: Request, tabs: &mut Tabs, rpc_peer: &MainPeer<'a>) -> Option<Value> {
+fn handle_req(request: Request, tabs: &mut Tabs, rpc_peer: &MainPeer) -> Option<Value> {
     match request {
         Request::TabCommand { tab_command } => tabs.do_rpc(tab_command, rpc_peer)
     }

--- a/rust/src/tabs.rs
+++ b/rust/src/tabs.rs
@@ -33,7 +33,7 @@ pub struct Tabs {
 pub struct TabCtx<'a> {
     tab: &'a str,
     kill_ring: &'a Mutex<Rope>,
-    rpc_peer: &'a MainPeer<'a>,
+    rpc_peer: &'a MainPeer,
     self_ref: Arc<Mutex<Editor>>,
 }
 


### PR DESCRIPTION
I think the lifetime annotation for `MainPeer` is, after your recent refactoring, not necessary anymore, isn't it?

Side question: what is your feeling about using rustfmt?