### PR TITLE
Document refactor cleanup

### DIFF
--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -70,7 +70,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if let obj = params as? [String : AnyObject], let line = obj["line"] as? Int, let col = obj["col"] as? Int {
                 guard let tab = obj["tab"] as? String, let document = documentForTabName(tabName: tab)
                     else { print("tab or document missing for update event: ", obj); return }
-                    document.editView?.scrollTo(line, col)
+                    document.editViewController?.scrollTo(line, col)
             }
         case "def_style":
             if let obj = params as? [String : AnyObject] {

--- a/XiEditor/Document.swift
+++ b/XiEditor/Document.swift
@@ -44,9 +44,9 @@ class Document: NSDocument {
         let storyboard = NSStoryboard(name: "Main", bundle: nil)
         let windowController = storyboard.instantiateController(withIdentifier: "Document Window Controller") as! NSWindowController
         self.editViewController = windowController.contentViewController as? EditViewController
-        editViewController?.editView.document = self
-
+        editViewController?.document = self
         windowController.window?.delegate = editViewController
+
         //FIXME: some saner way of positioning new windows. maybe based on current window size, with some checks to not completely obscure an existing window?
         // also awareness of multiple screens (prefer to open on currently active screen)
         let screenHeight = windowController.window?.screen?.frame.height ?? 800

--- a/XiEditor/Document.swift
+++ b/XiEditor/Document.swift
@@ -17,44 +17,35 @@ import Cocoa
 
 class Document: NSDocument {
 
-    /*
-    override var windowNibName: String? {
-        // Override returning the nib file name of the document
-        // If you need to use a subclass of NSWindowController or if your document supports multiple NSWindowControllers, you should remove this method and override -makeWindowControllers instead.
-        return "Document"
-    }
-    */
+    var dispatcher: Dispatcher!
+    var tabName: String
     
-    var dispatcher: Dispatcher?
-    var tabName: String?
-    var editView: EditView?
-    
-    var filename: String? {
+    /// an initial backend update to be rendered on load
+    var pendingUpdate: [String: AnyObject]? = nil
+    var editViewController: EditViewController? {
         didSet {
-            if let filename = filename {
-                let url = URL(fileURLWithPath: filename)
-                let lastComponent = url.lastPathComponent;
-                for controller in windowControllers {
-                    controller.window?.title = lastComponent
-                }
+            if let new = editViewController, let content = pendingUpdate {
+                new.update(content)
+                pendingUpdate = nil
             }
         }
     }
-    
+
     override init() {
-        super.init()
-        
         dispatcher = (NSApplication.shared().delegate as? AppDelegate)?.dispatcher
+        tabName = Events.NewTab().dispatch(dispatcher!)
+        super.init()
+        // I'm not 100% sure this is necessary but it can't _hurt_
+        self.hasUndoManager = false
     }
     
     override func makeWindowControllers() {
         // Returns the Storyboard that contains your Document window.
         let storyboard = NSStoryboard(name: "Main", bundle: nil)
         let windowController = storyboard.instantiateController(withIdentifier: "Document Window Controller") as! NSWindowController
-        tabName = Events.NewTab().dispatch(dispatcher!)
-        let editViewController = windowController.contentViewController as? EditViewController
+        self.editViewController = windowController.contentViewController as? EditViewController
         editViewController?.editView.document = self
-        self.editView = editViewController?.editView
+
         windowController.window?.delegate = editViewController
         //FIXME: some saner way of positioning new windows. maybe based on current window size, with some checks to not completely obscure an existing window?
         // also awareness of multiple screens (prefer to open on currently active screen)
@@ -62,31 +53,21 @@ class Document: NSDocument {
         let windowHeight: CGFloat = 800
         windowController.window?.setFrame(NSRect(x: 200, y: screenHeight - windowHeight - 200, width: 700, height: 800), display: true)
 
-        if let filename = filename {
-            open(filename)
-        }
-
         self.addWindowController(windowController)
     }
     
     override func read(from url: URL, ofType typeName: String) throws {
-        filename = url.path
+        self.open(url.path)
     }
     
     override func save(to url: URL, ofType typeName: String, for saveOperation: NSSaveOperationType, completionHandler: @escaping (Error?) -> Void) {
-        self.filename = url.path
-        save(url.path)
-        
-        // An RPC Call received to indicate Save can be used to call this completion
+        self.save(url.path)
+        //TODO: save operations should report success, and we should pass any errors to the completion handler
         completionHandler(nil)
     }
     
     override func close() {
         super.close()
-        
-        guard let tabName = tabName
-            else { return }
-
         Events.DeleteTab(tabId: tabName).dispatch(dispatcher!)
     }
     
@@ -108,19 +89,20 @@ class Document: NSDocument {
     
     
     func sendRpcAsync(_ method: String, params: Any) {
-        let inner = ["method": method as AnyObject, "params": params, "tab": tabName! as AnyObject] as [String : Any]
+        let inner = ["method": method as AnyObject, "params": params, "tab": tabName as AnyObject] as [String : Any]
         dispatcher?.coreConnection.sendRpcAsync("edit", params: inner)
     }
     
     func sendRpc(_ method: String, params: Any) -> Any? {
-        let inner = ["method": method as AnyObject, "params": params, "tab": tabName! as AnyObject] as [String : Any]
+        let inner = ["method": method as AnyObject, "params": params, "tab": tabName as AnyObject] as [String : Any]
         return dispatcher?.coreConnection.sendRpc("edit", params: inner)
     }
-    
+
     func update(_ content: [String: AnyObject]) {
-        for windowController in windowControllers {
-            (windowController.contentViewController as? EditViewController)?.editView.updateSafe(update: content)
+        if let editVC = editViewController {
+            editVC.update(content)
+        } else {
+            pendingUpdate = content
         }
     }
-
 }

--- a/XiEditor/Document.swift
+++ b/XiEditor/Document.swift
@@ -61,6 +61,7 @@ class Document: NSDocument {
     }
     
     override func save(to url: URL, ofType typeName: String, for saveOperation: NSSaveOperationType, completionHandler: @escaping (Error?) -> Void) {
+        self.fileURL = url
         self.save(url.path)
         //TODO: save operations should report success, and we should pass any errors to the completion handler
         completionHandler(nil)

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -191,7 +191,7 @@ class EditView: NSView, NSTextInputClient {
             let attrString = NSMutableAttributedString(string: line.text, attributes: self.attributes)
             let ctline = CTLineCreateWithAttributedString(attrString)
             let y = linespace * CGFloat(lineIx + 1)
-            context.setFillColor(selcolor().cgColor)
+            context.setFillColor(textSelectionColor.cgColor)
             for selection in selections {
                 let selStart = CTLineGetOffsetForStringIndex(ctline, selection.range.location, nil)
                 let selEnd = CTLineGetOffsetForStringIndex(ctline, selection.range.location + selection.range.length, nil)
@@ -204,12 +204,12 @@ class EditView: NSView, NSTextInputClient {
             // TODO: could block for ~1ms waiting for missing lines to arrive
             guard let line = getLine(lineIx) else { continue }
             let s = line.text
-            let attrString = NSMutableAttributedString(string: s, attributes: self.attributes)
+            var attrString = NSMutableAttributedString(string: s, attributes: self.attributes)
             /*
             let randcolor = NSColor(colorLiteralRed: Float(drand48()), green: Float(drand48()), blue: Float(drand48()), alpha: 1.0)
             attrString.addAttribute(NSForegroundColorAttributeName, value: randcolor, range: NSMakeRange(0, s.utf16.count))
             */
-            styleMap?.applyStyles(text: s, string: attrString, styles: line.styles, selColor: textSelectionColor)
+            styleMap?.applyStyles(text: s, string: &attrString, styles: line.styles)
             for c in line.cursor {
                 let cix = utf8_offset_to_utf16(s, c)
                 if (markedRange().location != NSNotFound) {

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -65,9 +65,9 @@ func camelCaseToUnderscored(_ name: NSString) -> NSString {
 class EditView: NSView, NSTextInputClient {
     var document: Document!
 
+    var styleMap: StyleMap?
     var lines: LineCache
 
-//    var widthConstraint: NSLayoutConstraint?
     @IBOutlet var heightConstraint: NSLayoutConstraint?
 
     var attributes: [String: AnyObject]
@@ -78,30 +78,71 @@ class EditView: NSView, NSTextInputClient {
     var linespace: CGFloat
     var fontWidth: CGFloat
 
-    let fgSelcolor: NSColor
-    let bgSelcolor: NSColor
-
-    // visible scroll region, exclusive of lastLine
-    var firstLine: Int = 0
-    var lastLine: Int = 0
+    var textSelectionColor: NSColor {
+        if self.isFrontmostView {
+            return NSColor.selectedTextBackgroundColor
+        } else {
+        return NSColor(colorLiteralRed: 0.8, green: 0.8, blue: 0.8, alpha: 1.0)
+        }
+    }
 
     var lastDragLineCol: (Int, Int)?
     var timer: Timer?
     var timerEvent: NSEvent?
 
-    var currentEvent: NSEvent?
-
     var cursorPos: (Int, Int)?
-    var _selectedRange: NSRange
-    var _markedRange: NSRange
+    fileprivate var _selectedRange: NSRange
+    fileprivate var _markedRange: NSRange
     
-    var isFrontmost: Bool // Are we frontmost, the view that gets keyboard input?
+    var isFrontmostView = false {
+        didSet {
+            //TODO: blinking should one day be a user preference
+            showBlinkingCursor = isFrontmostView
+            self.needsDisplay = true
+        }
+    }
+    
+    /*  Insertion point blinking.
+     Only the frontmost ('key') window should have a blinking insertion point.
+     A new 'on' cycle starts every time the window comes to the front, or the text changes, or the ins. point moves.
+     Type fast enough and the ins. point stays on.
+     */
+    var _blinkTimer : Timer?
+    private var _cursorStateOn = false
+    /// if set to true, this view will show blinking cursors
+    private var showBlinkingCursor = false {
+        didSet {
+            _cursorStateOn = showBlinkingCursor
+            _blinkTimer?.invalidate()
+            if showBlinkingCursor {
+                _blinkTimer = Timer.scheduledTimer(timeInterval: TimeInterval(1.0), target: self, selector: #selector(_blinkInsertionPoint), userInfo: nil, repeats: true)
+            } else {
+                _blinkTimer = nil
+            }
+        }
+    }
+    
+    private var cursorColor: CGColor {
+        return _cursorStateOn ? CGColor(gray: 0, alpha: 1) : CGColor(gray: 1, alpha: 1)
+    }
+    
+    required init?(coder: NSCoder) {
+        let font = CTFontCreateWithName("InconsolataGo" as CFString?, 14, nil)
+        ascent = CTFontGetAscent(font)
+        descent = CTFontGetDescent(font)
+        leading = CTFontGetLeading(font)
+        linespace = ceil(ascent + descent + leading)
+        baseline = ceil(ascent)
+        attributes = [String(kCTFontAttributeName): font]
+        fontWidth = getFontWidth(font)
+        _selectedRange = NSMakeRange(NSNotFound, 0)
+        _markedRange = NSMakeRange(NSNotFound, 0)
+        lines = LineCache()
+        styleMap = (NSApplication.shared().delegate as? AppDelegate)?.styleMap
+        super.init(coder: coder)
+    }
 
-    var cursorFlashOn: Bool
-    var blinkTimer : Timer?
-
-    var styleMap: StyleMap?
-
+    // this gets called when the user changes the font with the font book, for example
     override func changeFont(_ sender: Any?) {
         let oldFont = attributes[String(kCTFontAttributeName)] as! CTFont
         let font = (sender as! NSFontManager).convert(oldFont)
@@ -113,36 +154,6 @@ class EditView: NSView, NSTextInputClient {
         attributes[String(kCTFontAttributeName)] = font
         fontWidth = getFontWidth(font)
         needsDisplay = true
-    }
-
-    required init?(coder: NSCoder) {
-        let font = CTFontCreateWithName("InconsolataGo" as CFString?, 14, nil)
-        ascent = CTFontGetAscent(font)
-        descent = CTFontGetDescent(font)
-        leading = CTFontGetLeading(font)
-        linespace = ceil(ascent + descent + leading)
-        baseline = ceil(ascent)
-        attributes = [String(kCTFontAttributeName): font]
-        fontWidth = getFontWidth(font)
-        fgSelcolor =  NSColor.selectedTextBackgroundColor
-        bgSelcolor = NSColor(colorLiteralRed: 0.8, green: 0.8, blue: 0.8, alpha: 1.0) //Gray for the selected text background when not 'key'
-        _selectedRange = NSMakeRange(NSNotFound, 0)
-        _markedRange = NSMakeRange(NSNotFound, 0)
-        isFrontmost = false
-        cursorFlashOn = true
-        lines = LineCache()
-        styleMap = (NSApplication.shared().delegate as? AppDelegate)?.styleMap
-        super.init(coder: coder)
-    }
-
-
-    func utf8_offset_to_utf16(_ s: String, _ ix: Int) -> Int {
-        // String(s.utf8.prefix(ix)).utf16.count
-        return s.utf8.index(s.utf8.startIndex, offsetBy: ix).samePosition(in: s.utf16)!._offset
-    }
-
-    func utf16_offset_to_utf8(_ s: String, _ ix: Int) -> Int {
-        return String(describing: s.utf16.prefix(ix)).utf8.count
     }
 
     let x0: CGFloat = 2;
@@ -233,7 +244,7 @@ class EditView: NSView, NSTextInputClient {
                 }
             }
             */
-            styleMap?.applyStyles(text: s, string: attrString, styles: line.styles, selColor: selcolor())
+            styleMap?.applyStyles(text: s, string: attrString, styles: line.styles, selColor: textSelectionColor)
             for c in line.cursor {
                 let cix = utf8_offset_to_utf16(s, c)
                 if (markedRange().location != NSNotFound) {
@@ -260,7 +271,7 @@ class EditView: NSView, NSTextInputClient {
             //attrString.drawAtPoint(NSPoint(x: x0, y: y - 13))
             let y = linespace * CGFloat(lineIx + 1);
             attrString.draw(with: NSRect(x: x0, y: y, width: dirtyRect.origin.x + dirtyRect.width - x0, height: 14), options: [])
-            if isFrontmost {
+            if showBlinkingCursor {
                 for cursor in line.cursor {
                     let ctline = CTLineCreateWithAttributedString(attrString)
                     /*
@@ -273,7 +284,7 @@ class EditView: NSView, NSTextInputClient {
                         let utf16_ix = utf8_offset_to_utf16(s, cursor)
                         pos = CTLineGetOffsetForStringIndex(ctline, CFIndex(utf16_ix), nil)
                     }
-                    context.setStrokeColor(cursorColor())
+                    context.setStrokeColor(cursorColor)
                     context.move(to: CGPoint(x: x0 + pos, y: y + descent))
                     context.addLine(to: CGPoint(x: x0 + pos, y: y - ascent))
                     context.strokePath()
@@ -290,32 +301,44 @@ class EditView: NSView, NSTextInputClient {
     override var isFlipped: Bool {
         return true;
     }
-
-    // TODO: probably get rid of this, we get scroll notifications elsewhere
-    override func resize(withOldSuperviewSize oldSize: NSSize) {
-        super.resize(withOldSuperviewSize: oldSize)
-        //Swift.print("resizing, oldsize =", oldSize, ", frame =", frame);
+    
+    //MARK: - Public API
+    
+    /// apply the given updates to the view.
+    /// - Note: Threadsafe
+    public func updateSafe(update: [String: AnyObject]) {
+        var height: Int = 0;
+        lines.applyUpdate(update: update)
+        height = lines.height
+        DispatchQueue.main.async {
+            self.heightConstraint?.constant = CGFloat(height) * self.linespace + 2 * self.descent
+            self.showBlinkingCursor = self.isFrontmostView
+            self.needsDisplay = true
+        }
+    }
+    
+    /// scrolls the editview to display the given line and column
+    /// - Note: can be called from other threads
+    public func scrollTo(_ line: Int, _ col: Int) {
+        let x = CGFloat(col) * fontWidth  // TODO: deal with non-ASCII, non-monospaced case
+        let y = CGFloat(line) * linespace + baseline
+        let scrollRect = NSRect(x: x, y: y - baseline, width: 4, height: linespace + descent)
+        DispatchQueue.main.async {
+            self.scrollToVisible(scrollRect)
+        }
     }
 
-    override func keyDown(with theEvent: NSEvent) {
-        // store current event so that it can be sent to the core
-        // if the selector for the event is "noop:".
-        currentEvent = theEvent;
-        self.inputContext?.handleEvent(theEvent);
-        currentEvent = nil;
-    }
-
-    // NSResponder (used mostly for paste)
-    override func insertText(_ insertString: Any) {
-        document?.sendRpcAsync("insert", params: insertedStringToJson(insertString as! NSString))
-    }
-
-    // NSTextInputClient protocol
+    
+    // MARK: - NSTextInputClient protocol
     func insertText(_ aString: Any, replacementRange: NSRange) {
         self.removeMarkedText()
         self.replaceCharactersInRange(replacementRange, withText: aString as AnyObject)
     }
-
+    
+    public func characterIndex(for point: NSPoint) -> Int {
+        return 0
+    }
+    
     func replacementMarkedRange(_ replacementRange: NSRange) -> NSRange {
         var markedRange = _markedRange
 
@@ -421,10 +444,8 @@ class EditView: NSView, NSTextInputClient {
         }
     }
 
-    func characterIndex(for aPoint: NSPoint) -> Int {
-        return 0
-    }
-
+    /// MARK: - System Events
+    
     override func doCommand(by aSelector: Selector) {
         if (self.responds(to: aSelector)) {
             super.doCommand(by: aSelector);
@@ -438,43 +459,6 @@ class EditView: NSView, NSTextInputClient {
         }
     }
 
-    func cutCopy(_ method: String) {
-        let text = document?.sendRpc(method, params: [])
-        if let text = text as? String {
-            let pasteboard = NSPasteboard.general()
-            pasteboard.clearContents()
-            pasteboard.writeObjects([text as NSPasteboardWriting])
-        }
-    }
-
-    func cut(_ sender: AnyObject?) {
-        cutCopy("cut")
-    }
-
-    func copy(_ sender: AnyObject?) {
-        cutCopy("copy")
-    }
-
-    func paste(_ sender: AnyObject?) {
-        let pasteboard = NSPasteboard.general()
-        if let items = pasteboard.pasteboardItems {
-            for element in items {
-                if let str = element.string(forType: "public.utf8-plain-text") {
-                    insertText(str)
-                    break
-                }
-            }
-        }
-    }
-
-    func undo(_ sender: AnyObject?) {
-        document?.sendRpcAsync("undo", params: [])
-    }
-
-    func redo(_ sender: AnyObject?) {
-        document?.sendRpcAsync("redo", params: [])
-    }
-
     override func mouseDown(with theEvent: NSEvent) {
         removeMarkedText()
         self.inputContext?.discardMarkedText()
@@ -483,7 +467,7 @@ class EditView: NSView, NSTextInputClient {
         let flags = theEvent.modifierFlags.rawValue >> 16
         let clickCount = theEvent.clickCount
         document?.sendRpcAsync("click", params: [line, col, flags, clickCount])
-        timer = Timer.scheduledTimer(timeInterval: TimeInterval(1.0/60), target: self, selector: #selector(autoscrollTimer), userInfo: nil, repeats: true)
+        timer = Timer.scheduledTimer(timeInterval: TimeInterval(1.0/60), target: self, selector: #selector(_autoscrollTimerCallback), userInfo: nil, repeats: true)
         timerEvent = theEvent
     }
 
@@ -503,11 +487,18 @@ class EditView: NSView, NSTextInputClient {
         timer = nil
         timerEvent = nil
     }
-
-    func autoscrollTimer() {
+    
+    // MARK: - Helpers etc
+    func _autoscrollTimerCallback() {
         if let event = timerEvent {
             mouseDragged(with: event)
         }
+    }
+    
+    /// timer callback to toggle the blink state
+    func _blinkInsertionPoint() {
+        _cursorStateOn = !_cursorStateOn
+        needsDisplay = true
     }
 
     // TODO: more functions should call this, just dividing by linespace doesn't account for descent
@@ -535,168 +526,16 @@ class EditView: NSView, NSTextInputClient {
         return (lineIx, col)
     }
 
-    /*  Insertion point blinking.
-        Only the frontmost ('key') window should have a blinking insertion point.
-        A new 'on' cycle starts every time the window is comes to the front, or the text changes, or the ins. point moves.
-        Type fast enough and the ins. point stays on.
-     */
-
-    /// Turns the ins. point visible, and set it flashing. Does nothing if window is not key.
-    func setInsertionBlink(_ on: Bool) {
-        // caller must set NeedsDisplay
-        cursorFlashOn = on
-        blinkTimer?.invalidate()
-        if on {
-            blinkTimer = Timer.scheduledTimer(timeInterval: TimeInterval(1.0), target: self, selector: #selector(blinkInsertionPoint), userInfo: nil, repeats: true)
-        }
-        else {
-            blinkTimer = nil
-        }
+    private func utf8_offset_to_utf16(_ s: String, _ ix: Int) -> Int {
+        // String(s.utf8.prefix(ix)).utf16.count
+        return s.utf8.index(s.utf8.startIndex, offsetBy: ix).samePosition(in: s.utf16)!._offset
     }
-
-    // Just performs the actual blinking.
-    func blinkInsertionPoint() {
-        cursorFlashOn = !cursorFlashOn
-        needsDisplay = true
-    }
-
-    // Current color for the ins. point. Implements flashing.
-    func cursorColor() -> CGColor {
-        if cursorFlashOn {
-            return CGColor(gray: 0, alpha: 1) // Black
-        }
-        else {
-            return CGColor(gray: 1, alpha: 1) // should match background.
-        }
-    }
-
-    // Background color for selected text. Only the first responder of the key window should have a non-gray selection.
-    func selcolor() -> NSColor {
-        if isFrontmost {
-            return fgSelcolor
-        }
-        else {
-            return bgSelcolor
-        }
-    }
-
-    // can be called from other threads
-    func updateSafe(update: [String: AnyObject]) {
-        var height: Int = 0;
-        lines.applyUpdate(update: update)
-        height = lines.height
-        DispatchQueue.main.async {
-            self.needsDisplay = true
-            self.heightConstraint?.constant = CGFloat(height) * self.linespace + 2 * self.descent
-            if self.isFrontmost {
-                self.setInsertionBlink(true)
-            }
-        }
-    }
-
-    // can be called from other threads
-    func scrollTo(_ line: Int, _ col: Int) {
-        let x = CGFloat(col) * fontWidth  // TODO: deal with non-ASCII, non-monospaced case
-        let y = CGFloat(line) * linespace + baseline
-        let scrollRect = NSRect(x: x, y: y - baseline, width: 4, height: linespace + descent)
-        DispatchQueue.main.async {
-            self.scrollToVisible(scrollRect)
-        }
-    }
-
-    func updateScroll(_ bounds: NSRect) {
-        let first = Int(floor(bounds.origin.y / linespace))
-        let height = Int(ceil((bounds.size.height) / linespace))
-        let last = first + height
-        if first != firstLine || last != lastLine {
-            firstLine = first
-            lastLine = last
-            document?.sendRpcAsync("scroll", params: [firstLine, lastLine])
-        }
+    
+    private func utf16_offset_to_utf8(_ s: String, _ ix: Int) -> Int {
+        return String(describing: s.utf16.prefix(ix)).utf8.count
     }
 
     func getLine(_ lineNum: Int) -> Line? {
         return lines.get(lineNum)
-    }
-
-    /*
-    let MAX_CACHE_LINES = 1000
-    let CACHE_FETCH_CHUNK = 100
-
-    // get a line, trying to hit the cache
-    func getLine(_ lineNum: Int) -> [AnyObject]? {
-        // TODO: maybe core should take care to set height >= 1
-        if lineNum < 0 || lineNum >= max(1, self.height) {
-            return nil
-        }
-        if let line = self.lineMap[lineNum] {
-            return line
-        }
-        // speculatively prefetch a bigger chunk from RPC, but don't get anything we already have
-        var first = lineNum
-        while first > max(0, lineNum - CACHE_FETCH_CHUNK) && lineMap.index(forKey: first - 1) == nil {
-            first -= 1
-        }
-        var last = lineNum + 1
-        while last < min(lineNum, height) + CACHE_FETCH_CHUNK && lineMap.index(forKey: last + 1) == nil {
-            last += 1
-        }
-        if lineMap.count + (last - first) > MAX_CACHE_LINES {
-            // a more sophisticated approach would be LRU replacement, but simple is probably good enough
-            lineMap = [:]
-        }
-        if let lines = fetchLineRange(first, last) {
-            for lineNum in first..<last {
-                if lineNum - first < lines.count {
-                    lineMap[lineNum] = lines[lineNum - first]
-                } else {
-                    lineMap[lineNum] = ["" as AnyObject]  // TODO: maybe core should always supply
-                }
-            }
-        }
-        return lineMap[lineNum]
-    }
-
-    func fetchLineRange(_ first: Int, _ last: Int) -> [[AnyObject]]? {
-        let start = Date()
-        if let result = document?.sendRpc("render_lines", params: ["first_line": first, "last_line": last]) as? [[AnyObject]] {
-            let interval = Date().timeIntervalSince(start)
-            Swift.print(String(format: "RPC latency = %3.2fms", interval as Double * 1e3))
-            return result
-        } else {
-            Swift.print("rpc error")
-            return nil
-        }
-    }
-    */
-
-    var isEmpty: Bool {
-        if lines.height == 0 { return true }
-        if lines.height > 1 { return false }
-        if let line = getLine(0) {
-            return line.text == ""
-        } else {
-            return true
-        }
-    }
-
-    func updateIsFrontmost(_ frontmost : Bool) {
-        isFrontmost = frontmost
-        setInsertionBlink(isFrontmost)
-        needsDisplay = true
-    }
-
-    // MARK: - Debug Methods
-
-    @IBAction func debugRewrap(_ sender: AnyObject) {
-        document?.sendRpcAsync("debug_rewrap", params: [])
-    }
-
-    @IBAction func debugTestFGSpans(_ sender: AnyObject) {
-        document?.sendRpcAsync("debug_test_fg_spans", params: [])
-    }
-
-    @IBAction func debugRunPlugin(_ sender: AnyObject) {
-        document?.sendRpcAsync("debug_run_plugin", params: [])
     }
 }

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -21,9 +21,18 @@ class EditViewController: NSViewController {
     @IBOutlet var scrollView: NSScrollView!
     @IBOutlet var documentView: NSClipView!
     
+    var document: Document! {
+        didSet {
+            editView.document = document
+        }
+    }
+
+    // visible scroll region, exclusive of lastLine
+    var firstLine: Int = 0
+    var lastLine: Int = 0
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         self.shadowView.mouseUpHandler = editView.mouseUp(with:)
         self.shadowView.mouseDraggedHandler = editView.mouseDragged(with:)
         scrollView.contentView.documentCursor = NSCursor.iBeam();
@@ -40,6 +49,20 @@ class EditViewController: NSViewController {
         updateEditViewScroll()
     }
 
+    
+    fileprivate func updateEditViewScroll() {
+        let first = Int(floor(scrollView.contentView.bounds.origin.y / editView.linespace))
+        let height = Int(ceil((scrollView.contentView.bounds.size.height) / editView.linespace))
+        let last = first + height
+        if first != firstLine || last != lastLine {
+            firstLine = first
+            lastLine = last
+            document?.sendRpcAsync("scroll", params: [firstLine, lastLine])
+        }
+        shadowView?.updateScroll(scrollView.contentView.bounds, scrollView.documentView!.bounds)
+    }
+    
+    // MARK: - Core Commands
     func update(_ content: [String: AnyObject]) {
         editView.updateSafe(update: content)
     }
@@ -47,10 +70,66 @@ class EditViewController: NSViewController {
     func scrollTo(_ line: Int, _ col: Int) {
         editView.scrollTo(line, col)
     }
+    
+    // MARK: - System Events
+    override func keyDown(with theEvent: NSEvent) {
+        self.editView.inputContext?.handleEvent(theEvent);
+    }
+    
+    // NSResponder (used mostly for paste)
+    override func insertText(_ insertString: Any) {
+        document?.sendRpcAsync("insert", params: insertedStringToJson(insertString as! NSString))
+    }
+    // MARK: - Menu Items
+    
+    fileprivate func cutCopy(_ method: String) {
+        let text = document?.sendRpc(method, params: [])
+        if let text = text as? String {
+            let pasteboard = NSPasteboard.general()
+            pasteboard.clearContents()
+            pasteboard.writeObjects([text as NSPasteboardWriting])
+        }
+    }
+    
+    func cut(_ sender: AnyObject?) {
+        cutCopy("cut")
+    }
+    
+    func copy(_ sender: AnyObject?) {
+        cutCopy("copy")
+    }
+    
+    func paste(_ sender: AnyObject?) {
+        let pasteboard = NSPasteboard.general()
+        if let items = pasteboard.pasteboardItems {
+            for element in items {
+                if let str = element.string(forType: "public.utf8-plain-text") {
+                    insertText(str)
+                    break
+                }
+            }
+        }
+    }
+    
+    func undo(_ sender: AnyObject?) {
+        document?.sendRpcAsync("undo", params: [])
+    }
+    
+    func redo(_ sender: AnyObject?) {
+        document?.sendRpcAsync("redo", params: [])
+    }
 
-    fileprivate func updateEditViewScroll() {
-        editView?.updateScroll(scrollView.contentView.bounds)
-        shadowView?.updateScroll(scrollView.contentView.bounds, scrollView.documentView!.bounds)
+    // MARK: - Debug Methods
+    @IBAction func debugRewrap(_ sender: AnyObject) {
+        document?.sendRpcAsync("debug_rewrap", params: [])
+    }
+    
+    @IBAction func debugTestFGSpans(_ sender: AnyObject) {
+        document?.sendRpcAsync("debug_test_fg_spans", params: [])
+    }
+    
+    @IBAction func debugRunPlugin(_ sender: AnyObject) {
+        document?.sendRpcAsync("debug_run_plugin", params: [])
     }
 }
 
@@ -58,10 +137,10 @@ class EditViewController: NSViewController {
 //TODO: will have to think about whether this will work with splits
 extension EditViewController: NSWindowDelegate {
     func windowDidBecomeKey(_ notification: Notification) {
-        editView.updateIsFrontmost(true)
+        editView.isFrontmostView = true
     }
 
     func windowDidResignKey(_ notification: Notification) {
-        editView.updateIsFrontmost(false);
+        editView.isFrontmostView = false
     }
 }

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -39,7 +39,15 @@ class EditViewController: NSViewController {
     func frameDidChangeNotification(_ notification: Notification) {
         updateEditViewScroll()
     }
-    
+
+    func update(_ content: [String: AnyObject]) {
+        editView.updateSafe(update: content)
+    }
+
+    func scrollTo(_ line: Int, _ col: Int) {
+        editView.scrollTo(line, col)
+    }
+
     fileprivate func updateEditViewScroll() {
         editView?.updateScroll(scrollView.contentView.bounds)
         shadowView?.updateScroll(scrollView.contentView.bounds, scrollView.documentView!.bounds)

--- a/XiEditor/StyleMap.swift
+++ b/XiEditor/StyleMap.swift
@@ -88,6 +88,7 @@ class StyleMap {
         }
     }
 
+    /// applies a given style to the AttributedString
     private func applyStyle(string: NSMutableAttributedString, id: Int, range: NSRange) {
         if id >= map.count { return }
         guard let style = map[id] else { return }
@@ -108,18 +109,12 @@ class StyleMap {
         }
     }
 
-    // Apply styles to the given string.
-    // The selection color (for which style 0 is reserverd) is passed in, as it might be different for
-    // different windows (while the StyleMap object is shared).
-    func applyStyles(text: String, string: NSMutableAttributedString, styles: [StyleSpan], selColor: NSColor) {
+    /// Given style information, applies the appropriate text attributes to the passed NSAttributedString
+    func applyStyles(text: String, string: inout NSMutableAttributedString, styles: [StyleSpan]) {
         queue.sync {
-            for styleSpan in styles {
-                if styleSpan.style == 0 {
-                    // we handle selection drawing in EditView.drawRect
-                    continue
-                } else {
+            // we handle the 0 style (selection) in EditView.drawRect
+            for styleSpan in styles.filter({ $0.style != 0 }) {
                     applyStyle(string: string, id: styleSpan.style, range: styleSpan.range)
-                }
             }
         }
     }


### PR DESCRIPTION
This is a first pass at fixing a bit of the mess left over from #162. 

While this PR looks a bit daunting there are very few actual changes. It is _mostly_ just moving things around.

- any code that was doing interaction handling or communication with the backend that could be trivially moved into the EditViewController was;

- the remaining code in EditView was organized by role, and got a little bit more documentation, to hopefully make it less daunting for other people to dip into;

- and a very few places (such as the code around blinking the cursor) were refactored to be a bit more concise and a bit more readable. 

- anything redundant or unused was removed. I hope I wasn't too gung-ho on this front. 😏 

Open & Save are now working as expected, fixing a brief regression.

There's still no cmd-T for a new tab. That's on deck, though. I'll open an issue. Tabs _do_ work when the tab bar is visible, and you can drag them out of and into windows.