### PR TITLE
Do not insert chars with unassigned command key

### DIFF
--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -442,7 +442,7 @@ class EditView: NSView, NSTextInputClient {
         } else {
             let commandName = camelCaseToUnderscored(aSelector.description).stringByReplacingOccurrencesOfString(":", withString: "");
             if (commandName == "noop") {
-                sendRpcAsync("key", params: eventToJson(currentEvent!));
+                NSBeep()
             } else {
                 sendRpcAsync(commandName, params: []);
             }


### PR DESCRIPTION
Type a command that key that Xi doesn't implement, such as cmd-f. 
Xi enters an 'f' into the document. This PR makes Xi just Beep on unassigned command keys.
Although this current behavior appears to be deliberate, I belive it is surprising, and likely to unintentionally edit documents. If I wanted to type a letter, I wouldn't be holding down the command key.
I not sure what Sublime or BBEdit do when they encounter an unassigned key, since I couldn't find any keys that they didn't assigned.
