### PR TITLE
Blink Insertion Point/Use std highlight color

### DIFF
--- a/XiEditor/AppWindowController.swift
+++ b/XiEditor/AppWindowController.swift
@@ -113,3 +113,14 @@ class AppWindowController: NSWindowController {
         editView.mouseUp(theEvent)
     }
 }
+
+// AppWindowController.xib makes us the window's delegate (as nib owner), as well as its controler.
+extension AppWindowController: NSWindowDelegate {
+    func windowDidBecomeKey(notification: NSNotification) {
+        editView.updateIsFrontmost(true)
+    }
+    func windowDidResignKey(notification: NSNotification) {
+        editView.updateIsFrontmost(false);
+        
+    }
+}


### PR DESCRIPTION
Make text selection behave more normally.
*Insertion point blinks in frontmost window.
*Selected text is highlighted in system color in front window. To see the effect of this, go into System Preferences/General, and change your highlight color. Xi will now use whatever you pick. Before Xi used a hardcoded blue regardless.
*Selected text is highlighted in gray in non-frontmost windows, helping to clarify which window will receive typing.

There is still flashing cursor even when a range of text is selected. This is nonstandard, but matches SublimeText at least. 

Xcode ignores the system highlight color, it is set separately in the Xcode prefs. That may be were Xi wants to go someday; I don’t think this make that any harder.
