### PR TITLE
Update intro paragraph on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 
 The xi editor project is an attempt to build a high quality text editor,
 using modern software engineering techniques. It is initially built for
-Mac OS X, using Cocoa for the user interface, but other targets are planned.
+Mac OS X, using Cocoa for the user interface. There are also frontends for
+other operating systems available from third-party developers.
 
 Goals include:
 


### PR DESCRIPTION
Frontends for other operating systems are available, but the current
intro paragraph discourages reading further if the reader is not on
OS X. The intro paragraph should make it clear that people can run Xi
even if they run a different OS.