### PR TITLE
Propagate Plugin changes to the frontend

### DIFF
--- a/rust/src/editor.rs
+++ b/rust/src/editor.rs
@@ -185,7 +185,7 @@ impl Editor {
     }
 
     // render if needed, sending to ui
-    fn render(&mut self, tab_ctx: &TabCtx) {
+    pub fn render(&mut self, tab_ctx: &TabCtx) {
         if self.dirty {
             tab_ctx.update_tab(&self.view.render(&self.text, self.scroll_to));
             self.dirty = false;
@@ -752,7 +752,7 @@ impl Editor {
             sb.add_span(Interval::new_open_open(start, end), style);
         }
         self.view.set_fg_spans(start_offset, end_offset, sb.build());
-        // TODO: set dirty, propagate update
+        self.dirty = true;
     }
 }
 

--- a/rust/src/editor.rs
+++ b/rust/src/editor.rs
@@ -16,9 +16,7 @@ use std::cmp::max;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::collections::BTreeSet;
-use std::sync::Weak;
 use serde_json::Value;
-use serde_json::builder::ObjectBuilder;
 
 use xi_rope::rope::{LinesMetric, Rope};
 use xi_rope::interval::Interval;
@@ -30,8 +28,7 @@ use view::{Style, View};
 
 use tabs::TabCtx;
 use rpc::EditCommand;
-use run_plugin::{start_plugin, PluginPeer};
-use MainPeer;
+use run_plugin::start_plugin;
 
 const FLAG_SELECT: u64 = 2;
 
@@ -40,7 +37,6 @@ const MAX_UNDOS: usize = 20;
 const TAB_SIZE: usize = 4;
 
 pub struct Editor {
-    rpc_peer: Weak<MainPeer>,
     text: Rope,
     view: View,
 
@@ -72,13 +68,11 @@ enum EditType {
     Delete,
 }
 
-
 impl Editor {
-    pub fn new(rpc_peer: Weak<MainPeer>) -> Editor {
+    pub fn new() -> Editor {
         let engine = Engine::new(Rope::from(""));
         let last_rev_id = engine.get_head_rev_id();
         Editor {
-            rpc_peer: rpc_peer,
             text: Rope::from(""),
             view: View::new(),
             dirty: false,
@@ -268,7 +262,7 @@ impl Editor {
                 (self.view.sel_start + TAB_SIZE, self.view.sel_end + added)
             } else {
                 (self.view.sel_start + added, self.view.sel_end + TAB_SIZE)
-            };            
+            };
             for line in first_line..last_line {
                 let offset = self.view.line_col_to_offset(&self.text, line, 0);
                 let iv = Interval::new_closed_open(offset, offset);
@@ -569,7 +563,8 @@ impl Editor {
 
     fn debug_run_plugin(&mut self, tab_ctx: &TabCtx) {
         print_err!("running plugin");
-        start_plugin(tab_ctx.get_self_ref());
+        let plugin_ctx = tab_ctx.to_plugin_ctx();
+        start_plugin(plugin_ctx);
     }
 
     fn do_cut(&mut self) -> Value {
@@ -726,15 +721,12 @@ impl Editor {
         result
     }
 
-    // Support for plugins
-
-    pub fn on_plugin_connect(&mut self, peer: &PluginPeer) {
-        let buf_size = self.text.len();
-        peer.send_rpc_notification("ping_from_editor", &Value::Array(vec![Value::U64(buf_size as u64)]));
-    }
-
     // Note: the following are placeholders for prototyping, and are not intended to
     // deal with asynchrony or be efficient.
+
+    pub fn plugin_buf_size(&self) -> usize {
+        self.text.len()
+    }
 
     pub fn plugin_n_lines(&self) -> usize {
         self.text.measure::<LinesMetric>() + 1
@@ -761,16 +753,6 @@ impl Editor {
         }
         self.view.set_fg_spans(start_offset, end_offset, sb.build());
         // TODO: set dirty, propagate update
-    }
-
-    pub fn plugin_alert(&self, msg: &str) {
-        match self.rpc_peer.upgrade() {
-            Some(rpc_peer) => rpc_peer.send_rpc_notification("alert",
-                &ObjectBuilder::new()
-                    .insert("msg", msg)
-                    .unwrap()),
-            None => print_err!("rpc_peer reference is gone")
-        }
     }
 }
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -17,8 +17,6 @@ extern crate serde_json;
 extern crate time;
 
 use std::io;
-use std::io::Write;
-use std::sync::Arc;
 
 use serde_json::Value;
 
@@ -43,9 +41,9 @@ use xi_rpc::{RpcLoop, RpcPeer};
 
 pub type MainPeer = RpcPeer<io::Stdout>;
 
-fn handle_req(request: Request, tabs: &mut Tabs, rpc_peer: Arc<MainPeer>) -> Option<Value> {
+fn handle_req(request: Request, tabs: &mut Tabs, rpc_peer: MainPeer) -> Option<Value> {
     match request {
-        Request::TabCommand { tab_command } => tabs.do_rpc(tab_command, &rpc_peer)
+        Request::TabCommand { tab_command } => tabs.do_rpc(tab_command, rpc_peer)
     }
 }
 
@@ -54,7 +52,7 @@ fn main() {
     let stdin = io::stdin();
     let stdout = io::stdout();
     let mut rpc_looper = RpcLoop::new(stdout);
-    let peer = Arc::new(rpc_looper.get_peer());
+    let peer = rpc_looper.get_peer();
 
     rpc_looper.mainloop(|| stdin.lock(),
         |method, params| {

--- a/rust/src/rpc.rs
+++ b/rust/src/rpc.rs
@@ -15,7 +15,6 @@
 //! RPC handling for communications with front-end.
 
 use std::collections::BTreeMap;
-use std::io::Write;
 use std::error;
 use std::fmt;
 use serde_json::Value;

--- a/rust/src/tabs.rs
+++ b/rust/src/tabs.rs
@@ -150,7 +150,9 @@ impl PluginCtx {
     }
 
     pub fn set_line_fg_spans(&self, line_num: usize, spans: &Value) {
-        self.tab_ctx.self_ref.lock().unwrap().plugin_set_line_fg_spans(line_num, spans);
+        let mut editor = self.tab_ctx.self_ref.lock().unwrap();
+        editor.plugin_set_line_fg_spans(line_num, spans);
+        editor.render(&self.tab_ctx);
     }
 
     pub fn alert(&self, msg: &str) {


### PR DESCRIPTION
When thinking about my implementation of #101 during the last couple of days, I came to the conclusion that I prefer the idea of having the `TabCtx` as some kind of glue instead of making the editor to have references to everything.

With that in mind, the idea was now to introduce a `PluginCtx`, which is basically a `TabCtx` with an additional `PluginPeer`, even though this `PluginPeer` reference is not yet used. But it should pave the way for getting change notifications from the editor to its plugins. I also got rid of the nested `Arc` for the `MainPeer` (at least if I understood this one right).

Things that could be improved:

- [ ] I made the `TabCtx` cloneable, to be able to add a clone to the `PluginCtx`. Therefore, I had to wrap the `TabCtx` `kill_ring` into an `Arc`. Maybe there is better way to solve this?
- [ ] Maybe it is possible to change the `rpc_peer` of the `PluginCtx` from `Option<PluginPeer>` to `PluginPeer`, but I wasn't able to achieve this because of the lifetime requirements of the plugin thread.
- [ ] Do not run `editor.render()` after each plugin command, but rather collect some changes and send them in bulk. Not yet sure how to do implement this in a nice way ...
- [ ] Implement notifications form editor to its plugins.

For the latter, it is probably necessary that either the tabs or the editor keeps a reference to the `PluginCtx`. However I am not yet sure how to implement this; e.g. should the `PluginCtx` be cloned or an `Arc` be used for the `PluginCtx`. Up to now, I am not quite happy with both, but I'll keep thinking about it.

Please understand this PR mainly as a basis for discussions. If you prefer the implementation without the `PluginCtx`, I am totally fine if we close this PR. Also, if some parts are hard to understand, please tell me and I'll try to rephrase them.
