### PR TITLE
another batch of clippy warnings fixed

### DIFF
--- a/rust/src/editor.rs
+++ b/rust/src/editor.rs
@@ -221,13 +221,11 @@ impl Editor {
     fn delete(&mut self) {
         let start = if self.view.sel_start != self.view.sel_end {
             self.view.sel_min()
+        } else if let Some(bsp_pos) = self.text.prev_codepoint_offset(self.view.sel_end) {
+            // TODO: implement complex emoji logic
+            bsp_pos
         } else {
-            if let Some(bsp_pos) = self.text.prev_codepoint_offset(self.view.sel_end) {
-                // TODO: implement complex emoji logic
-                bsp_pos
-            } else {
-                self.view.sel_max()
-            }
+            self.view.sel_max()
         };
 
         if start < self.view.sel_max() {
@@ -633,12 +631,10 @@ impl Editor {
             val = self.text.slice_to_string(current, offset);
             let del_interval = Interval::new_closed_open(current, offset);
             self.add_delta(del_interval, Rope::from(""), current, current);
-        } else {
-            if let Some(grapheme_offset) = self.text.next_grapheme_offset(self.view.sel_end) {
-                val = self.text.slice_to_string(current, grapheme_offset);
-                let del_interval = Interval::new_closed_open(current, grapheme_offset);
-                self.add_delta(del_interval, Rope::from(""), current, current)
-            }
+        } else if let Some(grapheme_offset) = self.text.next_grapheme_offset(self.view.sel_end) {
+            val = self.text.slice_to_string(current, grapheme_offset);
+            let del_interval = Interval::new_closed_open(current, grapheme_offset);
+            self.add_delta(del_interval, Rope::from(""), current, current)
         }
 
         tab_ctx.set_kill_ring(Rope::from(val));

--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -13,6 +13,16 @@
 // limitations under the License.
 
 macro_rules! print_err {
+    ($arg:tt) => (
+        {
+            use std::io::prelude::*;
+            if let Err(e) = write!(&mut ::std::io::stderr(), "{}\n", format_args!($arg)) {
+                panic!("Failed to write to stderr.\
+                    \nOriginal error output: {}\
+                    \nSecondary error writing to stderr: {}", $arg, e);
+            }
+        }
+    );
     ($($arg:tt)*) => (
         {
             use std::io::prelude::*;

--- a/rust/src/rpc.rs
+++ b/rust/src/rpc.rs
@@ -107,12 +107,12 @@ impl<'a> TabCommand<'a> {
 
             "delete_tab" => params.as_object().and_then(|dict| {
                 dict_get_string(dict, "tab").map(|tab_name| DeleteTab { tab_name: tab_name })
-            }).ok_or(MalformedTabParams(method.to_string(), params.clone())),
+            }).ok_or_else(|| MalformedTabParams(method.to_string(), params.clone())),
 
             "edit" =>
                 params
                 .as_object()
-                .ok_or(MalformedTabParams(method.to_string(), params.clone()))
+                .ok_or_else(|| MalformedTabParams(method.to_string(), params.clone()))
                 .and_then(|dict| {
                     if let (Some(tab), Some(method), Some(edit_params)) =
                         (dict_get_string(dict, "tab"), dict_get_string(dict, "method"), dict.get("params")) {
@@ -142,7 +142,7 @@ impl<'a> EditCommand<'a> {
                                 last_line: last_line as usize
                             })
                         } else { None }
-                }).ok_or(MalformedEditParams(method.to_string(), params.clone()))
+                }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone()))
             },
 
             "key" => params.as_object().and_then(|dict| {
@@ -151,11 +151,11 @@ impl<'a> EditCommand<'a> {
                         Key { chars: chars, flags: flags }
                     })
                 })
-            }).ok_or(MalformedEditParams(method.to_string(), params.clone())),
+            }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
 
             "insert" => params.as_object().and_then(|dict| {
                 dict_get_string(dict, "chars").map(|chars| Insert { chars: chars })
-            }).ok_or(MalformedEditParams(method.to_string(), params.clone())),
+            }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
 
             "delete_forward" => Ok(DeleteForward),
             "delete_backward" => Ok(DeleteBackward),
@@ -189,11 +189,11 @@ impl<'a> EditCommand<'a> {
 
             "open" => params.as_object().and_then(|dict| {
                 dict_get_string(dict, "filename").map(|path| Open { file_path: path })
-            }).ok_or(MalformedEditParams(method.to_string(), params.clone())),
+            }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
 
             "save" => params.as_object().and_then(|dict| {
                 dict_get_string(dict, "filename").map(|path| Save { file_path: path })
-            }).ok_or(MalformedEditParams(method.to_string(), params.clone())),
+            }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
 
             "scroll" => params.as_array().and_then(|arr| {
                 if let (Some(first), Some(last)) =
@@ -201,7 +201,7 @@ impl<'a> EditCommand<'a> {
 
                     Some(Scroll { first: first, last: last })
                 } else { None }
-            }).ok_or(MalformedEditParams(method.to_string(), params.clone())),
+            }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
 
             "yank" => Ok(Yank),
             "transpose" => Ok(Transpose),
@@ -212,7 +212,7 @@ impl<'a> EditCommand<'a> {
 
                         Some(Click { line: line, column: column, flags: flags, click_count: click_count })
                     } else { None }
-            }).ok_or(MalformedEditParams(method.to_string(), params.clone())),
+            }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
 
             "drag" => params.as_array().and_then(|arr| {
                 if let (Some(line), Some(column), Some(flags)) =
@@ -220,7 +220,7 @@ impl<'a> EditCommand<'a> {
 
                         Some(Drag { line: line, column: column, flags: flags })
                     } else { None }
-            }).ok_or(MalformedEditParams(method.to_string(), params.clone())),
+            }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
 
             "undo" => Ok(Undo),
             "redo" => Ok(Redo),


### PR DESCRIPTION
I somehow missed them in my last PR.

The `.ok_or_else(_)`-related changes could avoid some allocations, which could improve performance just a smidgen.

The one macro change involves some code duplication to avoid a needless `format!(_)`. I can back it out if you don't want it.