### PR TITLE
RPC protocol update + multi-view plumbing [ready]

### DIFF
--- a/doc/frontend.md
+++ b/doc/frontend.md
@@ -72,7 +72,7 @@ note for `new_view`. Errors are not currently reported.
 
 
 ### edit
-`edit {"method": "insert", "params": {"chars": "A"}, view_id:
+`edit {"method": "insert", "params": {"chars": "A"}, "view_id":
 "view-id-4"}`
 
 Dispatches the inner method to the per-tab handler, with individual

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -821,15 +821,11 @@ impl<W: Write + Send + 'static> Editor<W> {
 
         use rpc::EditCommand::*;
 
-        // if this view is not the currently active view, swap it out
+        // if the rpc's originating view is different from current self.view, swap it in
         if self.view.view_id != view_id {
-            if self.view.view_id != "Null" {
-                let mut temp = self.views.remove(view_id).expect("no view for provided view_id");
-                mem::swap(&mut temp, &mut self.view);
-                self.views.insert(temp.view_id.clone(), temp);
-            } else {
-                self.view = self.views.remove(view_id).expect("no view for provided view_id");
-            }
+            let mut temp = self.views.remove(view_id).expect("no view for provided view_id");
+            mem::swap(&mut temp, &mut self.view);
+            self.views.insert(temp.view_id.clone(), temp);
         }
         
         self.this_edit_type = EditType::Other;

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -49,7 +49,10 @@ pub struct Editor<W: Write> {
     // Maybe this should be in TabCtx or equivelant?
     path: Option<PathBuf>,
 
+    /// A collection of non-primary views attached to this buffer.
     views: BTreeMap<ViewIdentifier, View>,
+    /// The currently active view. This property is dynamically modified as events originating in
+    /// different views arrive.
     view: View,
     engine: Engine,
     last_rev_id: usize,
@@ -146,7 +149,7 @@ impl<W: Write + Send + 'static> Editor<W> {
     /// If the editor only has a single view this is a no-op. After removing a view the caller must
     /// always call Editor::has_views() to determine whether or not the editor should be cleaned up.
     #[allow(unreachable_code)] 
-   pub fn remove_view(&mut self, view_id: &str) {
+    pub fn remove_view(&mut self, view_id: &str) {
         if self.view.view_id == view_id {
             if self.views.len() > 0 {
                 panic!("multi-view support is not currently implemented");

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -134,7 +134,9 @@ impl<W: Write + Send + 'static> Editor<W> {
     }
 
 
+    #[allow(unreachable_code, unused_variables)] 
     pub fn add_view(&mut self, view_id: &str) {
+        panic!("multi-view support is not currently implemented");
         assert!(!self.views.contains_key(view_id), "view_id already exists");
         self.views.insert(view_id.to_owned(), View::new(view_id.to_owned()));
     }
@@ -143,9 +145,11 @@ impl<W: Write + Send + 'static> Editor<W> {
     /// 
     /// If the editor only has a single view this is a no-op. After removing a view the caller must
     /// always call Editor::has_views() to determine whether or not the editor should be cleaned up.
+    #[allow(unreachable_code)] 
    pub fn remove_view(&mut self, view_id: &str) {
         if self.view.view_id == view_id {
             if self.views.len() > 0 {
+                panic!("multi-view support is not currently implemented");
                 //set some other view as active. This will be reset on the next EditCommand
                 let tempkey = self.views.keys().nth(0).unwrap().clone();
                 let mut temp = self.views.remove(&tempkey).unwrap();
@@ -157,9 +161,9 @@ impl<W: Write + Send + 'static> Editor<W> {
         }
     }
 
-    /// Returns true if this editor has any attached views.
+    /// Returns true if this editor has additional attached views.
     pub fn has_views(&self) -> bool {
-        return self.view.view_id != "Null" || self.views.len() > 0
+        self.views.len() > 0
     }
 
     pub fn set_path<P: AsRef<Path>>(&mut self, path: P) {

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -96,7 +96,7 @@ impl<W: Write + Send + 'static> MainState<W> {
     fn handle_req(&mut self, request: Request, rpc_peer: &MainPeer<W>) ->
         Option<Value> {
         match request {
-            Request::TabCommand { tab_command } => self.tabs.do_rpc(tab_command, rpc_peer)
+            Request::CoreCommand { core_command } => self.tabs.do_rpc(core_command, rpc_peer)
         }
     }
 }

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -91,7 +91,7 @@ impl<W: Write + Send + 'static> Tabs<W> {
 
         match cmd {
             CloseView { view_id } => {
-                self.do_close_view(view_id); self.
+                self.do_close_view(view_id);
                 None
             },
 

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -33,7 +33,7 @@ pub type ViewIdentifier = String;
 /// BufferIdentifiers uniquely identify open buffers.
 type BufferIdentifier = String;
 
-//TODO: proposed new name: something like "Core" or "CoreState" or "EditorState"? "Documents?"
+// TODO: proposed new name: something like "Core" or "CoreState" or "EditorState"? "Documents?"
 pub struct Tabs<W: Write> {
     /// maps file names to buffer identifiers. If a client asks to open a file that is already
     /// open, we treat it as a request for a new view.
@@ -91,7 +91,7 @@ impl<W: Write + Send + 'static> Tabs<W> {
 
         match cmd {
             CloseView { view_id } => {
-                self.do_close_view(view_id);
+                self.do_close_view(view_id); self.
                 None
             },
 
@@ -101,9 +101,9 @@ impl<W: Write + Send + 'static> Tabs<W> {
         }
     }
 
-    /// handles client `new_view` requests.
+    /// Creates a new view and associates it with a buffer.
     ///
-    ///This function always creates a new view and associates it with a buffer (which we access
+    /// This function always creates a new view and associates it with a buffer (which we access
     ///through an `Editor` instance). This buffer may be existing, or it may be created.
     ///
     ///A `new_view` request is handled differently depending on the `file_path` argument, and on
@@ -115,20 +115,19 @@ impl<W: Write + Send + 'static> Tabs<W> {
         // three code paths: new buffer, open file, and new view into existing buffer
         let view_id = self.next_view_id();
         if let Some(file_path) = file_path.map(PathBuf::from) {
-            // if this file is open, add a new view
+            // TODO: here, we should eventually be adding views to the existing editor.
+            // for the time being, we just create a new empty view.
             if self.open_files.contains_key(&file_path) {
-                //TODO: we should eventually be adding views to the existing editor.
-                // for the time being, we just create a new empty view.
                 let buffer_id = self.next_buffer_id();
                 self.new_empty_view(rpc_peer, &view_id, buffer_id);
-                //let buffer_id = self.open_files.get(&file_path).unwrap().to_owned();
+                // let buffer_id = self.open_files.get(&file_path).unwrap().to_owned();
                 //self.add_view(&view_id, buffer_id);
             } else {
                 // not open: create new buffer_id and open file
                 let buffer_id = self.next_buffer_id();
                 self.open_files.insert(file_path.to_owned(), buffer_id.clone());
                 self.new_view_with_file(rpc_peer, &view_id, buffer_id.clone(), &file_path);
-                // above fn takes two paths: set path after
+                // above fn has two branches: set path after
                 self.buffers.get(&buffer_id).unwrap().lock().unwrap().set_path(&file_path);
             }
         } else {
@@ -156,7 +155,7 @@ impl<W: Write + Send + 'static> Tabs<W> {
                 self.finalize_new_view(view_id, buffer_id, editor)
             }
             Err(err) => {
-                //TODO: we should be reporting errors to the client
+                // TODO: we should be reporting errors to the client
                 // (if this is even an error? we treat opening a non-existent file as a new buffer,
                 // but set the editor's path)
                 print_err!("unable to read file: {}, error: {:?}", buffer_id, err);

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -117,8 +117,12 @@ impl<W: Write + Send + 'static> Tabs<W> {
         if let Some(file_path) = file_path.map(PathBuf::from) {
             // if this file is open, add a new view
             if self.open_files.contains_key(&file_path) {
-                let buffer_id = self.open_files.get(&file_path).unwrap().to_owned();
-                self.add_view(&view_id, buffer_id);
+                //TODO: we should eventually be adding views to the existing editor.
+                // for the time being, we just create a new empty view.
+                let buffer_id = self.next_buffer_id();
+                self.new_empty_view(rpc_peer, &view_id, buffer_id);
+                //let buffer_id = self.open_files.get(&file_path).unwrap().to_owned();
+                //self.add_view(&view_id, buffer_id);
             } else {
                 // not open: create new buffer_id and open file
                 let buffer_id = self.next_buffer_id();
@@ -162,7 +166,7 @@ impl<W: Write + Send + 'static> Tabs<W> {
     }
 
     /// Adds a new view to an existing editor instance.
-    #[allow(unreachable_code, unused_variables)] 
+    #[allow(unreachable_code, unused_variables, dead_code)] 
     fn add_view(&mut self, view_id: &str, buffer_id: BufferIdentifier) {
         panic!("add_view should not currently be accessible");
         let editor = self.buffers.get(&buffer_id).expect("missing editor_id for view_id");
@@ -173,7 +177,6 @@ impl<W: Write + Send + 'static> Tabs<W> {
     fn finalize_new_view(&mut self, view_id: &str, buffer_id: String, editor: Arc<Mutex<Editor<W>>>) {
         self.views.insert(view_id.to_owned(), buffer_id.clone());
         self.buffers.insert(buffer_id, editor.clone());
-        editor.lock().unwrap().add_view(view_id);
     }
     
     fn read_file<P: AsRef<Path>>(&self, path: P) -> io::Result<String> {

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -25,7 +25,7 @@ use xi_rope::interval::Interval;
 use xi_rope::spans::Spans;
 use xi_rpc::dict_add_value;
 
-use tabs::TabCtx;
+use tabs::{ViewIdentifier, TabCtx};
 use styles;
 use index_set::IndexSet;
 
@@ -40,6 +40,7 @@ pub struct Style {
 }
 
 pub struct View {
+    pub view_id: ViewIdentifier,
     pub sel_start: usize,
     pub sel_end: usize,
     first_line: usize,  // vertical scroll position
@@ -57,9 +58,10 @@ pub struct View {
     dirty: bool,
 }
 
-impl Default for View {
-    fn default() -> View {
+impl View {
+    pub fn new<S: AsRef<str>>(view_id: S) -> View {
         View {
+            view_id: view_id.as_ref().to_owned(),
             sel_start: 0,
             sel_end: 0,
             first_line: 0,
@@ -70,13 +72,7 @@ impl Default for View {
             cursor_col: 0,
             valid_lines: IndexSet::new(),
             dirty: true,
-        }
-    }
-}
-
-impl View {
-    pub fn new() -> View {
-        View::default()
+        }   
     }
 
     pub fn set_scroll(&mut self, first: usize, last: usize) {
@@ -227,7 +223,7 @@ impl View {
             ops.push(self.build_update_op(op, None, height - last_line));
         }
         let params = json!({"ops": ops});
-        tab_ctx.update_view(&params);
+        tab_ctx.update_view(&self.view_id, &params);
         self.valid_lines.union_one_range(first_line, last_line);
     }
 
@@ -272,7 +268,7 @@ impl View {
             ops.push(self.build_update_op("copy", None, height - line));
         }
         let params = json!({"ops": ops});
-        tab_ctx.update_view(&params);
+        tab_ctx.update_view(&self.view_id, &params);
         self.valid_lines.union_one_range(first_line, last_line);
     }
 

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -227,7 +227,7 @@ impl View {
             ops.push(self.build_update_op(op, None, height - last_line));
         }
         let params = json!({"ops": ops});
-        tab_ctx.update_tab(&params);
+        tab_ctx.update_view(&params);
         self.valid_lines.union_one_range(first_line, last_line);
     }
 
@@ -272,7 +272,7 @@ impl View {
             ops.push(self.build_update_op("copy", None, height - line));
         }
         let params = json!({"ops": ops});
-        tab_ctx.update_tab(&params);
+        tab_ctx.update_view(&params);
         self.valid_lines.union_one_range(first_line, last_line);
     }
 

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -22,7 +22,7 @@ use xi_rope::delta::{Delta};
 use xi_rope::tree::Cursor;
 use xi_rope::breaks::{Breaks, BreaksInfo, BreaksMetric, BreaksBaseMetric};
 use xi_rope::interval::Interval;
-use xi_rope::spans::{Spans, SpansBuilder};
+use xi_rope::spans::Spans;
 use xi_rpc::dict_add_value;
 
 use tabs::TabCtx;
@@ -408,9 +408,5 @@ impl View {
             linewrap::rewrap(self.breaks.as_mut().unwrap(), text, iv, new_len, self.wrap_col);
         }
         self.dirty = true;
-    }
-
-    pub fn reset_breaks(&mut self) {
-        self.breaks = None;
     }
 }


### PR DESCRIPTION
~edit: After a bit of playing around there may be a few performance regressions I want to look at, but this is good for review.~ (all good)

This is approximately where I would like it to be in terms of the API modifications discussed in #191. It also includes a variety of naming changes, which are intended to more clearly document the use of particular APIs & methods. I'm touchy about renaming other people's code: please consider all naming changes to be suggestions, and I'm happy to revert them. 😄

### RPC Changes:
Because this already involved breaking changes to the RPC protocol, I took the liberty of normalizing certain other RPC signatures.

- In *all* RPC methods, the word `tab` as an identifier of 'client viewports' has been replaced with `view_id`.
- in *all* RPC methods, the word `filename` has been replaced with the word `file_path`. (We were using both in different places, I just grepped the src directory and picked the most common).
- `TabCommand` is now `CoreCommand`. (not a protocol change)
-  `NewTab` and `DeleteTab` (`new_tab`, `delete_tab`) have been removed from `CoreCommand`.
- `NewView { file_path }`, `CloseView { view_id }` and `Save { view_id, file_path }` have been added to `CoreCommand`.
- `Open` and `Save` have been removed from `EditCommand`.

In error messages and other names, the word `tab` has been replaced with `core`, where appropriate.

### Other changes:

The other main change here is that `Editor` now behaves as it if has multiple views, although the actual multi-view support isn't implemented. To reduce the diff size, `Editor` still does everything through a `self.view` instance. There is code in place to dynamically swap this variable out when an event arrives associated with a new view, but these codepaths are not currently available.

Anyway: the real consequence of this is that events and responses are associated with a specific view_id, rather than a buffer+view (e.g. a 'tab'). This plus the clarified view and editor lifecycle stuff enabled by the RPC changes set me up to _hopefully_ start implementing provisional plugin support. Maybe? 🤞 

### To think about:

- What is the role of `TabCtx`, now? with message routing now based on `view_id`, which isn't owned by a particular `TabCtx`, this should be rethought.
- How will actual multi-view support happen, and what refactoring is required to make that possible? It still feels like there's a lot of state split between the editor and the view. I haven't looked into this very much.
- **Are  there any other protocol changes to make now**, while we're already breaking things?



