### PR TITLE
Improve mouse cursor switching

### DIFF
--- a/XiEditor/AppWindowController.swift
+++ b/XiEditor/AppWindowController.swift
@@ -53,6 +53,8 @@ class AppWindowController: NSWindowController {
         editView.coreConnection = dispatcher.coreConnection
         editView.tabName = tabName
         appDelegate.registerTab(tabName, controller: self)
+        
+        scrollView.contentView.documentCursor = NSCursor.IBeamCursor();
 
         // set up autolayout constraints
         let views = ["editView": editView, "clipView": scrollView.contentView]

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -146,11 +146,6 @@ class EditView: NSView, NSTextInputClient {
         needsDisplay = true
     }
 
-    override func resetCursorRects() {
-        super.resetCursorRects()
-        addCursorRect(frameRect, cursor: NSCursor.IBeamCursor())
-    }
-
     required init?(coder: NSCoder) {
         fatalError("View doesn't support NSCoding")
     }


### PR DESCRIPTION
This makes the cursor switch from standard pointer to I-Beam cursor work
regardless of the window size.