### PR TITLE
Fix Autoresize/Constraint conflict that breaks scrolling for some Xcode

### DIFF
--- a/XiEditor/AppWindowController.xib
+++ b/XiEditor/AppWindowController.xib
@@ -32,6 +32,9 @@
                             <subviews>
                                 <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hxn-ZY-xOb" customClass="EditView" customModule="XiEditor" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="boolean" keyPath="translatesAutoresizingMaskIntoConstraints" value="NO"/>
+                                    </userDefinedRuntimeAttributes>
                                 </customView>
                             </subviews>
                         </clipView>


### PR DESCRIPTION
Fix a conflict with constraints generated from the EditView’s
auto-resize mask. These extraneous constraints cause Xi edit windows
not to be scrollable or resizable on some versions of Xcode. The effect
of this conflict depends on which of the conflicting constraints are
discarded, which seems to somewhat unpredictable. This change marks the
EditView as translatesAutoresizingMaskIntoConstraints=NO. 
We know that this is a constraint conflict because the xi stderr says so:
```
Unable to simultaneously satisfy constraints:
(
    "<NSAutoresizingMaskLayoutConstraint:0x610000083f20 h=--& v=&-- V:[XiEditor.EditView:0x101d06bc0(270)]>",
    "<NSLayoutConstraint:0x608000082f80 V:[XiEditor.EditView:0x101d06bc0(>=4880.32)]>"
)

```
  and because this one change fixes the conflict message,  and make the xi edit window scrollable.
This is not an unknown issue see for example  [https://www.innoq.com/en/blog/ios-auto-layout-problem/](url)