### PR TITLE
faster newline count via bit twiddling

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,3 +17,7 @@ path = "unicode"
 
 [dependencies.xi-rpc]
 path = "rpc"
+
+[features]
+avx-accel = ["xi-rope/avx-accel"]
+simd-accel = ["xi-rope/simd-accel"]

--- a/rust/rope/Cargo.toml
+++ b/rust/rope/Cargo.toml
@@ -8,3 +8,7 @@ version = "0.1.0"
 
 [dependencies]
 bytecount = "0.1.2"
+
+[features]
+avx-accel = ["bytecount/avx-accel"]
+simd-accel = ["bytecount/simd-accel"]

--- a/rust/rope/Cargo.toml
+++ b/rust/rope/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
-name = "xi-rope"
-version = "0.1.0"
-license = "Apache-2.0"
 authors = ["Raph Levien <raph@google.com>"]
-repository = "https://github.com/google/xi-editor"
 description = "A generic rope data structure built on top of B-Trees."
+license = "Apache-2.0"
+name = "xi-rope"
+repository = "https://github.com/google/xi-editor"
+version = "0.1.0"
+
+[dependencies]
+bytecount = "0.1.2"


### PR DESCRIPTION
The alignment splitting technique as well as the idea to partially unroll the loop to 2×wordsize was nicked from @burntsushi 's rust-memchr crate, and the bit twiddling is classic Stanford. :smile:

In my benchmarks, I see between 100% and 200% speedup.
