### PR TITLE
Typed events

### DIFF
--- a/XiEditor.xcodeproj/project.pbxproj
+++ b/XiEditor.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		50370A2B1D4209F300EA1B18 /* Dispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50370A2A1D4209F300EA1B18 /* Dispatcher.swift */; };
 		AE228F5D1C897CE7000E9B0F /* xi-core in Resources */ = {isa = PBXBuildFile; fileRef = AE228F5C1C897CE7000E9B0F /* xi-core */; };
 		AE499DD01C82BB2B002D68AF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE499DCF1C82BB2B002D68AF /* AppDelegate.swift */; };
 		AE499DD21C82BB2B002D68AF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AE499DD11C82BB2B002D68AF /* Assets.xcassets */; };
@@ -19,7 +20,6 @@
 		AED23F151C83C689002246CE /* AppWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED23F131C83C689002246CE /* AppWindowController.swift */; };
 		AED23F161C83C689002246CE /* AppWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = AED23F141C83C689002246CE /* AppWindowController.xib */; };
 		AED23F181C83CBED002246CE /* EditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED23F171C83CBEC002246CE /* EditView.swift */; };
-		DBB50DF11CDE819000B4BBBE /* xi-core.sh in Resources */ = {isa = PBXBuildFile; fileRef = DBB50DF01CDE819000B4BBBE /* xi-core.sh */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,6 +47,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		50370A2A1D4209F300EA1B18 /* Dispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dispatcher.swift; sourceTree = "<group>"; };
 		AE228F5C1C897CE7000E9B0F /* xi-core */ = {isa = PBXFileReference; lastKnownFileType = text; path = "xi-core"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE499DCC1C82BB2B002D68AF /* XiEditor.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = XiEditor.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE499DCF1C82BB2B002D68AF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -125,6 +126,7 @@
 				AE499DD11C82BB2B002D68AF /* Assets.xcassets */,
 				AE499DD31C82BB2B002D68AF /* MainMenu.xib */,
 				AED23F131C83C689002246CE /* AppWindowController.swift */,
+				50370A2A1D4209F300EA1B18 /* Dispatcher.swift */,
 				AED23F141C83C689002246CE /* AppWindowController.xib */,
 				AE499DD61C82BB2B002D68AF /* Info.plist */,
 			);
@@ -315,6 +317,7 @@
 			files = (
 				AE499DF91C82C835002D68AF /* CoreConnection.swift in Sources */,
 				AED23F151C83C689002246CE /* AppWindowController.swift in Sources */,
+				50370A2B1D4209F300EA1B18 /* Dispatcher.swift in Sources */,
 				AED23F181C83CBED002246CE /* EditView.swift in Sources */,
 				AE499DD01C82BB2B002D68AF /* AppDelegate.swift in Sources */,
 				AEB66A791CAEFC8F002F686A /* ShadowView.swift in Sources */,
@@ -585,6 +588,7 @@
 				D023DA001CD0715E0087EC0A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -17,20 +17,23 @@ import Cocoa
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
 
-    var coreConnection: CoreConnection?
     var appWindowController: AppWindowController?
+    var dispatcher: Dispatcher?
 
     func applicationWillFinishLaunching(aNotification: NSNotification) {
         // show main app window
         appWindowController = AppWindowController(windowNibName: "AppWindowController")
 
-        let corePath = NSBundle.mainBundle().pathForResource("xi-core", ofType: "")
-        if let corePath = corePath {
-            coreConnection = CoreConnection(path: corePath) { [weak self] json -> () in
-                self?.handleCoreCmd(json)
-            }
+        guard let corePath = NSBundle.mainBundle().pathForResource("xi-core", ofType: "")
+            else { fatalError("XI Core not found") }
+
+        let coreConnection = CoreConnection(path: corePath) { [weak self] (json: AnyObject) -> Void in
+            self?.handleCoreCmd(json)
         }
-        appWindowController?.coreConnection = coreConnection
+        let dispatcher = Dispatcher(coreConnection: coreConnection)
+
+        self.dispatcher = dispatcher
+        appWindowController?.dispatcher = dispatcher
 
         appWindowController?.showWindow(self)
     }

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -21,29 +21,32 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var dispatcher: Dispatcher?
 
     func applicationWillFinishLaunching(aNotification: NSNotification) {
-        // show main app window
-        appWindowController = AppWindowController(windowNibName: "AppWindowController")
 
         guard let corePath = NSBundle.mainBundle().pathForResource("xi-core", ofType: "")
             else { fatalError("XI Core not found") }
 
-        let coreConnection = CoreConnection(path: corePath) { [weak self] (json: AnyObject) -> Void in
-            self?.handleCoreCmd(json)
-        }
-        let dispatcher = Dispatcher(coreConnection: coreConnection)
+        let dispatcher: Dispatcher = {
+            let coreConnection = CoreConnection(path: corePath) { [weak self] (json: AnyObject) -> Void in
+                self?.handleCoreCmd(json)
+            }
+
+            return Dispatcher(coreConnection: coreConnection)
+        }()
 
         self.dispatcher = dispatcher
-        appWindowController?.dispatcher = dispatcher
 
+        appWindowController = AppWindowController()
+        appWindowController?.dispatcher = dispatcher
         appWindowController?.showWindow(self)
     }
 
     func handleCoreCmd(json: AnyObject) {
-        if let obj = json as? [String : AnyObject], let method = obj["method"] as? String, let params = obj["params"] {
-            handleRpc(method, params: params)
-        } else {
-            print("unknown json from core:", json)
-        }
+        guard let obj = json as? [String : AnyObject],
+            method = obj["method"] as? String,
+            params = obj["params"]
+            else { print("unknown json from core:", json); return }
+
+        handleRpc(method, params: params)
     }
 
     func handleRpc(method: String, params: AnyObject) {

--- a/XiEditor/AppWindowController.swift
+++ b/XiEditor/AppWindowController.swift
@@ -19,7 +19,7 @@ class AppWindowController: NSWindowController {
     @IBOutlet weak var scrollView: NSScrollView!
     @IBOutlet weak var shadowView: ShadowView!
 
-    var coreConnection: CoreConnection?
+    var dispatcher: Dispatcher!
     
     var filename: String?
 
@@ -31,8 +31,9 @@ class AppWindowController: NSWindowController {
     override func windowDidLoad() {
         super.windowDidLoad()
         //window?.backgroundColor = NSColor.whiteColor()
-        let tabName = coreConnection?.sendRpc("new_tab", params: []) as! String
-        editView.coreConnection = coreConnection
+
+        let tabName = Events.NewTab().dispatch(dispatcher)
+        editView.coreConnection = dispatcher.coreConnection
         editView.tabName = tabName
 
         // set up autolayout constraints
@@ -46,7 +47,10 @@ class AppWindowController: NSWindowController {
     }
 
     func windowWillClose(_: NSNotification) {
-        editView.coreConnection?.sendRpcAsync("delete_tab", params: ["tab": editView.tabName!] as [String : AnyObject])
+        guard let tabName = editView.tabName
+            else { return }
+
+        Events.DeleteTab(tabId: tabName).dispatch(dispatcher)
     }
 
     func boundsDidChangeNotification(notification: NSNotification) {

--- a/XiEditor/AppWindowController.swift
+++ b/XiEditor/AppWindowController.swift
@@ -67,11 +67,12 @@ class AppWindowController: NSWindowController {
     }
 
     func saveDocument(sender: AnyObject) {
-        if filename == nil {
+        guard filename != nil else {
             saveDocumentAs(sender)
-        } else {
-            editView.sendRpcAsync("save", params: ["filename": filename!])
+            return
         }
+
+        editView.sendRpcAsync("save", params: ["filename": filename!])
     }
     
     func saveDocumentAs(sender: AnyObject) {

--- a/XiEditor/AppWindowController.swift
+++ b/XiEditor/AppWindowController.swift
@@ -15,6 +15,11 @@
 import Cocoa
 
 class AppWindowController: NSWindowController {
+
+    convenience init() {
+        self.init(windowNibName: "AppWindowController")
+    }
+
     @IBOutlet weak var editView: EditView!
     @IBOutlet weak var scrollView: NSScrollView!
     @IBOutlet weak var shadowView: ShadowView!

--- a/XiEditor/Dispatcher.swift
+++ b/XiEditor/Dispatcher.swift
@@ -1,0 +1,71 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+class Dispatcher {
+    let coreConnection: CoreConnection
+
+    init(coreConnection: CoreConnection) {
+        self.coreConnection = coreConnection
+    }
+
+    func dispatch<E: Event, O>(event: E) -> O {
+        let rpc = event.rpcRepresentation
+        return coreConnection.sendRpc(rpc.method, params: rpc.params) as! O
+    }
+}
+
+typealias RpcRepresentation = (method: String, params: AnyObject)
+
+protocol Event {
+    associatedtype Output
+
+    var method: String { get }
+    var params: AnyObject? { get }
+    var rpcRepresentation: RpcRepresentation { get }
+
+    func dispatch(dispatcher: Dispatcher) -> Output
+}
+
+extension Event {
+    var rpcRepresentation: RpcRepresentation {
+        return (method, params ?? [])
+    }
+
+    func dispatch(dispatcher: Dispatcher) -> Output {
+        return dispatcher.dispatch(self)
+    }
+}
+
+typealias TabIdentifier = String
+
+enum Events { // namespace
+    struct NewTab: Event {
+        typealias Output = String
+
+        let method = "new_tab"
+        let params: AnyObject? = nil
+    }
+
+    struct DeleteTab: Event {
+        typealias Output = Void
+
+        let tabId: TabIdentifier
+
+        let method = "delete_tab"
+        var params: AnyObject? { return ["tab": tabId] }
+    }
+}
+

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -307,7 +307,7 @@ class EditView: NSView, NSTextInputClient {
             replacementRange.length = 0
         }
         for _ in 0..<aRange.length {
-            sendRpcAsync("delete_backward", params: [])
+            sendRpcAsync("delete_backward", params  : [])
         }
         if let attrStr = aString as? NSAttributedString {
             sendRpcAsync("insert", params: insertedStringToJson(attrStr.string))


### PR DESCRIPTION
**This is a work-in-progress mainly to open the topic for discussion before I move along.**

I propose that RPC commands be typed properly so that we don't run into the usual "stringly" typing problems and let the compiler do most of the work.

- [ ] Don't dispatch from `AppWindowController` into its `editView` directly (like `editView.sendRpcAsync("save", params: ["filename": filename!])`)
- [ ] Type `EditView` events for text editing

What does the community think about this approach?

---

I don't like the `EventDispatchMethod` enum very much to distinguish between sync/async sending of RPC requests. Maybe changing the method signature to `Event.dispatch(dispatcher: Dispatcher, method: EventDispatchMethod = .sync) -> Output` will be necessary, too, so the dispatching method can vary on a per-call basis instead of per-event.