### PR TITLE
Do view rendering using new multi-selection

### DIFF
--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -199,7 +199,7 @@ impl<W: Write + Send + 'static> Editor<W> {
             self.scroll_to = Some(offset);
         }
         self.view.scroll_to_cursor(&self.text);
-        self.view.set_dirty();
+        self.view.set_old_sel_dirty();
     }
 
     // Apply the delta to the buffer, and store the new cursor so that it gets
@@ -632,7 +632,7 @@ impl<W: Write + Send + 'static> Editor<W> {
     fn select_all(&mut self) {
         self.view.sel_start = 0;
         self.view.sel_end = self.text.len();
-        self.view.set_dirty();
+        self.view.set_old_sel_dirty();
     }
 
     fn do_key(&mut self, chars: &str, flags: u64) {

--- a/rust/core-lib/src/selection.rs
+++ b/rust/core-lib/src/selection.rs
@@ -178,6 +178,11 @@ impl SelRegion {
         self.start == self.end
     }
 
+    /// Determines whether the region's affinity is upstream.
+    pub fn is_upstream(&self) -> bool {
+        self.affinity == Affinity::Upstream
+    }
+
     // Indicate whether this region should merge with the next.
     // Assumption: regions are sorted (self.min() <= other.min())
     fn should_merge(&self, other: &SelRegion) -> bool {

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -148,10 +148,9 @@ impl View {
         for region in self.selection.regions_in_range(start_pos, pos) {
             // cursor
             let c = region.end;
-            let is_upstream = region.affinity == Affinity::Upstream;
             if (c > start_pos && c < pos) ||
-                (!is_upstream && c == start_pos) ||
-                (is_upstream && c == pos) ||
+                (!region.is_upstream() && c == start_pos) ||
+                (region.is_upstream() && c == pos) ||
                 (c == pos && c == text.len() && self.line_of_offset(text, c) == line_num)
             {
                 cursors.push(c - start_pos);

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -152,19 +152,12 @@ impl View {
             if (c > start_pos && c < pos) ||
                 (!is_upstream && c == start_pos) ||
                 (is_upstream && c == pos) ||
-                (c == pos && pos == text.len())
+                (c == pos && c == text.len() && self.line_of_offset(text, c) == line_num)
             {
                 if cursors.is_none() {
                     cursors = Some(Vec::new());
                 }
-                // TODO: make this handle upstream case (should be prev line)
-                // TODO: we really need utf-8 byte offsets; if the function starts
-                // using different units to measure "columns" we need to adapt.
-                let (cursor_line, cursor_col) = self.offset_to_line_col(text, c);
-                // this test is needed for previous line when at end of text
-                if cursor_line == line_num {
-                    cursors.as_mut().unwrap().push(cursor_col);
-                }
+                cursors.as_mut().unwrap().push(c - start_pos);
             }
 
             // selection with interior


### PR DESCRIPTION
This is part of a migration to the new multi-selection approach. The
old cursor/selection state (which is still what's used in edit
operations) is copied over (when dirty) to the new format. Then, all
rendering is done with the new format.

Most of the logic upstream affinity is in place, but it will require
some small changes. I suggest we get back to that when we can generate
upstream positions from mouse clicks.

Another step towards #188