### PR TITLE
Reuse empty views when opening a new document

### DIFF
--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -20,6 +20,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var dispatcher: Dispatcher?
     var styleMap: StyleMap = StyleMap()
 
+    /// used internally to force open to an existing empty document when present.
+    var _documentForNextOpenCall: Document?
+
     func applicationWillFinishLaunching(_ aNotification: Notification) {
 
         guard let corePath = Bundle.main.path(forResource: "xi-core", ofType: "")
@@ -46,7 +49,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
         return nil
     }
-    
+
     func handleCoreCmd(_ json: Any) {
         guard let obj = json as? [String : Any],
             let method = obj["method"] as? String,

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -81,6 +81,14 @@ class EditViewController: NSViewController {
         document?.sendRpcAsync("insert", params: insertedStringToJson(insertString as! NSString))
     }
     
+    // we override this to see if our view is empty, and should be reused for this open call
+     func openDocument(_ sender: Any?) {
+        if editView?.lines.isEmpty ?? false {
+            (NSApplication.shared().delegate as? AppDelegate)?._documentForNextOpenCall = self.document
+        }
+        NSDocumentController.shared().openDocument(sender)
+    }
+    
     // MARK: - Menu Items
     fileprivate func cutCopy(_ method: String) {
         let text = document?.sendRpc(method, params: [])

--- a/XiEditor/LineCache.swift
+++ b/XiEditor/LineCache.swift
@@ -81,7 +81,7 @@ class LineCache {
     /// - Note: An empty line cache will still contain a single empty line, this
     /// is sent as an update from the core after a new document is created.
     var isEmpty: Bool {
-        return lines.count == 1 && lines[0]?.text == ""
+        return lines.count == 0 || (lines.count == 1 && lines[0]?.text  == "")
     }
 
     func get(_ ix: Int) -> Line? {

--- a/XiEditor/LineCache.swift
+++ b/XiEditor/LineCache.swift
@@ -76,6 +76,13 @@ class LineCache {
             return nInvalidBefore + lines.count + nInvalidAfter
         }
     }
+    
+    /// A boolean value indicating whether or not the linecache contains any text.
+    /// - Note: An empty line cache will still contain a single empty line, this
+    /// is sent as an update from the core after a new document is created.
+    var isEmpty: Bool {
+        return lines.count == 1 && lines[0]?.text == ""
+    }
 
     func get(_ ix: Int) -> Line? {
         if ix < nInvalidBefore { return nil }


### PR DESCRIPTION
This fixes another small regression from the document model changes.

I'm not totally in love with this fix; it involves stashing state in the app delegate at one point, which feels kind of gross. If someone has a cleaner approach, I'd be happy to try it.

**N.B.** This doesn't work with files opened from the Open Recent > menu, which uses different API, and would be hackier. We can revisit at some point.


I'm starting to develop a better understanding of the NSDocument architecture, which is giving me a stronger sense of its limitations, and of the assumptions it makes which don't really hold true for us. This becomes clearest when I think about split windows. 