### PR TITLE
Support simple text search

### DIFF
--- a/XiEditor.xcodeproj/project.pbxproj
+++ b/XiEditor.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		50370A2B1D4209F300EA1B18 /* Dispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50370A2A1D4209F300EA1B18 /* Dispatcher.swift */; };
+		81FE0A1B1DE222E200C3BBBA /* SearchController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 81FE0A1A1DE222E200C3BBBA /* SearchController.xib */; };
+		81FE0A1D1DE226E400C3BBBA /* SearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81FE0A1C1DE226E400C3BBBA /* SearchController.swift */; };
 		AE041BA61D4327EB0069AB8B /* xi-syntect-plugin in Resources */ = {isa = PBXBuildFile; fileRef = AE041BA51D4327EB0069AB8B /* xi-syntect-plugin */; };
 		AE228F5D1C897CE7000E9B0F /* xi-core in Resources */ = {isa = PBXBuildFile; fileRef = AE228F5C1C897CE7000E9B0F /* xi-core */; };
 		AE499DD01C82BB2B002D68AF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE499DCF1C82BB2B002D68AF /* AppDelegate.swift */; };
@@ -49,6 +51,8 @@
 
 /* Begin PBXFileReference section */
 		50370A2A1D4209F300EA1B18 /* Dispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dispatcher.swift; sourceTree = "<group>"; };
+		81FE0A1A1DE222E200C3BBBA /* SearchController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SearchController.xib; sourceTree = "<group>"; };
+		81FE0A1C1DE226E400C3BBBA /* SearchController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchController.swift; sourceTree = "<group>"; };
 		AE041B971D4323460069AB8B /* build-rust-xcode.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "build-rust-xcode.sh"; sourceTree = "<group>"; };
 		AE041BA51D4327EB0069AB8B /* xi-syntect-plugin */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = "xi-syntect-plugin"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE228F5C1C897CE7000E9B0F /* xi-core */ = {isa = PBXFileReference; lastKnownFileType = text; path = "xi-core"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -127,6 +131,8 @@
 				AE499DF81C82C835002D68AF /* CoreConnection.swift */,
 				AE499DD11C82BB2B002D68AF /* Assets.xcassets */,
 				AE499DD31C82BB2B002D68AF /* MainMenu.xib */,
+				81FE0A1A1DE222E200C3BBBA /* SearchController.xib */,
+				81FE0A1C1DE226E400C3BBBA /* SearchController.swift */,
 				AED23F131C83C689002246CE /* AppWindowController.swift */,
 				50370A2A1D4209F300EA1B18 /* Dispatcher.swift */,
 				AED23F141C83C689002246CE /* AppWindowController.xib */,
@@ -296,6 +302,7 @@
 				AEBAAA651C83BB1A005637A3 /* python in Resources */,
 				AED23F161C83C689002246CE /* AppWindowController.xib in Resources */,
 				AE041BA61D4327EB0069AB8B /* xi-syntect-plugin in Resources */,
+				81FE0A1B1DE222E200C3BBBA /* SearchController.xib in Resources */,
 				AE499DD21C82BB2B002D68AF /* Assets.xcassets in Resources */,
 				AE499DD51C82BB2B002D68AF /* MainMenu.xib in Resources */,
 			);
@@ -323,6 +330,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AE499DF91C82C835002D68AF /* CoreConnection.swift in Sources */,
+				81FE0A1D1DE226E400C3BBBA /* SearchController.swift in Sources */,
 				AED23F151C83C689002246CE /* AppWindowController.swift in Sources */,
 				50370A2B1D4209F300EA1B18 /* Dispatcher.swift in Sources */,
 				AED23F181C83CBED002246CE /* EditView.swift in Sources */,

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -121,4 +121,62 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Insert code here to tear down your application
     }
 
+    // Find/Replace 
+    
+    var findString : String = ""
+    var searchWindowController : SearchController? = nil
+    
+    // Show the search panel. As for cmd-f
+    func showSearch()  {
+        if searchWindowController==nil {
+            self.searchWindowController = SearchController()
+            self.searchWindowController!.appDelegate = self
+        }
+        if let searchWindowController = self.searchWindowController {
+            searchWindowController.setSearchString(self.findString)
+            searchWindowController.showWindow(self)
+            searchWindowController.window?.makeKeyAndOrderFront(self)
+        }
+    }
+    
+    // Set the search string as cmd-e dose with the current selection
+    // This update is not comming from the search dlg, which calls updateSearch.
+    // This update goes to the search dlg.
+    func setSearchString(newSearchString: String) {
+        self.findString=newSearchString
+        self.searchWindowController?.setSearchString(self.findString)
+    }
+    
+    func getSearchString() -> String {
+        return self.findString
+    }
+    
+    /// Receives live notifications of changes in the search panel.
+    func updateSearch(text :String, regExp:Bool, matchCase:Bool,  wholeWord:Bool ) {
+        // At the moment, we don't really do any thing with the live date.
+        // We wait for the user to hit search.
+        self.findString = text
+        //Swift.print("searching for \(text)")
+    }
+
+    // Select the next occurrence of the search string after the selection.
+    func searchNext() {
+        guard findString != "" else {
+            return
+        }
+        // The document that we are searching could be the 2nd window, if the find window is first.
+        // This wouldn't be an issue if we hasn't let the find 'panel' become 'main' as well as 'key'.
+        for window in NSApp.orderedWindows {
+            if let appWindowController = window.windowController as? AppWindowController {
+                appWindowController.editView.findNext(self.findString)
+                break
+            }
+        }
+     }
+}
+
+
+extension AppDelegate{
+
+
 }

--- a/XiEditor/AppWindowController.swift
+++ b/XiEditor/AppWindowController.swift
@@ -63,6 +63,7 @@ class AppWindowController: NSWindowController {
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(AppWindowController.frameDidChangeNotification(_:)), name: NSViewFrameDidChangeNotification, object: scrollView)
         updateEditViewScroll()
     }
+    
 
     func windowWillClose(_: NSNotification) {
         guard let tabName = editView.tabName

--- a/XiEditor/AppWindowController.xib
+++ b/XiEditor/AppWindowController.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11542" systemVersion="15G1108" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11542"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="AppWindowController" customModule="XiEditor" customModuleProvider="target">
@@ -19,7 +20,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="480" height="270"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1177"/>
             <view key="contentView" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -32,6 +33,7 @@
                             <subviews>
                                 <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hxn-ZY-xOb" customClass="EditView" customModule="XiEditor" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 </customView>
                             </subviews>
                         </clipView>

--- a/XiEditor/Base.lproj/MainMenu.xib
+++ b/XiEditor/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11542" systemVersion="15G1108" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11542"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -13,47 +13,6 @@
 // limitations under the License.
 
 import Cocoa
-import Carbon
-
-func getKeyboardData() -> NSData {
-    let currentKeyboard = TISCopyCurrentKeyboardLayoutInputSource().takeRetainedValue()
-    let propPtr = TISGetInputSourceProperty(currentKeyboard, kTISPropertyUnicodeKeyLayoutData)
-    let layoutData = Unmanaged<NSData>.fromOpaque(COpaquePointer(propPtr)).takeUnretainedValue()
-    
-    // do we need a copy?, idk
-    return NSData(bytes:layoutData.bytes, length:layoutData.length)
-}
-
-func translateKeyPress(event: NSEvent, keyboardLayoutData: NSData, inout deadKeyState:UInt32) -> NSString? {
-    // Translate the key ourselves, inputs are the current event and the past deadKeyState,
-    // the user can type <option-u> <u> for u-umlaut, 
-    // the first key press dose not produce a char it is a 'dead' key that establishes the *deadKeyState*
-    // for the keypress that follows.
-  
-    var chars : [UniChar] = [0,0,0,0]
-    var realLength : Int = 0
-    
-    let modifierKeyState = UInt32((event.modifierFlags.rawValue >> 16) & 0xFF)
-    
-    let err = UCKeyTranslate(UnsafePointer<UCKeyboardLayout>(keyboardLayoutData.bytes),
-                             event.keyCode,
-                             UInt16(kUCKeyActionDown),
-                             modifierKeyState,
-                             UInt32(LMGetKbdType()),
-                             0,
-                             &deadKeyState,
-                             chars.count,
-                             &realLength,
-                             &chars);
-    
-    if err == noErr && realLength>0 {
-        return  NSString(characters: chars, length:realLength)
-    }
-    else {
-        return nil
-    }
-}
-
 
 func eventToJson(event: NSEvent) -> AnyObject {
     let flags = event.modifierFlags.rawValue >> 16;
@@ -103,7 +62,7 @@ func camelCaseToUnderscored(name: NSString) -> NSString {
     return underscored;
 }
 
-class EditView: NSView {
+class EditView: NSView, NSTextInputClient {
     var tabName: String?
     var coreConnection: CoreConnection?
 
@@ -138,9 +97,11 @@ class EditView: NSView {
 
     var currentEvent: NSEvent?
     
-    // dead key events not yet applied
-    var deadKeyState : UInt32 = 0
-    var keyboardData : NSData
+    var cursorPos: (Int, Int)?
+    var _selectedRange: NSRange
+    var _markedRange: NSRange
+    
+    var frameRect: NSRect
 
     override init(frame frameRect: NSRect) {
         let font = CTFontCreateWithName("InconsolataGo", 14, nil)
@@ -153,31 +114,38 @@ class EditView: NSView {
         fontWidth = getFontWidth(font)
         selcolor = NSColor(colorLiteralRed: 0.7, green: 0.85, blue: 0.99, alpha: 1.0)
         updateQueue = dispatch_queue_create("com.levien.xi.update", DISPATCH_QUEUE_SERIAL)
-        keyboardData = getKeyboardData();
+        _selectedRange = NSMakeRange(NSNotFound, 0)
+        _markedRange = NSMakeRange(NSNotFound, 0)
+        self.frameRect = frameRect
         super.init(frame: frameRect)
         widthConstraint = NSLayoutConstraint(item: self, attribute: .Width, relatedBy: .GreaterThanOrEqual, toItem: nil, attribute: .Width, multiplier: 1, constant: 400)
         widthConstraint!.active = true
         heightConstraint = NSLayoutConstraint(item: self, attribute: .Height, relatedBy: .GreaterThanOrEqual, toItem: nil, attribute: .Height, multiplier: 1, constant: 100)
         heightConstraint!.active = true
-        
-        // When the user switches keyboards, relaod keyboard layout data
-        let mainQueue = NSOperationQueue.mainQueue()
-        let center = NSDistributedNotificationCenter.defaultCenter()
-        
-        center.addObserverForName(kTISNotifySelectedKeyboardInputSourceChanged as NSString as String, object: nil, queue: mainQueue) { _ in
-                self.keyboardData = getKeyboardData()
-            
-        }
+    }
+    
+    override func changeFont(sender: AnyObject?) {
+        let oldFont = attributes[String(kCTFontAttributeName)] as! CTFontRef
+        guard let font = sender?.convertFont(oldFont) else { return }
+        ascent = CTFontGetAscent(font)
+        descent = CTFontGetDescent(font)
+        leading = CTFontGetLeading(font)
+        linespace = ceil(ascent + descent + leading)
+        baseline = ceil(ascent)
+        attributes[String(kCTFontAttributeName)] = font
+        fontWidth = getFontWidth(font)
+        needsDisplay = true
+    }
+
+    override func resetCursorRects() {
+        super.resetCursorRects()
+        addCursorRect(frameRect, cursor: NSCursor.IBeamCursor())
     }
 
     required init?(coder: NSCoder) {
         fatalError("View doesn't support NSCoding")
     }
 
-    deinit {
-        NSNotificationCenter.defaultCenter().removeObserver(self)
-    }
-    
     func sendRpcAsync(method: String, params: AnyObject) {
         let inner = ["method": method, "params": params, "tab": tabName!] as [String : AnyObject]
         coreConnection?.sendRpcAsync("edit", params: inner)
@@ -198,6 +166,10 @@ class EditView: NSView {
     }
 
     let x0: CGFloat = 2;
+
+    let font_style_bold: Int = 1;
+    let font_style_underline: Int = 2;
+    let font_style_italic: Int = 4;
 
     override func drawRect(dirtyRect: NSRect) {
         super.drawRect(dirtyRect)
@@ -231,6 +203,7 @@ class EditView: NSView {
                 let type = attr[0] as! String
                 if type == "cursor" {
                     cursor = attr[1] as? Int
+                    self.cursorPos = (lineIx, utf8_offset_to_utf16(s, cursor!))
                 } else if type == "sel" {
                     let start = attr[1] as! Int
                     let u16_start = utf8_offset_to_utf16(s, start)
@@ -243,10 +216,57 @@ class EditView: NSView {
                     let end = attr[2] as! Int
                     let u16_end = utf8_offset_to_utf16(s, end)
                     let fgcolor = colorFromArgb(UInt32(attr[3] as! Int))
+                    let font_style = attr[4] as! Int
                     //let fgcolor = colorFromArgb(0xff800000)
                     attrString.addAttribute(NSForegroundColorAttributeName, value: fgcolor, range: NSMakeRange(u16_start, u16_end - u16_start))
+                    if (font_style & font_style_underline) != 0 {
+                        attrString.addAttribute(NSUnderlineStyleAttributeName,
+                                                value: NSUnderlineStyle.StyleSingle.rawValue,
+                                                range: NSMakeRange(u16_start, u16_end - u16_start))
+                    }
+                    let fake_italic = true  // TODO: figure this out based on font support
+                    if fake_italic  && (font_style & font_style_italic) != 0 {
+                        attrString.addAttribute(NSObliquenessAttributeName,
+                                                value: 0.2,
+                                                range: NSMakeRange(u16_start, u16_end - u16_start))
+                    }
+                    let trait_mask = font_style_bold | (fake_italic ? 0 : font_style_italic)
+                    if (font_style & trait_mask) != 0 {
+                        var traits: NSFontTraitMask
+                        switch font_style & trait_mask {
+                        case font_style_bold:
+                            traits = NSFontTraitMask.BoldFontMask
+                        case font_style_italic:
+                            traits = NSFontTraitMask.ItalicFontMask
+                        case (font_style_bold | font_style_italic):
+                            traits = [NSFontTraitMask.BoldFontMask, NSFontTraitMask.ItalicFontMask]
+                        default:
+                            traits = []
+                        }
+                        attrString.applyFontTraits(traits, range: NSMakeRange(u16_start, u16_end - u16_start))
+                    }
                 }
             }
+            if let c = cursor {
+                let cix = utf8_offset_to_utf16(s, c)
+                if (markedRange().location != NSNotFound) {
+                    let markRangeStart = cix - markedRange().length
+                    if (markRangeStart >= 0) {
+                        attrString.addAttribute(NSUnderlineStyleAttributeName,
+                                                value: NSUnderlineStyle.StyleSingle.rawValue,
+                                                range: NSMakeRange(markRangeStart, markedRange().length))
+                    }
+                }
+                if (selectedRange().location != NSNotFound) {
+                    let selectedRangeStart = cix - markedRange().length + selectedRange().location
+                    if (selectedRangeStart >= 0) {
+                        attrString.addAttribute(NSUnderlineStyleAttributeName,
+                                                value: NSUnderlineStyle.StyleThick.rawValue,
+                                                range: NSMakeRange(selectedRangeStart, selectedRange().length))
+                    }
+                }
+            }
+            
             // TODO: I don't understand where the 13 comes from (it's what aligns with baseline. We
             // probably want to move to using CTLineDraw instead of drawing the attributed string,
             // but that means drawing the selection highlight ourselves (which has other benefits).
@@ -292,26 +312,130 @@ class EditView: NSView {
         // store current event so that it can be sent to the core
         // if the selector for the event is "noop:".
         currentEvent = theEvent;
-        self.interpretKeyEvents([theEvent]);
+        self.inputContext?.handleEvent(theEvent);
         currentEvent = nil;
     }
 
+    // NSResponder (used mostly for paste)
     override func insertText(insertString: AnyObject) {
-        guard let insertString:NSString = insertString as? NSString,
-              let theEvent = self.currentEvent else { return }
-        
-        if insertString.length == 0  || self.deadKeyState != 0 {
-            //we got a dead key, this time or last time
-            // Translate the key ourselves, using the current event and the past deadKeyState.
-            if let typedText = translateKeyPress(theEvent, keyboardLayoutData:keyboardData, deadKeyState:&deadKeyState) {
-                sendRpcAsync("insert", params: insertedStringToJson(typedText))
-            }
-        }
-        else {
-            sendRpcAsync("insert", params: insertedStringToJson(insertString))
-        }
+        sendRpcAsync("insert", params: insertedStringToJson(insertString as! NSString))
     }
 
+    // NSTextInputClient protocol
+    func insertText(aString: AnyObject, replacementRange: NSRange) {
+        self.removeMarkedText()
+        self.replaceCharactersInRange(replacementRange, withText: aString)
+    }
+    
+    func replacementMarkedRange(replacementRange: NSRange) -> NSRange {
+        var markedRange = _markedRange
+        
+        
+        if (markedRange.location == NSNotFound) {
+            markedRange = _selectedRange
+        }
+        if (replacementRange.location != NSNotFound) {
+            var newRange: NSRange = markedRange
+            newRange.location += replacementRange.location
+            newRange.length += replacementRange.length
+            if (NSMaxRange(newRange) <= NSMaxRange(markedRange)) {
+                markedRange = newRange
+            }
+        }
+        
+        return markedRange
+    }
+    
+    func replaceCharactersInRange(aRange: NSRange, withText aString: AnyObject) -> NSRange {
+        var replacementRange = aRange
+        var len = 0
+        if let attrStr = aString as? NSAttributedString {
+            len = attrStr.string.characters.count
+        } else if let str = aString as? NSString {
+            len = str.length
+        }
+        if (replacementRange.location == NSNotFound) {
+            replacementRange.location = 0
+            replacementRange.length = 0
+        }
+        for _ in 0..<aRange.length {
+            sendRpcAsync("delete_backward", params  : [])
+        }
+        if let attrStr = aString as? NSAttributedString {
+            sendRpcAsync("insert", params: insertedStringToJson(attrStr.string))
+        } else if let str = aString as? NSString {
+            sendRpcAsync("insert", params: insertedStringToJson(str))
+        }
+        return NSMakeRange(replacementRange.location, len)
+    }
+    
+    func setMarkedText(aString: AnyObject, selectedRange: NSRange, replacementRange: NSRange) {
+        var mutSelectedRange = selectedRange
+        let effectiveRange = self.replaceCharactersInRange(self.replacementMarkedRange(replacementRange), withText: aString)
+        if (selectedRange.location != NSNotFound) {
+            mutSelectedRange.location += effectiveRange.location
+        }
+        _selectedRange = mutSelectedRange
+        _markedRange = effectiveRange
+        if (effectiveRange.length == 0) {
+            self.removeMarkedText()
+        }
+    }
+    
+    func removeMarkedText() {
+        if (_markedRange.location != NSNotFound) {
+            for _ in 0..<_markedRange.length {
+                sendRpcAsync("delete_backward", params: [])
+            }
+        }
+        _markedRange = NSMakeRange(NSNotFound, 0)
+        _selectedRange = NSMakeRange(NSNotFound, 0)
+    }
+    
+    func unmarkText() {
+        self._markedRange = NSMakeRange(NSNotFound, 0)
+    }
+    
+    func selectedRange() -> NSRange {
+        return _selectedRange
+    }
+    
+    func markedRange() -> NSRange {
+        return _markedRange
+    }
+    
+    func hasMarkedText() -> Bool {
+        return _markedRange.location != NSNotFound
+    }
+    
+    func attributedSubstringForProposedRange(aRange: NSRange, actualRange: NSRangePointer) -> NSAttributedString? {
+        return NSAttributedString()
+    }
+    
+    func validAttributesForMarkedText() -> [String] {
+        return [NSForegroundColorAttributeName, NSBackgroundColorAttributeName]
+    }
+    
+    func firstRectForCharacterRange(aRange: NSRange, actualRange: NSRangePointer) -> NSRect {
+        if let viewWinFrame = self.window?.convertRectToScreen(self.frame),
+            let (lineIx, pos) = self.cursorPos,
+            let line = getLine(lineIx) {
+            let str = line[0] as! String
+            let ctLine = CTLineCreateWithAttributedString(NSMutableAttributedString(string: str, attributes: self.attributes))
+            let rangeWidth = CTLineGetOffsetForStringIndex(ctLine, pos, nil) - CTLineGetOffsetForStringIndex(ctLine, pos - aRange.length, nil)
+            return NSRect(x: viewWinFrame.origin.x + CTLineGetOffsetForStringIndex(ctLine, pos, nil),
+                          y: viewWinFrame.origin.y + viewWinFrame.size.height - linespace * CGFloat(lineIx + 1) - 5,
+                          width: rangeWidth,
+                          height: linespace)
+        } else {
+            return NSRect(x: 0, y: 0, width: 0, height: 0)
+        }
+    }
+    
+    func characterIndexForPoint(aPoint: NSPoint) -> Int {
+        return 0
+    }
+    
     override func doCommandBySelector(aSelector: Selector) {
         if (self.respondsToSelector(aSelector)) {
             super.doCommandBySelector(aSelector);
@@ -354,7 +478,17 @@ class EditView: NSView {
         }
     }
 
+    func undo(sender: AnyObject?) {
+        sendRpcAsync("undo", params: [])
+    }
+
+    func redo(sender: AnyObject?) {
+        sendRpcAsync("redo", params: [])
+    }
+
     override func mouseDown(theEvent: NSEvent) {
+        removeMarkedText()
+        self.inputContext?.discardMarkedText()
         let (line, col) = pointToLineCol(convertPoint(theEvent.locationInWindow, fromView: nil))
         lastDragLineCol = (line, col)
         let flags = theEvent.modifierFlags.rawValue >> 16
@@ -514,14 +648,28 @@ class EditView: NSView {
             return nil
         }
     }
+    
+    var isEmpty: Bool {
+        if height == 0 { return true }
+        if height > 1 { return false }
+        if let line = getLine(0) {
+            return line[0] as? String == ""
+        } else {
+            return true
+        }
+    }
 
     // MARK: - Debug Methods
 
     @IBAction func debugRewrap(sender: AnyObject) {
-        sendRpcAsync("debug_rewrap", params: []);
+        sendRpcAsync("debug_rewrap", params: [])
     }
 
     @IBAction func debugTestFGSpans(sender: AnyObject) {
-        sendRpcAsync("debug_test_fg_spans", params: []);
+        sendRpcAsync("debug_test_fg_spans", params: [])
+    }
+
+    @IBAction func debugRunPlugin(sender: AnyObject) {
+        sendRpcAsync("debug_run_plugin", params: [])
     }
 }

--- a/XiEditor/SearchController.swift
+++ b/XiEditor/SearchController.swift
@@ -1,0 +1,79 @@
+//
+//  SearchControler.swift
+//  XiEditor
+//
+//  Created by Christopher Stern on 11/20/16.
+//  Copyright © 2016 Raph Levien. All rights reserved.
+//
+
+import Cocoa
+
+class SearchController: NSWindowController{
+    @IBOutlet var textField: NSTextField!
+    @IBOutlet var regExpCheck: NSButton!
+    @IBOutlet var caseCheck: NSButton!
+    @IBOutlet var wholeWordCheck: NSButton!
+    
+    @IBAction func findNext(sender: AnyObject) {
+        appDelegate?.searchNext()
+    }
+    
+    weak var appDelegate: AppDelegate?
+    
+    class SearchData: NSObject {
+        dynamic var regExp = 0
+        dynamic var matchCase = 0
+        dynamic var wholeWord = 0
+        
+        dynamic var text : NSString? = ""
+    }
+    dynamic var searchData : SearchData = SearchData()
+    
+    
+    convenience init() {
+        self.init(windowNibName: "SearchController")
+    }
+
+    private var kvoContext: UInt8 = 1
+
+    override func windowDidLoad() {
+        
+        searchData.addObserver(self, forKeyPath: "regExp", options: NSKeyValueObservingOptions.New, context: &kvoContext)
+        searchData.addObserver(self, forKeyPath: "matchCase", options: NSKeyValueObservingOptions.New, context: &kvoContext)
+        searchData.addObserver(self, forKeyPath: "wholeWord", options: NSKeyValueObservingOptions.New, context: &kvoContext)
+        searchData.addObserver(self, forKeyPath: "text", options: NSKeyValueObservingOptions.New, context: &kvoContext)
+        
+        regExpCheck.enabled = false
+        caseCheck.state=1
+        caseCheck.enabled = false
+        wholeWordCheck.enabled = false
+    }
+    
+    func setSearchString(s: String) {
+        searchData.text = s
+    }
+    
+    override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
+        if context == &kvoContext {
+            let searchText : String
+            if let sdt = searchData.text {
+                searchText = sdt as String
+            }
+            else {
+                searchText = ""
+            }
+            
+           appDelegate?.updateSearch(searchText,
+                            regExp:searchData.regExp != 0,
+                            matchCase:searchData.matchCase != 0,
+                            wholeWord:searchData.wholeWord != 0 )
+        }
+    }
+ 
+    deinit {
+        searchData.removeObserver(self, forKeyPath: "regExp")
+        searchData.removeObserver(self, forKeyPath: "matchCase")
+        searchData.removeObserver(self, forKeyPath: "wholeWord")
+        searchData.removeObserver(self, forKeyPath: "text")
+    }
+}

--- a/XiEditor/SearchController.xib
+++ b/XiEditor/SearchController.xib
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11542" systemVersion="15G1108" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11542"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+        <capability name="stacking Non-gravity area distributions on NSStackView" minToolsVersion="7.0" minSystemVersion="10.11"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="SearchController" customModule="XiEditor" customModuleProvider="target">
+            <connections>
+                <outlet property="caseCheck" destination="myL-1b-OBi" id="Odz-N2-wBW"/>
+                <outlet property="regExpCheck" destination="gL3-NU-8nB" id="wOD-DZ-Xlb"/>
+                <outlet property="textField" destination="7Ea-qz-Wiq" id="YA6-oq-xdl"/>
+                <outlet property="wholeWordCheck" destination="EfA-8T-MKm" id="uht-9Q-pAp"/>
+                <outlet property="window" destination="QvC-M9-y7g" id="1Ap-BK-ppa"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <window title="Find" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="196" y="240" width="660" height="148"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1177"/>
+            <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
+                <rect key="frame" x="0.0" y="0.0" width="660" height="148"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FRO-mO-zhn">
+                        <rect key="frame" x="20" y="20" width="620" height="108"/>
+                        <subviews>
+                            <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lEz-Sf-vW5">
+                                <rect key="frame" x="0.0" y="50" width="99" height="58"/>
+                                <subviews>
+                                    <button horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="gL3-NU-8nB">
+                                        <rect key="frame" x="-2" y="42" width="68" height="18"/>
+                                        <buttonCell key="cell" type="check" title="RegExp" bezelStyle="regularSquare" imagePosition="left" enabled="NO" inset="2" id="kvq-CQ-l1g">
+                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <binding destination="-2" name="value" keyPath="self.searchData.regExp" id="Elc-xP-b1P"/>
+                                        </connections>
+                                    </button>
+                                    <button horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="myL-1b-OBi">
+                                        <rect key="frame" x="-2" y="20" width="94" height="18"/>
+                                        <buttonCell key="cell" type="check" title="Match Case" bezelStyle="regularSquare" imagePosition="left" enabled="NO" inset="2" id="SgK-Xf-8AY">
+                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <binding destination="-2" name="value" keyPath="self.searchData.matchCase" id="tg6-O2-g3E"/>
+                                        </connections>
+                                    </button>
+                                    <button verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="EfA-8T-MKm">
+                                        <rect key="frame" x="-2" y="-2" width="103" height="18"/>
+                                        <buttonCell key="cell" type="check" title="Whole Words" bezelStyle="regularSquare" imagePosition="left" enabled="NO" inset="2" id="Huw-hc-yB5">
+                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <binding destination="-2" name="value" keyPath="self.searchData.wholeWord" id="nUm-0E-keT"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="myL-1b-OBi" firstAttribute="top" secondItem="gL3-NU-8nB" secondAttribute="bottom" constant="8" id="49R-dT-6hl"/>
+                                    <constraint firstAttribute="width" constant="99" id="7dl-fl-36j"/>
+                                    <constraint firstAttribute="height" constant="58" id="ox0-dc-xbC"/>
+                                </constraints>
+                                <visibilityPriorities>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                </visibilityPriorities>
+                                <customSpacing>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                </customSpacing>
+                            </stackView>
+                            <textField horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="7Ea-qz-Wiq">
+                                <rect key="frame" x="107" y="0.0" width="448" height="108"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" continuous="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="Yg8-cw-uhy">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                                <connections>
+                                    <binding destination="-2" name="value" keyPath="self.searchData.text" id="I5H-4W-OIO">
+                                        <dictionary key="options">
+                                            <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                        </dictionary>
+                                    </binding>
+                                </connections>
+                            </textField>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TYA-23-7jS">
+                                <rect key="frame" x="557" y="80" width="69" height="32"/>
+                                <buttonCell key="cell" type="push" title="Next" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="QtD-2z-86q">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="findNext:" target="-2" id="Imo-9R-yTt"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="7Ea-qz-Wiq" secondAttribute="bottom" id="FBA-Sv-8bp"/>
+                            <constraint firstItem="TYA-23-7jS" firstAttribute="leading" secondItem="7Ea-qz-Wiq" secondAttribute="trailing" constant="8" id="GfO-MW-RAd"/>
+                            <constraint firstItem="7Ea-qz-Wiq" firstAttribute="leading" secondItem="lEz-Sf-vW5" secondAttribute="trailing" constant="8" id="MRX-kW-zQo"/>
+                            <constraint firstItem="TYA-23-7jS" firstAttribute="leading" secondItem="7Ea-qz-Wiq" secondAttribute="trailing" constant="8" id="Ras-iS-y22"/>
+                        </constraints>
+                        <visibilityPriorities>
+                            <integer value="1000"/>
+                            <integer value="1000"/>
+                            <integer value="1000"/>
+                        </visibilityPriorities>
+                        <customSpacing>
+                            <real value="3.4028234663852886e+38"/>
+                            <real value="3.4028234663852886e+38"/>
+                            <real value="3.4028234663852886e+38"/>
+                        </customSpacing>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="FRO-mO-zhn" firstAttribute="top" secondItem="EiT-Mj-1SZ" secondAttribute="top" constant="20" symbolic="YES" id="06u-la-RoO"/>
+                    <constraint firstAttribute="trailing" secondItem="FRO-mO-zhn" secondAttribute="trailing" constant="20" symbolic="YES" id="BK5-X0-68J"/>
+                    <constraint firstItem="FRO-mO-zhn" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="20" symbolic="YES" id="LBu-UL-vAV"/>
+                    <constraint firstAttribute="bottom" secondItem="FRO-mO-zhn" secondAttribute="bottom" constant="20" symbolic="YES" id="hst-xR-jOW"/>
+                </constraints>
+            </view>
+            <connections>
+                <outlet property="delegate" destination="-2" id="h5j-22-ZWQ"/>
+            </connections>
+            <point key="canvasLocation" x="195" y="303"/>
+        </window>
+        <userDefaultsController representsSharedInstance="YES" id="3K6-OS-BqI"/>
+    </objects>
+</document>

--- a/rust/src/rpc.rs
+++ b/rust/src/rpc.rs
@@ -95,6 +95,7 @@ pub enum EditCommand<'a> {
     DebugRewrap,
     DebugTestFgSpans,
     DebugRunPlugin,
+    Search { text: &'a str }
 }
 
 impl<'a> TabCommand<'a> {
@@ -229,6 +230,11 @@ impl<'a> EditCommand<'a> {
             "debug_rewrap" => Ok(DebugRewrap),
             "debug_test_fg_spans" => Ok(DebugTestFgSpans),
             "debug_run_plugin" => Ok(DebugRunPlugin),
+
+            "search" => params.as_object().and_then(|dict| {
+                dict_get_string(dict, "text").map(|text| Search { text: text })
+            }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
+
 
             _ => Err(UnknownEditMethod(method.to_string())),
         }


### PR DESCRIPTION
Add support for simple text search.  
Adds a new Find dialog. 
Adds the support for the following standard menu commands
 cmd-e - enter selection as find string
 cmd-f - show find dialog
 cmd-g - find next occurrence
These commands were already on the Xi Edit menu, which is not changed by this PR. I am hooking up the existing menu items. 
This PR introduces a single app-global find string and find dlg. This differs from SublimeText and Atom which have find controls in the editor window. Those editors however can open multiple files in one window.  Also the separate dialog seemed less likely to conflict with any other UI changes.