### PR TITLE
Incremental update protocol

### DIFF
--- a/XiEditor.xcodeproj/project.pbxproj
+++ b/XiEditor.xcodeproj/project.pbxproj
@@ -8,7 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		50370A2B1D4209F300EA1B18 /* Dispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50370A2A1D4209F300EA1B18 /* Dispatcher.swift */; };
+		AE0243F61E4BDF8A00641BDA /* StyleMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0243F51E4BDF8A00641BDA /* StyleMap.swift */; };
 		AE041BA61D4327EB0069AB8B /* xi-syntect-plugin in Resources */ = {isa = PBXBuildFile; fileRef = AE041BA51D4327EB0069AB8B /* xi-syntect-plugin */; };
+		AE168C5C1E4AD87B008249AE /* LineCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE168C5B1E4AD87B008249AE /* LineCache.swift */; };
 		AE228F5D1C897CE7000E9B0F /* xi-core in Resources */ = {isa = PBXBuildFile; fileRef = AE228F5C1C897CE7000E9B0F /* xi-core */; };
 		AE499DD01C82BB2B002D68AF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE499DCF1C82BB2B002D68AF /* AppDelegate.swift */; };
 		AE499DD21C82BB2B002D68AF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AE499DD11C82BB2B002D68AF /* Assets.xcassets */; };
@@ -49,8 +51,10 @@
 
 /* Begin PBXFileReference section */
 		50370A2A1D4209F300EA1B18 /* Dispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dispatcher.swift; sourceTree = "<group>"; };
+		AE0243F51E4BDF8A00641BDA /* StyleMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StyleMap.swift; sourceTree = "<group>"; };
 		AE041B971D4323460069AB8B /* build-rust-xcode.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "build-rust-xcode.sh"; sourceTree = "<group>"; };
 		AE041BA51D4327EB0069AB8B /* xi-syntect-plugin */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = "xi-syntect-plugin"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AE168C5B1E4AD87B008249AE /* LineCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineCache.swift; sourceTree = "<group>"; };
 		AE228F5C1C897CE7000E9B0F /* xi-core */ = {isa = PBXFileReference; lastKnownFileType = text; path = "xi-core"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE499DCC1C82BB2B002D68AF /* XiEditor.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = XiEditor.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE499DCF1C82BB2B002D68AF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -131,6 +135,8 @@
 				50370A2A1D4209F300EA1B18 /* Dispatcher.swift */,
 				AED23F141C83C689002246CE /* AppWindowController.xib */,
 				AE499DD61C82BB2B002D68AF /* Info.plist */,
+				AE168C5B1E4AD87B008249AE /* LineCache.swift */,
+				AE0243F51E4BDF8A00641BDA /* StyleMap.swift */,
 			);
 			path = XiEditor;
 			sourceTree = "<group>";
@@ -322,6 +328,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AE0243F61E4BDF8A00641BDA /* StyleMap.swift in Sources */,
+				AE168C5C1E4AD87B008249AE /* LineCache.swift in Sources */,
 				AE499DF91C82C835002D68AF /* CoreConnection.swift in Sources */,
 				AED23F151C83C689002246CE /* AppWindowController.swift in Sources */,
 				50370A2B1D4209F300EA1B18 /* Dispatcher.swift in Sources */,

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -19,6 +19,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     var appWindowControllers: [String: AppWindowController] = [:]
     var dispatcher: Dispatcher?
+    var styleMap: StyleMap = StyleMap()
 
     func applicationWillFinishLaunching(_ aNotification: Notification) {
 
@@ -37,7 +38,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         newWindow()
     }
-    
+
     func newWindow() -> AppWindowController {
         let appWindowController = AppWindowController()
         appWindowController.dispatcher = dispatcher
@@ -73,7 +74,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     else { print("tab missing from update event"); return }
                 guard let appWindowController = appWindowControllers[tab]
                     else { print("tab " + tab + " not registered"); return }
-                appWindowController.editView.updateSafe(update)
+                appWindowController.editView.updateSafe(update: update)
+            }
+        case "scroll_to":
+            if let obj = params as? [String : AnyObject], let line = obj["line"] as? Int, let col = obj["col"] as? Int {
+                guard let tab = obj["tab"] as? String
+                    else { print("tab missing from update event"); return }
+                guard let appWindowController = appWindowControllers[tab]
+                    else { print("tab " + tab + " not registered"); return }
+                appWindowController.editView.scrollTo(line, col)
+            }
+        case "def_style":
+            if let obj = params as? [String : AnyObject] {
+                styleMap.defStyle(json: obj)
             }
         case "alert":
             if let obj = params as? [String : AnyObject], let msg = obj["msg"] as? String {

--- a/XiEditor/AppWindowController.swift
+++ b/XiEditor/AppWindowController.swift
@@ -28,7 +28,7 @@ class AppWindowController: NSWindowController {
     weak var appDelegate: AppDelegate!
 
     var dispatcher: Dispatcher!
-    
+
     var filename: String? {
         didSet {
             if let filename = filename {
@@ -50,9 +50,10 @@ class AppWindowController: NSWindowController {
 
         let tabName = Events.NewTab().dispatch(dispatcher)
         editView.coreConnection = dispatcher.coreConnection
+        editView.styleMap = appDelegate.styleMap
         editView.tabName = tabName
         appDelegate.registerTab(tabName, controller: self)
-        
+
         scrollView.contentView.documentCursor = NSCursor.iBeam();
 
         // set up autolayout constraints
@@ -94,7 +95,7 @@ class AppWindowController: NSWindowController {
 
         editView.sendRpcAsync("save", params: ["filename": filename!] as AnyObject)
     }
-    
+
     func saveDocumentAs(_ sender: AnyObject) {
         let fileDialog = NSSavePanel()
         if fileDialog.runModal() == NSFileHandlingPanelOKButton {
@@ -122,6 +123,6 @@ extension AppWindowController: NSWindowDelegate {
     }
     func windowDidResignKey(_ notification: Notification) {
         editView.updateIsFrontmost(false);
-        
+
     }
 }

--- a/XiEditor/CoreConnection.swift
+++ b/XiEditor/CoreConnection.swift
@@ -42,7 +42,7 @@ class CoreConnection {
         }
         task.launch()
     }
-    
+
     func recvHandler(_ data: Data) {
         if data.count == 0 {
             print("eof")

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -66,9 +66,7 @@ class EditView: NSView, NSTextInputClient {
     var tabName: String?
     var coreConnection: CoreConnection?
 
-    // basically a cache of lines, indexed by line number
-    var lineMap: [Int: [AnyObject]] = [:]
-    var height: Int = 0
+    var lines: LineCache
 
     var widthConstraint: NSLayoutConstraint?
     var heightConstraint: NSLayoutConstraint?
@@ -87,27 +85,25 @@ class EditView: NSView, NSTextInputClient {
     // visible scroll region, exclusive of lastLine
     var firstLine: Int = 0
     var lastLine: Int = 0
-    
+
     var lastDragLineCol: (Int, Int)?
     var timer: Timer?
     var timerEvent: NSEvent?
 
-    // magic for accepting updates from other threads
-    var updateQueue: DispatchQueue
-    var pendingUpdate: [String: AnyObject]? = nil
-
     var currentEvent: NSEvent?
-    
+
     var cursorPos: (Int, Int)?
     var _selectedRange: NSRange
     var _markedRange: NSRange
-    
+
     var frameRect: NSRect
-    
+
     var isFrontmost: Bool // Are we frontmost, the view that gets keyboard input?
-    
+
     var cursorFlashOn: Bool
     var blinkTimer : Timer?
+
+    var styleMap: StyleMap?
 
     override init(frame frameRect: NSRect) {
         let font = CTFontCreateWithName("InconsolataGo" as CFString?, 14, nil)
@@ -120,21 +116,20 @@ class EditView: NSView, NSTextInputClient {
         fontWidth = getFontWidth(font)
         fgSelcolor =  NSColor.selectedTextBackgroundColor
         bgSelcolor = NSColor(colorLiteralRed: 0.8, green: 0.8, blue: 0.8, alpha: 1.0) //Gray for the selected text background when not 'key'
-        updateQueue = DispatchQueue(label: "com.levien.xi.update", attributes: [])
         _selectedRange = NSMakeRange(NSNotFound, 0)
         _markedRange = NSMakeRange(NSNotFound, 0)
         self.frameRect = frameRect
         isFrontmost = false
         cursorFlashOn = true
+        lines = LineCache()
         super.init(frame: frameRect)
         widthConstraint = NSLayoutConstraint(item: self, attribute: .width, relatedBy: .greaterThanOrEqual, toItem: nil, attribute: .width, multiplier: 1, constant: 400)
         widthConstraint!.isActive = true
         heightConstraint = NSLayoutConstraint(item: self, attribute: .height, relatedBy: .greaterThanOrEqual, toItem: nil, attribute: .height, multiplier: 1, constant: 100)
         heightConstraint!.isActive = true
     }
-    
+
     override func changeFont(_ sender: Any?) {
-        Swift.print("changeFont...")
         let oldFont = attributes[String(kCTFontAttributeName)] as! CTFont
         let font = (sender as! NSFontManager).convert(oldFont)
         ascent = CTFontGetAscent(font)
@@ -192,18 +187,22 @@ class EditView: NSView, NSTextInputClient {
         let first = Int(floor(dirtyRect.origin.y / linespace))
         let last = Int(ceil((dirtyRect.origin.y + dirtyRect.size.height) / linespace))
 
+        let missing = lines.computeMissing(first, last)
+        for (f, l) in missing {
+            Swift.print("requesting missing: \(f)..\(l)")
+            sendRpcAsync("request_lines", params: [f, l])
+        }
+
         for lineIx in first..<last {
-            let line = getLine(lineIx)
-            if line == nil {
-                continue
-            }
-            let s = line![0] as! String
+            // TODO: could block for ~1ms waiting for missing lines to arrive
+            guard let line = getLine(lineIx) else { continue }
+            let s = line.text
             let attrString = NSMutableAttributedString(string: s, attributes: self.attributes)
             /*
             let randcolor = NSColor(colorLiteralRed: Float(drand48()), green: Float(drand48()), blue: Float(drand48()), alpha: 1.0)
             attrString.addAttribute(NSForegroundColorAttributeName, value: randcolor, range: NSMakeRange(0, s.utf16.count))
             */
-            var cursor: Int? = nil;
+            /*
             for attr in line!.dropFirst() {
                 let attr = attr as! [AnyObject]
                 let type = attr[0] as! String
@@ -253,7 +252,9 @@ class EditView: NSView, NSTextInputClient {
                     }
                 }
             }
-            if let c = cursor {
+            */
+            styleMap?.applyStyles(text: s, string: attrString, styles: line.styles, selColor: selcolor())
+            for c in line.cursor {
                 let cix = utf8_offset_to_utf16(s, c)
                 if (markedRange().location != NSNotFound) {
                     let markRangeStart = cix - markedRange().length
@@ -272,33 +273,35 @@ class EditView: NSView, NSTextInputClient {
                     }
                 }
             }
-            
+
             // TODO: I don't understand where the 13 comes from (it's what aligns with baseline. We
             // probably want to move to using CTLineDraw instead of drawing the attributed string,
             // but that means drawing the selection highlight ourselves (which has other benefits).
             //attrString.drawAtPoint(NSPoint(x: x0, y: y - 13))
             let y = linespace * CGFloat(lineIx + 1);
             attrString.draw(with: NSRect(x: x0, y: y, width: dirtyRect.origin.x + dirtyRect.width - x0, height: 14), options: [])
-            if isFrontmost, let cursor = cursor {
-                let ctline = CTLineCreateWithAttributedString(attrString)
-                /*
-                CGContextSetTextMatrix(context, CGAffineTransform(a: 1, b: 0, c: 0, d: -1, tx: x0, ty: y))
-                CTLineDraw(ctline, context)
-                */
-                var pos = CGFloat(0)
-                // special case because measurement is so expensive; might have to rethink in rtl
-                if cursor != 0 {
-                    let utf16_ix = utf8_offset_to_utf16(s, cursor)
-                    pos = CTLineGetOffsetForStringIndex(ctline, CFIndex(utf16_ix), nil)
+            if isFrontmost {
+                for cursor in line.cursor {
+                    let ctline = CTLineCreateWithAttributedString(attrString)
+                    /*
+                    CGContextSetTextMatrix(context, CGAffineTransform(a: 1, b: 0, c: 0, d: -1, tx: x0, ty: y))
+                    CTLineDraw(ctline, context)
+                    */
+                    var pos = CGFloat(0)
+                    // special case because measurement is so expensive; might have to rethink in rtl
+                    if cursor != 0 {
+                        let utf16_ix = utf8_offset_to_utf16(s, cursor)
+                        pos = CTLineGetOffsetForStringIndex(ctline, CFIndex(utf16_ix), nil)
+                    }
+                    context.setStrokeColor(cursorColor())
+                    context.move(to: CGPoint(x: x0 + pos, y: y + descent))
+                    context.addLine(to: CGPoint(x: x0 + pos, y: y - ascent))
+                    context.strokePath()
                 }
-                context.setStrokeColor(cursorColor())
-                context.move(to: CGPoint(x: x0 + pos, y: y + descent))
-                context.addLine(to: CGPoint(x: x0 + pos, y: y - ascent))
-                context.strokePath()
             }
         }
     }
-    
+
     override var acceptsFirstResponder: Bool {
         return true;
     }
@@ -332,11 +335,11 @@ class EditView: NSView, NSTextInputClient {
         self.removeMarkedText()
         self.replaceCharactersInRange(replacementRange, withText: aString as AnyObject)
     }
-    
+
     func replacementMarkedRange(_ replacementRange: NSRange) -> NSRange {
         var markedRange = _markedRange
-        
-        
+
+
         if (markedRange.location == NSNotFound) {
             markedRange = _selectedRange
         }
@@ -348,10 +351,10 @@ class EditView: NSView, NSTextInputClient {
                 markedRange = newRange
             }
         }
-        
+
         return markedRange
     }
-    
+
     func replaceCharactersInRange(_ aRange: NSRange, withText aString: AnyObject) -> NSRange {
         var replacementRange = aRange
         var len = 0
@@ -374,7 +377,7 @@ class EditView: NSView, NSTextInputClient {
         }
         return NSMakeRange(replacementRange.location, len)
     }
-    
+
     func setMarkedText(_ aString: Any, selectedRange: NSRange, replacementRange: NSRange) {
         var mutSelectedRange = selectedRange
         let effectiveRange = self.replaceCharactersInRange(self.replacementMarkedRange(replacementRange), withText: aString as AnyObject)
@@ -387,7 +390,7 @@ class EditView: NSView, NSTextInputClient {
             self.removeMarkedText()
         }
     }
-    
+
     func removeMarkedText() {
         if (_markedRange.location != NSNotFound) {
             for _ in 0..<_markedRange.length {
@@ -397,36 +400,36 @@ class EditView: NSView, NSTextInputClient {
         _markedRange = NSMakeRange(NSNotFound, 0)
         _selectedRange = NSMakeRange(NSNotFound, 0)
     }
-    
+
     func unmarkText() {
         self._markedRange = NSMakeRange(NSNotFound, 0)
     }
-    
+
     func selectedRange() -> NSRange {
         return _selectedRange
     }
-    
+
     func markedRange() -> NSRange {
         return _markedRange
     }
-    
+
     func hasMarkedText() -> Bool {
         return _markedRange.location != NSNotFound
     }
-    
+
     func attributedSubstring(forProposedRange aRange: NSRange, actualRange: NSRangePointer?) -> NSAttributedString? {
         return NSAttributedString()
     }
-    
+
     func validAttributesForMarkedText() -> [String] {
         return [NSForegroundColorAttributeName, NSBackgroundColorAttributeName]
     }
-    
+
     func firstRect(forCharacterRange aRange: NSRange, actualRange: NSRangePointer?) -> NSRect {
         if let viewWinFrame = self.window?.convertToScreen(self.frame),
             let (lineIx, pos) = self.cursorPos,
             let line = getLine(lineIx) {
-            let str = line[0] as! String
+            let str = line.text
             let ctLine = CTLineCreateWithAttributedString(NSMutableAttributedString(string: str, attributes: self.attributes))
             let rangeWidth = CTLineGetOffsetForStringIndex(ctLine, pos, nil) - CTLineGetOffsetForStringIndex(ctLine, pos - aRange.length, nil)
             return NSRect(x: viewWinFrame.origin.x + CTLineGetOffsetForStringIndex(ctLine, pos, nil),
@@ -437,11 +440,11 @@ class EditView: NSView, NSTextInputClient {
             return NSRect(x: 0, y: 0, width: 0, height: 0)
         }
     }
-    
+
     func characterIndex(for aPoint: NSPoint) -> Int {
         return 0
     }
-    
+
     override func doCommand(by aSelector: Selector) {
         if (self.responds(to: aSelector)) {
             super.doCommand(by: aSelector);
@@ -503,7 +506,7 @@ class EditView: NSView, NSTextInputClient {
         timer = Timer.scheduledTimer(timeInterval: TimeInterval(1.0/60), target: self, selector: #selector(autoscrollTimer), userInfo: nil, repeats: true)
         timerEvent = theEvent
     }
-    
+
     override func mouseDragged(with theEvent: NSEvent) {
         autoscroll(with: theEvent)
         let (line, col) = pointToLineCol(convert(theEvent.locationInWindow, from: nil))
@@ -540,7 +543,7 @@ class EditView: NSView, NSTextInputClient {
         let lineIx = yToLine(loc.y)
         var col = 0
         if let line = getLine(lineIx) {
-            let s = line[0] as! String
+            let s = line.text
             let attrString = NSAttributedString(string: s, attributes: self.attributes)
             let ctline = CTLineCreateWithAttributedString(attrString)
             let relPos = NSPoint(x: loc.x - x0, y: lineIxToBaseline(lineIx) - loc.y)
@@ -552,39 +555,13 @@ class EditView: NSView, NSTextInputClient {
         return (lineIx, col)
     }
 
-    func updateText(_ text: [String: AnyObject]) {
-        self.lineMap = [:]
-        let firstLine = text["first_line"] as! Int
-        self.height = text["height"] as! Int
-        let lines = text["lines"]! as! [[AnyObject]]
-        for lineNum in firstLine..<(firstLine + lines.count) {
-            self.lineMap[lineNum] = lines[lineNum - firstLine]
-        }
-        heightConstraint?.constant = CGFloat(self.height) * linespace + 2 * descent
-        if let cursor = text["scrollto"] as? [Int] {
-            let line = cursor[0]
-            let col = cursor[1]
-            let x = CGFloat(col) * fontWidth  // TODO: deal with non-ASCII, non-monospaced case
-            let y = CGFloat(line) * linespace + baseline
-            let scrollRect = NSRect(x: x, y: y - baseline, width: 4, height: linespace + descent)
-            DispatchQueue.main.async {
-                // defer until resize has had a chance to happen
-                self.scrollToVisible(scrollRect)
-            }
-        }
-        if self.isFrontmost {
-            setInsertionBlink(true)
-        }
-        needsDisplay = true
-    }
-    
     /*  Insertion point blinking.
         Only the frontmost ('key') window should have a blinking insertion point.
         A new 'on' cycle starts every time the window is comes to the front, or the text changes, or the ins. point moves.
         Type fast enough and the ins. point stays on.
      */
-    
-    /// Turns the ins. point visible, and set it flashing. Dose nothing if window is not key.
+
+    /// Turns the ins. point visible, and set it flashing. Does nothing if window is not key.
     func setInsertionBlink(_ on: Bool) {
         // caller must set NeedsDisplay
         cursorFlashOn = on
@@ -596,13 +573,13 @@ class EditView: NSView, NSTextInputClient {
             blinkTimer = nil
         }
     }
-    
+
     // Just performs the actual blinking.
     func blinkInsertionPoint() {
-        cursorFlashOn = !self.cursorFlashOn
+        cursorFlashOn = !cursorFlashOn
         needsDisplay = true
     }
-    
+
     // Current color for the ins. point. Implements flashing.
     func cursorColor() -> CGColor {
         if cursorFlashOn {
@@ -612,7 +589,7 @@ class EditView: NSView, NSTextInputClient {
             return CGColor(gray: 1, alpha: 1) // should match background.
         }
     }
-    
+
     // Background color for selected text. Only the first responder of the key window should have a non-gray selection.
     func selcolor() -> NSColor {
         if isFrontmost {
@@ -623,24 +600,27 @@ class EditView: NSView, NSTextInputClient {
         }
     }
 
-
-    func tryUpdate() {
-        var pendingUpdate: [String: AnyObject]?
-        updateQueue.sync {
-            pendingUpdate = self.pendingUpdate
-            self.pendingUpdate = nil
-        }
-        if let text = pendingUpdate {
-            updateText(text)
+    // can be called from other threads
+    func updateSafe(update: [String: AnyObject]) {
+        var height: Int = 0;
+        lines.applyUpdate(update: update)
+        height = lines.height
+        DispatchQueue.main.async {
+            self.needsDisplay = true
+            self.heightConstraint?.constant = CGFloat(height) * self.linespace + 2 * self.descent
+            if self.isFrontmost {
+                self.setInsertionBlink(true)
+            }
         }
     }
 
-    func updateSafe(_ text: [String: AnyObject]) {
-        updateQueue.sync {
-            self.pendingUpdate = text
-        }
+    // can be called from other threads
+    func scrollTo(_ line: Int, _ col: Int) {
+        let x = CGFloat(col) * fontWidth  // TODO: deal with non-ASCII, non-monospaced case
+        let y = CGFloat(line) * linespace + baseline
+        let scrollRect = NSRect(x: x, y: y - baseline, width: 4, height: linespace + descent)
         DispatchQueue.main.async {
-            self.tryUpdate()
+            self.scrollToVisible(scrollRect)
         }
     }
 
@@ -655,6 +635,11 @@ class EditView: NSView, NSTextInputClient {
         }
     }
 
+    func getLine(_ lineNum: Int) -> Line? {
+        return lines.get(lineNum)
+    }
+
+    /*
     let MAX_CACHE_LINES = 1000
     let CACHE_FETCH_CHUNK = 100
 
@@ -691,7 +676,7 @@ class EditView: NSView, NSTextInputClient {
         }
         return lineMap[lineNum]
     }
-    
+
     func fetchLineRange(_ first: Int, _ last: Int) -> [[AnyObject]]? {
         let start = Date()
         if let result = sendRpc("render_lines", params: ["first_line": first, "last_line": last]) as? [[AnyObject]] {
@@ -703,23 +688,24 @@ class EditView: NSView, NSTextInputClient {
             return nil
         }
     }
-    
+    */
+
     var isEmpty: Bool {
-        if height == 0 { return true }
-        if height > 1 { return false }
+        if lines.height == 0 { return true }
+        if lines.height > 1 { return false }
         if let line = getLine(0) {
-            return line[0] as? String == ""
+            return line.text == ""
         } else {
             return true
         }
     }
-    
+
     func updateIsFrontmost(_ frontmost : Bool) {
         isFrontmost = frontmost
         setInsertionBlink(isFrontmost)
         needsDisplay = true
     }
-    
+
     // MARK: - Debug Methods
 
     @IBAction func debugRewrap(_ sender: AnyObject) {

--- a/XiEditor/LineCache.swift
+++ b/XiEditor/LineCache.swift
@@ -1,0 +1,188 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A data structure holding a cache of lines, with methods for updating based
+// on deltas from the core.
+
+import Foundation
+
+struct Line {
+    var text: String
+    var cursor: [Int]
+    var styles: [Int]
+
+    init(fromJson json: [String: AnyObject]) {
+        if let text = json["text"] as? String {
+            self.text = text
+        } else {
+            self.text = ""  // this should probably be an exception
+        }
+        if let cursor = json["cursor"] as? [Int] {
+            self.cursor = cursor
+        } else {
+            self.cursor = []
+        }
+        if let styles = json["styles"] as? [Int] {
+            self.styles = styles
+        } else {
+            self.styles = []
+        }
+    }
+
+    init?(updateFromJson line: Line?, json: [String: AnyObject]) {
+        if let line = line {
+            self.text = line.text
+            if let cursor = json["cursor"] as? [Int] {
+                self.cursor = cursor
+            } else {
+                self.cursor = line.cursor
+            }
+            if let styles = json["styles"] as? [Int] {
+                self.styles = styles
+            } else {
+                self.styles = line.styles
+            }
+        } else {
+            return nil
+        }
+    }
+}
+
+// Note: all public methods of this class are designed to be thread-safe
+class LineCache {
+    private let queue = DispatchQueue(label: "com.levien.xi.LineCache")
+    var nInvalidBefore = 0;
+    var lines: [Line?] = []
+    var nInvalidAfter = 0;
+
+    var height: Int {
+        get {
+            return queue.sync { heightLocked }
+        }
+    }
+
+    private var heightLocked: Int {
+        get {
+            return nInvalidBefore + lines.count + nInvalidAfter
+        }
+    }
+
+    func get(_ ix: Int) -> Line? {
+        return queue.sync { getLocked(ix) }
+    }
+
+    private func getLocked(_ ix: Int) -> Line? {
+        if ix < nInvalidBefore { return nil }
+        let ix = ix - nInvalidBefore
+        if ix < lines.count {
+            return lines[ix]
+        }
+        return nil
+    }
+
+    func applyUpdate(update: [String: Any]) {
+        queue.sync { applyUpdateLocked(update: update) }
+    }
+
+    private func applyUpdateLocked(update: [String: Any]) {
+        guard let ops = update["ops"] else { return }
+        var newInvalidBefore = 0
+        var newLines: [Line?] = []
+        var newInvalidAfter = 0
+        var oldIx = 0;
+        for op in ops as! [[String: AnyObject]] {
+            guard let op_type = op["op"] as? String else { return }
+            guard let n = op["n"] as? Int else { return }
+            switch op_type {
+            case "invalidate":
+                if newLines.count == 0 {
+                    newInvalidBefore += n
+                } else {
+                    newInvalidAfter += n
+                }
+            case "ins":
+                for _ in 0..<newInvalidAfter {
+                    newLines.append(nil)
+                }
+                newInvalidAfter = 0
+                guard let json_lines = op["lines"] as? [[String: AnyObject]] else { return }
+                for json_line in json_lines {
+                    newLines.append(Line(fromJson: json_line))
+                }
+            case "copy", "update":
+                var nRemaining = n
+                if oldIx < nInvalidBefore {
+                    let nInvalid = min(n, nInvalidBefore - oldIx)
+                    if newLines.count == 0 {
+                        newInvalidBefore += nInvalid
+                    } else {
+                        newInvalidAfter += nInvalid
+                    }
+                    oldIx += nInvalid
+                    nRemaining -= nInvalid
+                }
+                if nRemaining > 0 && oldIx < nInvalidBefore + lines.count {
+                    let nCopy = min(nRemaining, nInvalidBefore + lines.count - oldIx)
+                    let startIx = oldIx - nInvalidBefore
+                    if op_type == "copy" {
+                        newLines.append(contentsOf: lines[startIx ..< startIx + nCopy])
+                    } else {
+                        guard let json_lines = op["lines"] as? [[String: AnyObject]] else { return }
+                        var jsonIx = n - nRemaining
+                        for ix in startIx ..< startIx + nCopy {
+                            newLines.append(Line(updateFromJson: lines[ix], json: json_lines[jsonIx]))
+                            jsonIx += 1
+                        }
+                    }
+                    oldIx += nCopy
+                    nRemaining -= nCopy
+                }
+                if newLines.count == 0 {
+                    newInvalidBefore += nRemaining
+                } else {
+                    newInvalidAfter += nRemaining
+                }
+                oldIx += nRemaining
+            case "skip":
+                oldIx += n
+            default:
+                print("unknown op type \(op_type)")
+            }
+        }
+        nInvalidBefore = newInvalidBefore
+        lines = newLines
+        nInvalidAfter = newInvalidAfter
+    }
+
+    // Return ranges of invalid lines within the given range
+    func computeMissing(_ first: Int, _ last: Int) -> [(Int, Int)] {
+        return queue.sync { computeMissingLocked(first, last) }
+    }
+
+    private func computeMissingLocked(_ first: Int, _ last: Int) -> [(Int, Int)] {
+        var result: [(Int, Int)] = []
+        let last = min(last, heightLocked)  // lines past the end aren't considered missing
+        for ix in first..<last {
+            // could optimize a bit here, but unlikely to be important
+            if ix < nInvalidBefore || ix >= nInvalidBefore + lines.count || lines[ix - nInvalidBefore] == nil {
+                if result.count == 0 || result[result.count - 1].1 != ix {
+                    result.append((ix, ix + 1))
+                } else {
+                    result[result.count - 1].1 = ix + 1
+                }
+            }
+        }
+        return result
+    }
+}

--- a/XiEditor/StyleMap.swift
+++ b/XiEditor/StyleMap.swift
@@ -1,0 +1,119 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A store of text styles, indexable by id.
+
+import Cocoa
+
+struct Style {
+    var fgColor: NSColor;
+    var bgColor: NSColor;
+    var weight: UInt16;
+    var underline: Bool;
+    var italic: Bool;
+}
+
+func utf8_offset_to_utf16(_ s: String, _ ix: Int) -> Int {
+    // String(s.utf8.prefix(ix)).utf16.count
+    return s.utf8.index(s.utf8.startIndex, offsetBy: ix).samePosition(in: s.utf16)!._offset
+}
+
+// Note: all public methods of this class are designed to be thread-safe
+class StyleMap {
+    private let queue = DispatchQueue(label: "com.levien.xi.StyleMap")
+    private var map: [Style?] = []
+
+    func defStyle(json: [String: AnyObject]) {
+        queue.sync {
+            defStyleLocked(json: json)
+        }
+    }
+
+    private func defStyleLocked(json: [String: AnyObject]) {
+        //print("defStyle: \(json)")
+        guard let id = json["id"] as? Int else { return }
+        var fgColor: UInt32 = 0xFF000000;
+        var bgColor: UInt32 = 0;
+        var weight: UInt16 = 400;
+        var underline = false;
+        var italic = false;
+        if let fg = json["fg_color"] as? UInt32 {
+            fgColor = fg;
+        }
+        if let bg = json["bg_color"] as? UInt32 {
+            bgColor = bg;
+        }
+        if let w = json["weight"] as? UInt16 {
+            weight = w;
+        }
+        if let u = json["underline"] as? Bool {
+            underline = u;
+        }
+        if let i = json["italic"] as? Bool {
+            italic = i;
+        }
+        let style = Style(fgColor: colorFromArgb(fgColor), bgColor: colorFromArgb(bgColor), weight: weight, underline: underline, italic: italic);
+        while map.count < id {
+            map.append(nil)
+        }
+        if map.count == id {
+            map.append(style)
+        } else {
+            map[id] = style
+        }
+    }
+
+    private func applyStyle(string: NSMutableAttributedString, id: Int, range: NSRange) {
+        if id >= map.count { return }
+        guard let style = map[id] else { return }
+        string.addAttribute(NSForegroundColorAttributeName, value: style.fgColor, range: range)
+        if style.bgColor.alphaComponent != 0.0 {
+            string.addAttribute(NSBackgroundColorAttributeName, value: style.bgColor, range: range)
+        }
+        if style.underline {
+            string.addAttribute(NSUnderlineStyleAttributeName, value: NSUnderlineStyle.styleSingle.rawValue, range: range)
+        }
+        if style.weight > 500 {
+            // TODO: apply actual numeric weight
+            string.applyFontTraits(NSFontTraitMask.boldFontMask, range: range)
+        }
+        if style.italic {
+            // TODO: use true italic in font if available
+            string.addAttribute(NSObliquenessAttributeName, value: 0.2, range: range)
+        }
+    }
+
+    // Apply styles (given in the array-triple format as defined in the protocol doc) to the given string.
+    // The selection color (for which style 0 is reserverd) is passed in, as it might be different for
+    // different windows (while the StyleMap object is shared).
+    func applyStyles(text: String, string: NSMutableAttributedString, styles: [Int], selColor: NSColor) {
+        queue.sync {
+            var ix = 0;
+            for i in stride(from: 0, to: styles.count, by: 3) {
+                let start = ix + styles[i]
+                let end = start + styles[i + 1]
+                let style = styles[i + 2]
+                let startIx = utf8_offset_to_utf16(text, start)
+                let endIx = utf8_offset_to_utf16(text, end)
+                let range = NSMakeRange(startIx, endIx - startIx)
+                if style == 0 {
+                    string.addAttribute(NSBackgroundColorAttributeName, value: selColor, range: range)
+                } else {
+                    applyStyle(string: string, id: style, range: range)
+                }
+                ix = end
+            }
+        }
+    }
+}

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -31,6 +31,7 @@ mod editor;
 mod view;
 mod linewrap;
 mod run_plugin;
+mod styles;
 
 use tabs::Tabs;
 use rpc::Request;

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -84,6 +84,7 @@ pub enum EditCommand<'a> {
     Open { file_path: &'a str },
     Save { file_path: &'a str },
     Scroll { first: i64, last: i64 },
+    RequestLines { first: i64, last: i64 },
     Yank,
     Transpose,
     Click { line: u64, column: u64, flags: u64, click_count: u64 },
@@ -200,6 +201,13 @@ impl<'a> EditCommand<'a> {
                     (arr_get_i64(arr, 0), arr_get_i64(arr, 1)) {
 
                     Some(Scroll { first: first, last: last })
+                } else { None }
+            }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
+            "request_lines" => params.as_array().and_then(|arr| {
+                if let (Some(first), Some(last)) =
+                    (arr_get_i64(arr, 0), arr_get_i64(arr, 1)) {
+
+                    Some(RequestLines { first: first, last: last })
                 } else { None }
             }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
 

--- a/rust/core-lib/src/styles.rs
+++ b/rust/core-lib/src/styles.rs
@@ -1,0 +1,80 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Management of styles.
+
+use std::collections::HashMap;
+use serde_json::Value;
+use serde_json::builder::ObjectBuilder;
+
+const N_RESERVED_STYLES: usize = 1;
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct Style {
+    pub fg: u32,  // ARGB format
+    pub bg: u32,  // ARGB format
+    pub weight: u16,  // 100-900, same interpretation as CSS
+    pub underline: bool,
+    pub italic: bool,
+}
+
+impl Style {
+    // construct the params for a def_style request
+    pub fn to_json(&self, id: usize) -> Value {
+        let mut builder = ObjectBuilder::new()
+            .insert("id", id)
+            .insert("fg_color", self.fg);
+        if (self.bg >> 24) > 0 {
+            builder = builder.insert("bg_color", self.bg);
+        }
+        if self.weight != 400 {
+            builder = builder.insert("weight", self.weight);
+        }
+        if self.underline {
+            builder = builder.insert("underline", self.underline);
+        }
+        if self.italic {
+            builder = builder.insert("italic", self.italic);
+        }
+        builder.build()
+    }
+}
+
+pub struct StyleMap {
+    map: HashMap<Style, usize>,
+
+    // It's not obvious we actually have to store the style, we seem to only need it
+    // as the key in the map.
+    styles: Vec<Style>,
+}
+
+impl StyleMap {
+    pub fn new() -> StyleMap {
+        StyleMap {
+            map: HashMap::new(),
+            styles: Vec::new(),
+        }
+    }
+
+    pub fn lookup(&self, style: &Style) -> Option<usize> {
+        self.map.get(style).map(|&ix| ix)
+    }
+
+    pub fn add(&mut self, style: &Style) -> usize {
+        let result = self.styles.len() + N_RESERVED_STYLES;
+        self.map.insert(style.clone(), result);
+        self.styles.push(style.clone());
+        result
+    }
+}

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::cmp::{min,max};
+use std::io::Write;
 
 use serde_json::Value;
 use serde_json::builder::{ArrayBuilder,ObjectBuilder};
@@ -20,9 +21,12 @@ use serde_json::builder::{ArrayBuilder,ObjectBuilder};
 use xi_rope::rope::{Rope, LinesMetric, RopeInfo};
 use xi_rope::delta::{Delta};
 use xi_rope::tree::Cursor;
-use xi_rope::breaks::{Breaks, BreaksMetric, BreaksBaseMetric};
+use xi_rope::breaks::{Breaks, BreaksInfo, BreaksMetric, BreaksBaseMetric};
 use xi_rope::interval::Interval;
 use xi_rope::spans::{Spans, SpansBuilder};
+
+use tabs::TabCtx;
+use styles;
 
 use linewrap;
 
@@ -42,6 +46,9 @@ pub struct View {
     breaks: Option<Breaks>,
     style_spans: Spans<Style>,
     cols: usize,
+
+    // TODO: much finer grained tracking of dirty state
+    dirty: bool,
 }
 
 impl Default for View {
@@ -54,6 +61,7 @@ impl Default for View {
             breaks: None,
             style_spans: Spans::default(),
             cols: 0,
+            dirty: false,
         }
     }
 }
@@ -89,6 +97,7 @@ impl View {
         }
     }
 
+    // TODO: remove this, no longer used
     pub fn render_lines(&self, text: &Rope, first_line: usize, last_line: usize) -> Value {
         let mut builder = ArrayBuilder::new();
         let (cursor_line, cursor_col) = self.offset_to_line_col(text, self.sel_end);
@@ -157,7 +166,8 @@ impl View {
                     builder.push("cursor")
                         .push(cursor_col)
                 );
-            }            builder = builder.push(line_builder.build());
+            }
+            builder = builder.push(line_builder.build());
             line_num += 1;
             if is_last_line || line_num == last_line {
                 break;
@@ -179,21 +189,147 @@ impl View {
         builder
     }
 
-    pub fn render(&self, text: &Rope, scroll_to: Option<usize>) -> Value {
-        let first_line = max(self.first_line, SCROLL_SLOP) - SCROLL_SLOP;
-        let last_line = self.first_line + self.height + SCROLL_SLOP;
-        let lines = self.render_lines(text, first_line, last_line);
-        let height = self.offset_to_line_col(text, text.len()).0 + 1;
-        let mut builder = ObjectBuilder::new()
-            .insert("lines", lines)
-            .insert("first_line", first_line)
-            .insert("height", height);
-        if let Some(scrollto) = scroll_to {
-            let (line, col) = self.offset_to_line_col(text, scrollto);
-            builder = builder.insert_array("scrollto", |builder|
-                builder.push(line).push(col));
+    // Render a single line, and advance cursors to next line.
+    fn render_line<W: Write>(&self, tab_ctx: &TabCtx<W>, text: &Rope,
+        builder: ArrayBuilder, cursor: &mut Cursor<RopeInfo>,
+        breaks_cursor: Option<&mut Cursor<BreaksInfo>>, line_num: usize) -> ArrayBuilder
+    {
+        let mut line_builder = ObjectBuilder::new();
+        let start_pos = cursor.pos();
+        let pos = match breaks_cursor {
+            Some(bc) => {
+                let pos = bc.next::<BreaksMetric>();
+                if let Some(pos) = pos {
+                    cursor.set(pos);
+                }
+                pos
+            }
+            None => cursor.next::<LinesMetric>()
+        };
+        let pos = match pos {
+            Some(pos) => pos,
+            None => {
+                text.len()
+            }
+        };
+        let l_str = text.slice_to_string(start_pos, pos);
+        line_builder = line_builder.insert("text", &l_str);
+        let (cursor_line, cursor_col) = self.offset_to_line_col(text, self.sel_end);
+        if line_num == cursor_line {
+            line_builder = line_builder.insert_array("cursor", |builder|
+                builder.push(cursor_col)
+            );
+        }
+        let mut sel = Vec::new();
+        if self.sel_start != self.sel_end {
+            let sel_min_line = self.line_of_offset(text, self.sel_min());
+            let sel_max_line = self.line_of_offset(text, self.sel_max());
+            // Note: could early-reject based on offsets (avoiding line_of_offset
+            // calculation for non-selected lines).
+            if line_num >= sel_min_line && line_num <= sel_max_line {
+                let sel_start_ix = if line_num == sel_min_line {
+                    self.sel_min() - start_pos
+                } else {
+                    0
+                };
+                let sel_end_ix = if line_num == sel_max_line {
+                    self.sel_max() - start_pos
+                } else {
+                    l_str.len()
+                };
+                sel.push((sel_start_ix, sel_end_ix));
+            }
+        }
+        line_builder = line_builder.insert("styles",
+            self.render_styles(tab_ctx, start_pos, pos, &sel));
+        builder.push(line_builder.build())
+    }
+
+    pub fn render_styles<W: Write>(&self, tab_ctx: &TabCtx<W>, start: usize, end: usize,
+        sel: &[(usize, usize)]) -> Value
+    { 
+        let style_spans = self.style_spans.subseq(Interval::new_closed_open(start, end));
+        let mut builder = ArrayBuilder::new();
+        let mut ix = 0;
+        for &(sel_start, sel_end) in sel {
+            builder = builder.push((sel_start as isize) - ix);
+            builder = builder.push(sel_end - sel_start);
+            builder = builder.push(0);
+            ix = sel_end as isize;
+        }
+        for (iv, style) in style_spans.iter() {
+            // This conversion will move because we'll store style id's in the spans
+            // data structure. But we're changing things one piece at a time.
+            let new_style = styles::Style {
+                fg: style.fg,
+                bg: 0,
+                weight: if (style.font_style & 1) != 0 { 700 } else { 400},
+                underline: (style.font_style & 2) != 0,
+                italic: (style.font_style & 4) != 0,
+            };
+            let style_id = tab_ctx.get_style_id(&new_style);
+            builder = builder.push((iv.start() as isize) - ix);
+            builder = builder.push(iv.end() - iv.start());
+            builder = builder.push(style_id);
+            ix = iv.end() as isize;
         }
         builder.build()
+    }
+
+    pub fn send_update<W: Write>(&mut self, text: &Rope, tab_ctx: &TabCtx<W>,
+        first_line: usize, last_line: usize)
+    {
+        let height = self.offset_to_line_col(text, text.len()).0 + 1;
+        let last_line = min(last_line, height);
+        let mut ops_builder = ArrayBuilder::new();
+        if first_line > 0 {
+            ops_builder = ops_builder.push_object(|builder|
+                builder.insert("op", if self.dirty { "invalidate" } else { "copy" })
+                .insert("n", first_line));
+        }
+        let first_line_offset = self.offset_of_line(text, first_line);
+        let mut cursor = Cursor::new(text, first_line_offset);
+        let mut breaks_cursor = self.breaks.as_ref().map(|breaks|
+            Cursor::new(breaks, first_line_offset)
+        );
+        let mut lines_builder = ArrayBuilder::new();
+        for line_num in first_line..last_line {
+            lines_builder = self.render_line(tab_ctx, text, lines_builder,
+                &mut cursor, breaks_cursor.as_mut(), line_num);
+        }
+        ops_builder = ops_builder.push_object(|builder|
+            builder.insert("op", "ins")
+            .insert("n", last_line - first_line)
+            .insert("lines", lines_builder.build()));
+        if last_line < height {
+            if !self.dirty {
+                ops_builder = ops_builder.push_object(|builder|
+                    builder.insert("op", "skip")
+                    .insert("n", last_line - first_line));
+            }
+            ops_builder = ops_builder.push_object(|builder|
+                builder.insert("op", if self.dirty { "invalidate" } else { "copy" })
+                .insert("n", height - last_line));
+        }
+        let params = ObjectBuilder::new()
+            .insert("ops", ops_builder.build())
+            .build();
+        tab_ctx.update_tab(&params);
+    }
+
+    // Update front-end with any changes to view since the last time sent.
+    pub fn render_if_dirty<W: Write>(&mut self, text: &Rope, tab_ctx: &TabCtx<W>) {
+        if self.dirty {
+            let first_line = max(self.first_line, SCROLL_SLOP) - SCROLL_SLOP;
+            let last_line = self.first_line + self.height + SCROLL_SLOP;
+            self.send_update(text, tab_ctx, first_line, last_line);
+            self.dirty = false;
+        }
+    }
+
+    // TODO: finer grained tracking
+    pub fn set_dirty(&mut self) {
+        self.dirty = true;
     }
 
     // How should we count "column"? Valid choices include:
@@ -304,6 +440,7 @@ impl View {
         // text. That's ok for syntax highlighting but not ideal for rich text.
         let empty_spans = SpansBuilder::new(new_len).build();
         self.style_spans.edit(iv, empty_spans);
+        self.dirty = true;
     }
 
     pub fn reset_breaks(&mut self) {


### PR DESCRIPTION
Starting to implement the new protocol described in #152.

As of this commit, the protocol should be in place, and functionality
should be basically unchanged, but the implementation is not very
optimized. In particular, updates just send the scroll area (with
slop), invalidating everything else, rather than actually sending a
small delta.

In addition, there are a whole bunch of optimizations not done yet,
for example style spans are stored as (old-style) view::Style objects,
and looked up in the style map one-at-a-time while rendering. A far
more efficient approach would be to use a similar style id system in
the plug-in protocol, and then basically plumb style id's through.

That said, all these optimizations should be possible without change
to the update protocol, and I'm reasonably satisfied that will be
stable now.