### PR TITLE
Keep track of saved/unsaved state

### DIFF
--- a/rust/rope/src/engine.rs
+++ b/rust/rope/src/engine.rs
@@ -234,16 +234,11 @@ impl Engine {
         self.rev_id_counter += 1;
     }
 
-    pub fn compare(&self, base_rev: usize, other_rev: usize) -> bool {
+    pub fn is_equivalent_revision(&self, base_rev: usize, other_rev: usize) -> bool {
         let base_subset = self.find_rev(base_rev).map(|rev_index| self.get_subset_from_index(rev_index));
         let other_subset = self.find_rev(other_rev).map(|rev_index| self.get_subset_from_index(rev_index));
 
-        if let Some(base_subset) = base_subset {
-            if let Some(other_subset) = other_subset {
-                return base_subset == other_subset;
-            }
-        }
-        false
+        base_subset.is_some() && base_subset == other_subset
     }
 
     // Note: this function would need some work to handle retaining arbitrary revisions,

--- a/rust/rope/src/subset.rs
+++ b/rust/rope/src/subset.rs
@@ -21,7 +21,7 @@ use tree::{Node, NodeInfo, TreeBuilder};
 use interval::Interval;
 
 // Internally, a sorted list of (begin, end) ranges.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct Subset(Vec<(usize, usize)>);
 
 #[derive(Default)]
@@ -205,7 +205,7 @@ impl Subset {
         for &(b, e) in &self.0[i..] {
             sb.add_deletion(b + delta, e + delta);
         }
-        sb.build()   
+        sb.build()
     }
 
     /// Transform subset through other coordinate transform, shrinking.


### PR DESCRIPTION
This initial implementation keeps track of a saved revision. This
revision is initially set to the latest revision when creating a new
editor and is updated to the latest revision during a save.

The unsaved state is calculated by comparing the deletion subset of both
revisions. This creates the following behavior: If new text is inserted
and the deleted back to the original state, there are no unsaved
changes; however, if existing text is deleted and retyped, there are now
unsaved changes. If you undo back to the state of the save revision,
there are no unsaved changes.