### PR TITLE
Add an example of a combine number parser

### DIFF
--- a/rust/lang/Cargo.toml
+++ b/rust/lang/Cargo.toml
@@ -10,6 +10,7 @@ description = "A language syntax coloring and indentation plugin for xi-editor."
 pom = { version = "0.8", optional = true }
 regex = { version = "0.2", optional = true }
 nom = { version = "2.1", optional = true }
+combine = { version = "2.2.2", optional = true }
 
 [dependencies.xi-plugin-lib]
 path = "../plugin-lib"


### PR DESCRIPTION
I cleaned up my example from https://www.reddit.com/r/rust/comments/5r6tib/parser_combinators_without_macros_my_take/ the time for combine is not quite as fast as nom or your peg parsers if one writes it in the normal way (first commit). I believe this is partly because of the drop glue from error types (no errors are allocated, but the drop glue still needs to run and check that `Vec::is_empty()` for the errors vector) and partly that LLVM is not quite able to optimize the `or` parsers as well as one might hope as modifying.

First commit
```
test combine_benches::bench_combine ... bench:          48 ns/iter (+/- 2)
test nom_benches::bench_nom         ... bench:          24 ns/iter (+/- 3)
test pom_benches::bench_pom         ... bench:       3,425 ns/iter (+/- 164)
test tests::bench_my_peg            ... bench:          20 ns/iter (+/- 2)
```

However, taking into account that the input string did not have a sign for the exponent I modified it slightly which seems to let LLVM optimize the parser to be more or less equal to nom.

```
test combine_benches::bench_combine ... bench:          25 ns/iter (+/- 4)
test nom_benches::bench_nom         ... bench:          24 ns/iter (+/- 1)
test pom_benches::bench_pom         ... bench:       3,240 ns/iter (+/- 660)
test tests::bench_my_peg            ... bench:          20 ns/iter (+/- 1)
```