### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: rust
+
+rust:
+  - stable
+  - nightly
+
+os:
+  - linux
+  - osx
+
+matrix:
+  allow_failures:
+    - rust: nightly
+
+cache:
+  directories:
+    - $HOME/.cargo
+
+script:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild; fi
+  - cd rust
+  - export CARGO_TARGET_DIR=/tmp/target
+  - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then cargo build && cargo build --manifest-path syntect-plugin/Cargo.toml; fi
+  - for MANIFEST in Cargo.toml */Cargo.toml; do cargo test --manifest-path $MANIFEST; done

--- a/build-rust-xcode.sh
+++ b/build-rust-xcode.sh
@@ -57,3 +57,6 @@ function build_target () {
 
 build_target xi-core rust
 build_target xi-syntect-plugin rust/syntect-plugin
+
+# workaround for https://github.com/travis-ci/travis-ci/issues/6522
+set +e


### PR DESCRIPTION
I couldn't find any evidence of previous work or discussions about Travis CI, so thought I'd whip up a quick proof of concept.

My key concern is that I don't know if you're allowed to use Travis CI with Google organisation projects, or whether you have any desire for CI at all.

* It builds on OS X (with Xcode 7.3, for the GUI) and Linux (mainly for turnaround time, as there are usually long queues for OS X builders)
* It builds on Rust stable and nightly, allowing nightly builds to fail
* It doesn't do anything fancy like uploading tagged releases to GitHub; I'll add that (at least for the OS X app) if you think it's worthwhile
* I have left the default email notifications settings; that can always be changed
* There's a minor change to your Xcode build script to work around a Travis bug, but it won't affect non-Travis builds

Getting much fancier than uploading builds of the OS X app to GitHub might prompt some repo splitting, but we don't have to worry about that for now. 😄