### PR TITLE
Add basic support for the Font menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ recommended and supported). You should have `cargo` in your path.
 
 Or `open XiEditor.xcodeproj` and hit the Run button.
 
-It will look better if you have [InconsolataGo](http://levien.com/type/myfonts/inconsolata.html)
-installed, a customized version of Inconsolata tuned for code editing. To choose other
-fonts, edit the `CTFontCreateWithName()` call in EditView.swift.
+It will look better if you have
+[InconsolataGo](http://levien.com/type/myfonts/inconsolata.html) installed, a
+customized version of Inconsolata tuned for code editing. You can change fonts
+per window in the Font menu or with `Cmd-T`. To choose another default font,
+edit the `CTFontCreateWithName()` call in EditView.swift.
 
 ### Building the core
 

--- a/XiEditor/Base.lproj/MainMenu.xib
+++ b/XiEditor/Base.lproj/MainMenu.xib
@@ -353,7 +353,7 @@
                                     <items>
                                         <menuItem title="Show Fonts" keyEquivalent="t" id="Q5e-8K-NDq">
                                             <connections>
-                                                <action selector="orderFrontFontPanel:" target="YLy-65-1bz" id="WHr-nq-2xA"/>
+                                                <action selector="orderFrontFontPanel:" target="-1" id="afu-NV-5cp"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Bold" tag="2" keyEquivalent="b" id="GB9-OM-e27">

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -124,6 +124,19 @@ class EditView: NSView, NSTextInputClient {
         heightConstraint!.active = true
     }
     
+    override func changeFont(sender: AnyObject?) {
+        let oldFont = attributes[String(kCTFontAttributeName)] as! CTFontRef
+        guard let font = sender?.convertFont(oldFont) else { return }
+        ascent = CTFontGetAscent(font)
+        descent = CTFontGetDescent(font)
+        leading = CTFontGetLeading(font)
+        linespace = ceil(ascent + descent + leading)
+        baseline = ceil(ascent)
+        attributes[String(kCTFontAttributeName)] = font
+        fontWidth = getFontWidth(font)
+        needsDisplay = true
+    }
+
     override func resetCursorRects() {
         super.resetCursorRects()
         addCursorRect(frameRect, cursor: NSCursor.IBeamCursor())


### PR DESCRIPTION
This lets each window have its own font, configurable in the font menu or with `Cmd-T`, which enables faster testing of rendering with various fonts.

<img width="450" alt="screen shot 2016-08-06 at 2 54 08 pm" src="https://cloud.githubusercontent.com/assets/1690225/17458679/644f1b0a-5be8-11e6-8b16-6813e6052c3e.png">