### PR TITLE
Fix selection clipping

### DIFF
--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -202,8 +202,8 @@ class EditView: NSView, NSTextInputClient {
             let y = linespace * CGFloat(lineIx + 1)
             context.setFillColor(selcolor().cgColor)
             for selection in selections {
-                let selStart = CTLineGetOffsetForStringIndex(ctline, utf8_offset_to_utf16(line.text, selection.range.location), nil)
-                let selEnd = CTLineGetOffsetForStringIndex(ctline, utf8_offset_to_utf16(line.text, selection.range.location + selection.range.length), nil)
+                let selStart = CTLineGetOffsetForStringIndex(ctline, selection.range.location, nil)
+                let selEnd = CTLineGetOffsetForStringIndex(ctline, selection.range.location + selection.range.length, nil)
                 context.fill(CGRect.init(x: x0 + selStart, y: y - ascent, width: selEnd - selStart + x0, height: linespace))
             }
             

--- a/XiEditor/StyleMap.swift
+++ b/XiEditor/StyleMap.swift
@@ -130,7 +130,8 @@ class StyleMap {
         queue.sync {
             for styleSpan in styles {
                 if styleSpan.style == 0 {
-                    string.addAttribute(NSBackgroundColorAttributeName, value: selColor, range: styleSpan.range)
+                    // we handle selection drawing in EditView.drawRect
+                    continue
                 } else {
                     applyStyle(string: string, id: styleSpan.style, range: styleSpan.range)
                 }

--- a/XiEditor/StyleMap.swift
+++ b/XiEditor/StyleMap.swift
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// A store of text styles, indexable by id.
-
 import Cocoa
 
+/// A represents a given text style.
 struct Style {
     var fgColor: NSColor;
     var bgColor: NSColor;
@@ -24,12 +23,42 @@ struct Style {
     var italic: Bool;
 }
 
+typealias StyleIdentifier = Int
+
+/// A basic type representing a range of text and and a style identifier.
+struct StyleSpan {
+    let range: NSRange
+    let style: StyleIdentifier
+
+    /// given a line of text and an array of style values, generate an array of StyleSpans.
+    /// see https://github.com/google/xi-editor/blob/protocol_doc/doc/update.md
+    static func styles(fromRaw raw: [Int], text: String) -> [StyleSpan] {
+        var out: [StyleSpan] = [];
+        var ix = 0;
+        for i in stride(from: 0, to: raw.count, by: 3) {
+            let start = ix + raw[i]
+            let end = start + raw[i + 1]
+            let style = raw[i + 2]
+            let startIx = utf8_offset_to_utf16(text, start)
+            let endIx = utf8_offset_to_utf16(text, end)
+            if startIx < 0 || endIx < startIx {
+                //FIXME: how should we be doing error handling?
+                print("malformed style array for line:", text, raw)
+            } else {
+                out.append(StyleSpan.init(range: NSMakeRange(startIx, endIx - startIx), style: style))
+            }
+            ix = end
+        }
+        return out
+    }
+}
+
 func utf8_offset_to_utf16(_ s: String, _ ix: Int) -> Int {
-    // String(s.utf8.prefix(ix)).utf16.count
     return s.utf8.index(s.utf8.startIndex, offsetBy: ix).samePosition(in: s.utf16)!._offset
 }
 
-// Note: all public methods of this class are designed to be thread-safe
+/// A store of text styles, indexable by id.
+/// - Note: all public methods of this class are designed to be thread-safe.
 class StyleMap {
     private let queue = DispatchQueue(label: "com.levien.xi.StyleMap")
     private var map: [Style?] = []
@@ -94,25 +123,17 @@ class StyleMap {
         }
     }
 
-    // Apply styles (given in the array-triple format as defined in the protocol doc) to the given string.
+    // Apply styles to the given string.
     // The selection color (for which style 0 is reserverd) is passed in, as it might be different for
     // different windows (while the StyleMap object is shared).
-    func applyStyles(text: String, string: NSMutableAttributedString, styles: [Int], selColor: NSColor) {
+    func applyStyles(text: String, string: NSMutableAttributedString, styles: [StyleSpan], selColor: NSColor) {
         queue.sync {
-            var ix = 0;
-            for i in stride(from: 0, to: styles.count, by: 3) {
-                let start = ix + styles[i]
-                let end = start + styles[i + 1]
-                let style = styles[i + 2]
-                let startIx = utf8_offset_to_utf16(text, start)
-                let endIx = utf8_offset_to_utf16(text, end)
-                let range = NSMakeRange(startIx, endIx - startIx)
-                if style == 0 {
-                    string.addAttribute(NSBackgroundColorAttributeName, value: selColor, range: range)
+            for styleSpan in styles {
+                if styleSpan.style == 0 {
+                    string.addAttribute(NSBackgroundColorAttributeName, value: selColor, range: styleSpan.range)
                 } else {
-                    applyStyle(string: string, id: style, range: range)
+                    applyStyle(string: string, id: styleSpan.style, range: styleSpan.range)
                 }
-                ix = end
             }
         }
     }

--- a/XiEditor/StyleMap.swift
+++ b/XiEditor/StyleMap.swift
@@ -70,36 +70,21 @@ class StyleMap {
     }
 
     private func defStyleLocked(json: [String: AnyObject]) {
-        //print("defStyle: \(json)")
-        guard let id = json["id"] as? Int else { return }
-        var fgColor: UInt32 = 0xFF000000;
-        var bgColor: UInt32 = 0;
-        var weight: UInt16 = 400;
-        var underline = false;
-        var italic = false;
-        if let fg = json["fg_color"] as? UInt32 {
-            fgColor = fg;
-        }
-        if let bg = json["bg_color"] as? UInt32 {
-            bgColor = bg;
-        }
-        if let w = json["weight"] as? UInt16 {
-            weight = w;
-        }
-        if let u = json["underline"] as? Bool {
-            underline = u;
-        }
-        if let i = json["italic"] as? Bool {
-            italic = i;
-        }
+        guard let styleID = json["id"] as? Int else { return }
+        let fgColor = json["fg_color"] as? UInt32 ?? 0xFF000000
+        let bgColor = json["bg_color"] as? UInt32 ?? 0
+        let weight = json["weight"] as? UInt16 ?? 400
+        let underline = json["underline"] as? Bool ?? false
+        let italic = json["italic"] as? Bool ?? false
+        
         let style = Style(fgColor: colorFromArgb(fgColor), bgColor: colorFromArgb(bgColor), weight: weight, underline: underline, italic: italic);
-        while map.count < id {
+        while map.count < styleID {
             map.append(nil)
         }
-        if map.count == id {
+        if map.count == styleID {
             map.append(style)
         } else {
-            map[id] = style
+            map[styleID] = style
         }
     }
 


### PR DESCRIPTION
This is a quick shot at #163.

Naive solution: when updating the view we now do a first pass through the lines and draw all of the selection backgrounds. 

To do this I needed more concrete access to the style information, so I introduced a `StyleSpan` struct that is just an NSRange and an identifier, and when we get a style array I convert it into an array of these.

I haven't profiled this, but it at least _looks_ fine.

Let me know if you have any thoughts!
