### PR TITLE
upgrade serde and serde_json to 0.8

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,8 +5,8 @@ license = "Apache-2.0"
 authors = ["Raph Levien <raph@google.com>"]
 
 [dependencies]
-serde = "*"
-serde_json = "*"
+serde = "0.8"
+serde_json = "0.8"
 time = "0.1"
 
 [dependencies.xi-rope]

--- a/rust/rpc/Cargo.toml
+++ b/rust/rpc/Cargo.toml
@@ -7,6 +7,6 @@ repository = "https://github.com/google/xi-editor"
 description = "Utilities for building peers (both client and server side) for xi's JSON RPC variant."
 
 [dependencies]
-serde = "0.7.14"
-serde_json = "0.7.4"
+serde = "0.8"
+serde_json = "0.8"
 crossbeam = "0.2.9"

--- a/rust/rpc/src/lib.rs
+++ b/rust/rpc/src/lib.rs
@@ -194,7 +194,7 @@ impl<W:Write> RpcPeer<W> {
             if let Err(e) = self.send(&ObjectBuilder::new()
                                  .insert("id", id)
                                  .insert("result", result)
-                                 .unwrap()) {
+                                 .build()) {
                 print_err!("error {} sending response to RPC {:?}", e, id);
             }
         } else {
@@ -207,7 +207,7 @@ impl<W:Write> RpcPeer<W> {
         if let Err(e) = self.send(&ObjectBuilder::new()
             .insert("method", method)
             .insert("params", params)
-            .unwrap()) {
+            .build()) {
             print_err!("send error on send_rpc_notification method {}: {}", method, e);
         }
     }
@@ -224,7 +224,7 @@ impl<W:Write> RpcPeer<W> {
             .insert("id", Value::U64(id as u64))
             .insert("method", method)
             .insert("params", params)
-            .unwrap()) {
+            .build()) {
             print_err!("send error on send_rpc_request method {}: {}", method, e);
             panic!("TODO: better error handling");
         }
@@ -288,5 +288,5 @@ impl<W:Write> Clone for RpcPeer<W> {
 }
 
 fn dict_get_string<'a>(dict: &'a BTreeMap<String, Value>, key: &str) -> Option<&'a str> {
-    dict.get(key).and_then(Value::as_string)
+    dict.get(key).and_then(Value::as_str)
 }

--- a/rust/src/rpc.rs
+++ b/rust/src/rpc.rs
@@ -287,7 +287,7 @@ fn dict_get_u64(dict: &BTreeMap<String, Value>, key: &str) -> Option<u64> {
 }
 
 fn dict_get_string<'a>(dict: &'a BTreeMap<String, Value>, key: &str) -> Option<&'a str> {
-    dict.get(key).and_then(Value::as_string)
+    dict.get(key).and_then(Value::as_str)
 }
 
 fn arr_get_u64(arr: &[Value], idx: usize) -> Option<u64> {

--- a/rust/src/run_plugin.rs
+++ b/rust/src/run_plugin.rs
@@ -74,7 +74,7 @@ fn rpc_handler(plugin_ctx: &PluginCtx, method: &str, params: &Value) -> Option<V
             None
         }
         "alert" => {
-            let msg = params.as_object().and_then(|dict| dict.get("msg").and_then(Value::as_string)).unwrap();
+            let msg = params.as_object().and_then(|dict| dict.get("msg").and_then(Value::as_str)).unwrap();
             plugin_ctx.alert(msg);
             None
         }

--- a/rust/src/tabs.rs
+++ b/rust/src/tabs.rs
@@ -111,7 +111,7 @@ impl TabCtx {
             &ObjectBuilder::new()
                 .insert("tab", &self.tab)
                 .insert("update", update)
-                .unwrap());
+                .build());
     }
 
     pub fn get_kill_ring(&self) -> Rope {
@@ -159,6 +159,6 @@ impl PluginCtx {
         self.tab_ctx.rpc_peer.send_rpc_notification("alert",
             &ObjectBuilder::new()
                 .insert("msg", msg)
-                .unwrap());
+                .build());
     }
 }

--- a/rust/src/view.rs
+++ b/rust/src/view.rs
@@ -157,13 +157,13 @@ impl View {
                     builder.push("cursor")
                         .push(cursor_col)
                 );
-            }            builder = builder.push(line_builder.unwrap());
+            }            builder = builder.push(line_builder.build());
             line_num += 1;
             if is_last_line || line_num == last_line {
                 break;
             }
         }
-        builder.unwrap()
+        builder.build()
     }
 
     pub fn render_spans(&self, mut builder: ArrayBuilder, start: usize, end: usize) -> ArrayBuilder {
@@ -193,7 +193,7 @@ impl View {
             builder = builder.insert_array("scrollto", |builder|
                 builder.push(line).push(col));
         }
-        builder.unwrap()
+        builder.build()
     }
 
     // How should we count "column"? Valid choices include:

--- a/rust/syntect-plugin/Cargo.toml
+++ b/rust/syntect-plugin/Cargo.toml
@@ -8,7 +8,7 @@ description = "A syntax highlighting plugin based on syntect."
 
 [dependencies]
 syntect = "1.0"
-serde_json = "0.7"
+serde_json = "0.8"
 
 [dependencies.xi-rpc]
 path = "../rpc"

--- a/rust/syntect-plugin/src/plugin_base.rs
+++ b/rust/syntect-plugin/src/plugin_base.rs
@@ -42,7 +42,7 @@ macro_rules! print_err {
 pub enum Error {
     RpcError(xi_rpc::Error),
     WrongReturnType,
-} 
+}
 
 pub struct SpansBuilder(Vec<Value>);
 pub type Spans = Value;
@@ -58,7 +58,7 @@ impl SpansBuilder {
             .insert("end", end as u64)
             .insert("fg", fg as u64)
             .insert("font", font_style as u64)
-            .unwrap());
+            .build());
     }
 
     pub fn build(self) -> Spans {
@@ -78,7 +78,7 @@ impl PluginPeer {
     }
 
     pub fn get_line(&self, line_num: usize) -> Result<String, Error> {
-        let params = ObjectBuilder::new().insert("line", Value::U64(line_num as u64)).unwrap();
+        let params = ObjectBuilder::new().insert("line", Value::U64(line_num as u64)).build();
         let result = self.send_rpc_request("get_line", &params);
         match result {
             Ok(Value::String(s)) => Ok(s),
@@ -91,7 +91,7 @@ impl PluginPeer {
         let params = ObjectBuilder::new()
             .insert("line", Value::U64(line_num as u64))
             .insert("spans", spans)
-            .unwrap();
+            .build();
         self.send_rpc_notification("set_line_fg_spans", &params);
     }
 


### PR DESCRIPTION
Fixes #107

Relevant changes in `serde_json` `0.8`:

- Object/ArrayBuilder::unwrap() has been renamed to build() to reflect the fact that they do not panic
- Value::as_string() has been renamed to as_str() and Value::as_boolean() has been renamed to as_bool() to improve consistency

Besides that, I updated the rpc crate to use the same `serde` version as the core.