### PR TITLE
Add cmake dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ Screenshot (will need to be updated as syntax coloring and UI polish is added):
 ![xi screenshot](/doc/img/xi-mac-screenshot.png?raw=true)
 
 ## Getting started
-You need [Xcode 7.3](https://developer.apple.com/xcode/) (only on Mac) and [Rust](https://www.rust-lang.org/) (version 1.10+ is
+You need [Xcode 7.3](https://developer.apple.com/xcode/) and cmake (only on Mac) and [Rust](https://www.rust-lang.org/) (version 1.10+ is
 recommended and supported). You should have `cargo` in your path.
 
 ```
+> brew install cmake
 > git clone https://github.com/google/xi-editor
 > cd xi-editor
 > xcodebuild


### PR DESCRIPTION
I couldn't compile on OS X without install cmake. This pull request adds a step to install that.

I'm assuming homebrew is already installed, but that might of course not be the case. Just didn't know how verbose to make it. Feel free to ditch this pull request in favor of something more precise.
