### PR TITLE
Update to serde 0.9

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2,8 +2,8 @@
 name = "xi-core"
 version = "0.1.0"
 dependencies = [
- "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "xi-core-lib 0.1.0",
  "xi-rpc 0.1.0",
 ]
@@ -20,12 +20,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "dtoa"
-version = "0.2.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "itoa"
-version = "0.1.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -49,23 +49,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "0.8.23"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_json"
-version = "0.8.6"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -74,8 +74,8 @@ version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -93,8 +93,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "xi-core-lib"
 version = "0.1.0"
 dependencies = [
- "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "xi-rope 0.1.1",
  "xi-rpc 0.1.0",
@@ -113,8 +113,8 @@ name = "xi-rpc"
 version = "0.1.0"
 dependencies = [
  "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -124,14 +124,14 @@ version = "0.1.0"
 [metadata]
 "checksum bytecount 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1e8f09fbc8c6726a4b616dcfbd4f54491068d6bb1b93ac03c78ac18ff9a5924a"
 "checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
-"checksum dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0dd841b58510c9618291ffa448da2e4e0f699d984d436122372f446dae62263d"
-"checksum itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae3088ea4baeceb0284ee9eea42f591226e6beaecf65373e41b38d95a1b8e7a1"
+"checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
+"checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "684f330624d8c3784fb9558ca46c4ce488073a8d22450415c5eb4f4cfb0d11b5"
+"checksum libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "88ee81885f9f04bff991e306fea7c1c60a5f0f9e409e99f6b40e3311a3363135"
 "checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
-"checksum redox_syscall 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd35cc9a8bdec562c757e3d43c1526b5c6d2653e23e2315065bc25556550753"
-"checksum serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
-"checksum serde_json 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "67f7d2e9edc3523a9c8ec8cd6ec481b3a27810aafee3e625d311febd3e656b4c"
+"checksum redox_syscall 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "29dbdfd4b9df8ab31dec47c6087b7b13cbf4a776f335e4de8efba8288dda075b"
+"checksum serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)" = "f023838e7e1878c679322dc7f66c3648bd33763a215fad752f378a623856898d"
+"checksum serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)" = "dbc45439552eb8fb86907a2c41c1fd0ef97458efb87ff7f878db466eb581824e"
 "checksum time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "211b63c112206356ef1ff9b19355f43740fc3f85960c598a93d3a3d3ba7beade"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Raph Levien <raph@google.com>"]
 description = "Main process for xi-core, based on json-rpc"
 
 [dependencies]
-serde = "0.8"
-serde_json = "0.8"
+serde = "0.9"
+serde_json = "0.9"
 
 [dependencies.xi-core-lib]
 path = "core-lib"

--- a/rust/core-lib/Cargo.toml
+++ b/rust/core-lib/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Raph Levien <raph@google.com>"]
 description = "Library module for xi-core"
 
 [dependencies]
-serde = "0.8"
-serde_json = "0.8"
+serde = "0.9"
+serde_json = "0.9"
 time = "0.1"
 
 xi-rope = { path = "../rope", version = "0.1.1" }

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -650,11 +650,6 @@ impl<W: Write + Send + 'static> Editor<W> {
         self.set_cursor(offset, true);
     }
 
-    fn do_render_lines(&mut self, first_line: usize, last_line: usize) -> Value {
-        self.this_edit_type = self.last_edit_type;  // doesn't break undo group
-        self.view.render_lines(&self.text, first_line as usize, last_line as usize)
-    }
-
     fn debug_rewrap(&mut self) {
         self.view.rewrap(&self.text, 72);
         self.view.set_dirty();
@@ -772,9 +767,6 @@ impl<W: Write + Send + 'static> Editor<W> {
         self.this_edit_type = EditType::Other;
 
         let result = match cmd {
-            RenderLines { first_line, last_line } => {
-                Some(self.do_render_lines(first_line, last_line))
-            }
             Key { chars, flags } => async(self.do_key(chars, flags)),
             Insert { chars } => async(self.do_insert(chars)),
             DeleteForward => async(self.delete_forward()),

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -15,6 +15,7 @@
 //! The main library for xi-core.
 
 extern crate serde;
+#[macro_use]
 extern crate serde_json;
 extern crate time;
 

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -50,7 +50,6 @@ pub enum TabCommand<'a> {
 /// An enum representing an edit command, parsed from JSON.
 #[derive(Debug, PartialEq, Eq)]
 pub enum EditCommand<'a> {
-    RenderLines { first_line: usize, last_line: usize },
     Key { chars: &'a str, flags: u64 },
     Insert { chars: &'a str },
     DeleteForward,
@@ -139,18 +138,6 @@ impl<'a> EditCommand<'a> {
         use self::Error::*;
 
         match method {
-            "render_lines" => {
-                params.as_object().and_then(|dict| {
-                    if let (Some(first_line), Some(last_line)) =
-                        (dict_get_u64(dict, "first_line"), dict_get_u64(dict, "last_line")) {
-                            Some(RenderLines {
-                                first_line: first_line as usize,
-                                last_line: last_line as usize
-                            })
-                        } else { None }
-                }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone()))
-            },
-
             "key" => params.as_object().and_then(|dict| {
                 dict_get_string(dict, "chars").and_then(|chars| {
                     dict_get_u64(dict, "flags").map(|flags| {

--- a/rust/core-lib/src/styles.rs
+++ b/rust/core-lib/src/styles.rs
@@ -38,19 +38,20 @@ impl Style {
             "id": id,
             "fg_color": self.fg,
         });
-            if (self.bg >> 24) > 0 {
-                dict_add_value(&mut json, "bg_color", self.bg);
-            }
-            if self.weight != 400 {
-                dict_add_value(&mut json, "weight", self.weight);
-            }
-            if self.underline {
-                dict_add_value(&mut json, "underline", self.underline);
-            }
-            if self.italic {
-                dict_add_value(&mut json, "italic", self.italic);
-            }
-       json 
+
+        if (self.bg >> 24) > 0 {
+            dict_add_value(&mut json, "bg_color", self.bg);
+        }
+        if self.weight != 400 {
+            dict_add_value(&mut json, "weight", self.weight);
+        }
+        if self.underline {
+            dict_add_value(&mut json, "underline", self.underline);
+        }
+        if self.italic {
+            dict_add_value(&mut json, "italic", self.italic);
+        }
+        json 
     }
 }
 

--- a/rust/core-lib/src/styles.rs
+++ b/rust/core-lib/src/styles.rs
@@ -15,8 +15,10 @@
 //! Management of styles.
 
 use std::collections::HashMap;
-use serde_json::Value;
-use serde_json::builder::ObjectBuilder;
+
+use serde_json::value::Value;
+
+use xi_rpc::dict_add_value;
 
 const N_RESERVED_STYLES: usize = 1;
 
@@ -32,22 +34,23 @@ pub struct Style {
 impl Style {
     // construct the params for a def_style request
     pub fn to_json(&self, id: usize) -> Value {
-        let mut builder = ObjectBuilder::new()
-            .insert("id", id)
-            .insert("fg_color", self.fg);
-        if (self.bg >> 24) > 0 {
-            builder = builder.insert("bg_color", self.bg);
-        }
-        if self.weight != 400 {
-            builder = builder.insert("weight", self.weight);
-        }
-        if self.underline {
-            builder = builder.insert("underline", self.underline);
-        }
-        if self.italic {
-            builder = builder.insert("italic", self.italic);
-        }
-        builder.build()
+        let mut json = json!({
+            "id": id,
+            "fg_color": self.fg,
+        });
+            if (self.bg >> 24) > 0 {
+                dict_add_value(&mut json, "bg_color", self.bg);
+            }
+            if self.weight != 400 {
+                dict_add_value(&mut json, "weight", self.weight);
+            }
+            if self.underline {
+                dict_add_value(&mut json, "underline", self.underline);
+            }
+            if self.italic {
+                dict_add_value(&mut json, "italic", self.italic);
+            }
+       json 
     }
 }
 

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -17,8 +17,7 @@
 use std::collections::BTreeMap;
 use std::io::Write;
 use std::sync::{Arc, Mutex};
-use serde_json::Value;
-use serde_json::builder::ObjectBuilder;
+use serde_json::value::Value;
 
 use xi_rope::rope::Rope;
 use editor::Editor;
@@ -112,19 +111,19 @@ impl<W: Write + Send + 'static> Tabs<W> {
 impl<W: Write> TabCtx<W> {
     pub fn update_tab(&self, update: &Value) {
         self.rpc_peer.send_rpc_notification("update",
-            &ObjectBuilder::new()
-                .insert("tab", &self.tab)
-                .insert("update", update)
-                .build());
+            &json!({
+                "tab": &self.tab,
+                "update": update,
+            }));
     }
 
     pub fn scroll_to(&self, line: usize, col: usize) {
         self.rpc_peer.send_rpc_notification("scroll_to",
-            &ObjectBuilder::new()
-                .insert("tab", &self.tab)
-                .insert("line", line)
-                .insert("col", col)
-                .build());
+            &json!({
+                "tab": &self.tab,
+                "line": line,
+                "col": col,
+            }));
     }
 
     pub fn get_kill_ring(&self) -> Rope {
@@ -138,9 +137,9 @@ impl<W: Write> TabCtx<W> {
 
     pub fn alert(&self, msg: &str) {
         self.rpc_peer.send_rpc_notification("alert",
-            &ObjectBuilder::new()
-                .insert("msg", msg)
-                .build());
+            &json!({
+                "msg": msg,
+            }));
     }
 
     // Get the index for a given style. If the style is not in the existing

--- a/rust/plugin-lib/Cargo.toml
+++ b/rust/plugin-lib/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/google/xi-editor"
 description = "The library base for implementing xi-editor plugins."
 
 [dependencies]
-serde_json = "0.8"
+serde_json = "0.9"
 
 [dependencies.xi-rpc]
 path = "../rpc"

--- a/rust/plugin-lib/src/lib.rs
+++ b/rust/plugin-lib/src/lib.rs
@@ -15,6 +15,7 @@
 //! The library base for implementing xi-editor plugins.
 
 extern crate xi_rpc;
+#[macro_use]
 extern crate serde_json;
 
 #[macro_use]

--- a/rust/plugin-lib/src/plugin_base.rs
+++ b/rust/plugin-lib/src/plugin_base.rs
@@ -17,8 +17,7 @@
 use std::io;
 use std::fmt;
 
-use serde_json::Value;
-use serde_json::builder::ObjectBuilder;
+use serde_json::value::Value;
 
 use xi_rpc;
 use xi_rpc::{RpcLoop, RpcCtx, dict_get_u64, dict_get_string};
@@ -59,12 +58,12 @@ impl SpansBuilder {
     }
 
     pub fn add_style_span(&mut self, start: usize, end: usize, fg: u32, font_style: u8) {
-        self.0.push(ObjectBuilder::new()
-            .insert("start", start as u64)
-            .insert("end", end as u64)
-            .insert("fg", fg as u64)
-            .insert("font", font_style as u64)
-            .build());
+        self.0.push(json!({
+            "start": start,
+            "end": end,
+            "fg": fg,
+            "font": font_style,
+        }));
     }
 
     pub fn build(self) -> Spans {
@@ -100,11 +99,11 @@ impl<'a> PluginCtx<'a> {
     */
 
     pub fn get_data(&self, offset: usize, max_size: usize, rev: usize) -> Result<String, Error> {
-        let params = ObjectBuilder::new()
-            .insert("offset", offset)
-            .insert("max_size", max_size)
-            .insert("rev", rev)
-            .build();
+        let params = json!({
+            "offset": offset,
+            "max_size": max_size,
+            "rev": rev,
+        });
         let result = self.send_rpc_request("get_data", &params);
         match result {
             Ok(Value::String(s)) => Ok(s),
@@ -114,12 +113,12 @@ impl<'a> PluginCtx<'a> {
     }
 
     pub fn set_fg_spans(&self, start: usize, len: usize, spans: Spans, rev: usize) {
-        let params = ObjectBuilder::new()
-            .insert("start", start)
-            .insert("len", len)
-            .insert("spans", spans)
-            .insert("rev", rev)
-            .build();
+        let params = json!({
+            "start": start,
+            "len": len,
+            "spans": spans,
+            "rev": rev,
+        });
         self.send_rpc_notification("set_fg_spans", &params);
     }
 

--- a/rust/rpc/Cargo.toml
+++ b/rust/rpc/Cargo.toml
@@ -7,6 +7,6 @@ repository = "https://github.com/google/xi-editor"
 description = "Utilities for building peers (both client and server side) for xi's JSON RPC variant."
 
 [dependencies]
-serde = "0.8"
-serde_json = "0.8"
+serde = "0.9"
+serde_json = "0.9"
 crossbeam = "0.2.9"

--- a/rust/syntect-plugin/Cargo.lock
+++ b/rust/syntect-plugin/Cargo.lock
@@ -56,7 +56,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "dtoa"
-version = "0.2.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -80,7 +80,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "itoa"
-version = "0.1.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -207,14 +207,19 @@ version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "serde"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "serde_json"
-version = "0.8.6"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -269,7 +274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "xi-plugin-lib"
 version = "0.1.0"
 dependencies = [
- "serde_json 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "xi-rpc 0.1.0",
 ]
 
@@ -278,8 +283,8 @@ name = "xi-rpc"
 version = "0.1.0"
 dependencies = [
  "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -303,11 +308,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
 "checksum cmake 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "e1acc68a3f714627af38f9f5d09706a28584ba60dfe2cca68f40bf779f941b25"
 "checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
-"checksum dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0dd841b58510c9618291ffa448da2e4e0f699d984d436122372f446dae62263d"
+"checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
 "checksum flate2 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "d4e4d0c15ef829cbc1b7cda651746be19cceeb238be7b1049227b14891df9e25"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
 "checksum gcc 0.3.43 (registry+https://github.com/rust-lang/crates.io-index)" = "c07c758b972368e703a562686adb39125707cc1ef3399da8c019fc6c2498a75d"
-"checksum itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae3088ea4baeceb0284ee9eea42f591226e6beaecf65373e41b38d95a1b8e7a1"
+"checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6abe0ee2e758cd6bc8a2cd56726359007748fbf4128da998b65d0b70f881e19b"
 "checksum libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "684f330624d8c3784fb9558ca46c4ce488073a8d22450415c5eb4f4cfb0d11b5"
@@ -325,7 +330,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "237546c689f20bb44980270c73c3b9edd0891c1be49cc1274406134a66d3957b"
 "checksum serde 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1b0e0732aa8ec4267f61815a396a942ba3525062e3bd5520aa8419927cfc0a92"
 "checksum serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
-"checksum serde_json 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "67f7d2e9edc3523a9c8ec8cd6ec481b3a27810aafee3e625d311febd3e656b4c"
+"checksum serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)" = "f023838e7e1878c679322dc7f66c3648bd33763a215fad752f378a623856898d"
+"checksum serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)" = "dbc45439552eb8fb86907a2c41c1fd0ef97458efb87ff7f878db466eb581824e"
 "checksum syntect 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e9d678dfa7f7f9c90535caaa81778c971765942fcd57aceffc3acd34564fc0fd"
 "checksum time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "211b63c112206356ef1ff9b19355f43740fc3f85960c598a93d3a3d3ba7beade"
 "checksum walkdir 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c66c0b9792f0a765345452775f3adbd28dde9d33f30d13e5dcc5ae17cf6f3780"


### PR DESCRIPTION
The majority of this PR is replacing the use of `ObjectBuilder` and `ArrayBuilder` with the new `json!({})` macro. The only place where this got a little tricky was in `view.rs`; the code around building updates heavily relied on passing around builder objects. I've now mostly modified it to just build `Vec<Value>`s in place, which hopefully has the side-benefit of making the code a bit easier to follow. I'm not sure if there were any subtle optimizations that I might've undone, but in general I was careful to keep things as streamlined as possible.


closes #182 
