### PR TITLE
RPC notification from backend to frontend

### DIFF
--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -44,11 +44,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func handleRpc(method: String, params: AnyObject) {
-        if method == "update" {
+        switch method {
+        case "update":
             if let obj = params as? [String : AnyObject], let update = obj["update"] as? [String : AnyObject] {
                 // TODO: dispatch to appropriate editView based on obj["tab"]
                 self.appWindowController?.editView.updateSafe(update)
             }
+        case "alert":
+            if let obj = params as? [String : AnyObject], let msg = obj["msg"] as? String {
+                dispatch_async(dispatch_get_main_queue(), {
+                    let alert =  NSAlert.init()
+                    alert.alertStyle = .InformationalAlertStyle
+                    alert.messageText = msg
+                    alert.runModal()
+                });
+            }
+        default:
+            print("unknown method from core:", method)
         }
     }
 

--- a/rust/src/editor.rs
+++ b/rust/src/editor.rs
@@ -16,6 +16,7 @@ use std::cmp::max;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::collections::BTreeSet;
+use std::sync::Weak;
 use serde_json::Value;
 
 use xi_rope::rope::{LinesMetric, Rope, RopeInfo};
@@ -29,12 +30,14 @@ use view::View;
 use tabs::TabCtx;
 use rpc::EditCommand;
 use run_plugin::{start_plugin, PluginPeer};
+use MainPeer;
 
 const FLAG_SELECT: u64 = 2;
 
 const MAX_UNDOS: usize = 20;
 
 pub struct Editor {
+    rpc_peer: Weak<MainPeer>,
     text: Rope,
     view: View,
     delta: Option<Delta<RopeInfo>>,
@@ -68,8 +71,9 @@ enum EditType {
 
 
 impl Editor {
-    pub fn new() -> Editor {
+    pub fn new(rpc_peer: Weak<MainPeer>) -> Editor {
         Editor {
+            rpc_peer: rpc_peer,
             text: Rope::from(""),
             view: View::new(),
             dirty: false,

--- a/rust/src/editor.rs
+++ b/rust/src/editor.rs
@@ -18,6 +18,7 @@ use std::io::{Read, Write};
 use std::collections::BTreeSet;
 use std::sync::Weak;
 use serde_json::Value;
+use serde_json::builder::ObjectBuilder;
 
 use xi_rope::rope::{LinesMetric, Rope, RopeInfo};
 use xi_rope::interval::Interval;
@@ -726,6 +727,16 @@ impl Editor {
         }
         self.view.set_fg_spans(start_offset, end_offset, sb.build());
         // TODO: set dirty, propagate update
+    }
+
+    pub fn plugin_alert(&self, msg: &str) {
+        match self.rpc_peer.upgrade() {
+            Some(rpc_peer) => rpc_peer.send_rpc_async("alert",
+                &ObjectBuilder::new()
+                    .insert("msg", msg)
+                    .unwrap()),
+            None => print_err!("rpc_peer reference is gone")
+        }
     }
 }
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -40,9 +40,9 @@ extern crate xi_rpc;
 
 use xi_rpc::{RpcLoop, RpcPeer};
 
-pub type MainPeer<'a> = RpcPeer<io::Stdout>;
+pub type MainPeer = RpcPeer<io::Stdout>;
 
-fn handle_req<'a>(request: Request, tabs: &mut Tabs, rpc_peer: &MainPeer<'a>) -> Option<Value> {
+fn handle_req(request: Request, tabs: &mut Tabs, rpc_peer: &MainPeer) -> Option<Value> {
     match request {
         Request::TabCommand { tab_command } => tabs.do_rpc(tab_command, rpc_peer)
     }

--- a/rust/src/run_plugin.rs
+++ b/rust/src/run_plugin.rs
@@ -75,6 +75,11 @@ fn rpc_handler(editor: &Arc<Mutex<Editor>>, method: &str, params: &Value) -> Opt
             editor.plugin_set_line_fg_spans(line_num, spans);
             None
         }
+        "alert" => {
+            let msg = params.as_object().and_then(|dict| dict.get("msg").and_then(Value::as_string)).unwrap();
+            editor.plugin_alert(msg);
+            None
+        }
         _ => {
             print_err!("unknown plugin callback method: {}", method);
             None

--- a/rust/src/tabs.rs
+++ b/rust/src/tabs.rs
@@ -33,7 +33,7 @@ pub struct Tabs {
 pub struct TabCtx<'a> {
     tab: &'a str,
     kill_ring: &'a Mutex<Rope>,
-    rpc_peer: &'a MainPeer<'a>,
+    rpc_peer: &'a MainPeer,
     self_ref: Arc<Mutex<Editor>>,
 }
 


### PR DESCRIPTION
This PR implements RPC notification from backend to frontend, as already discussed in #99.
It also had to already contain the PR #100.

I went for using `Arc<T>` instead of the discussed queue approach. Mainly because it is simpler and also has, as @raphlinus mentioned, slightly better performance.

Some points for discussion:

- I've used `Arc<T>` instead of `Arc<Mutex<T>>` because we do not need write access to the `rpc_peer` object and `RpcPeer.send` already has uses a mutex when writing data (`self.0.writer.lock()`). But maybe I've missed something?
- We now call `self.rpc_peer.send_rpc_async` from both the editor itself and also from the `TabCtx`. Maybe `TabCtx` can be removed and integrated into editor, now?

If wished, I can also remove the `alert` plugin method from this PR.

![screen shot 2016-07-22 at 10 16 14](https://cloud.githubusercontent.com/assets/409021/17051201/a3775b3c-4ff7-11e6-8aad-d8cf904239fa.png)


