### PR TITLE
update front-end link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ experimental GL-based front-end in Rust.
 
 * [XiEditorVS2015](https://github.com/Sineaggi/XiEditorVS2015), C#.
 
-* [`xi-electron`](https://gitlab.com/callodacity/xi-electron), a front-end based on web-technologies.
+* [`xi-electron`](https://github.com/callodacity/xi-electron), a front-end based on web-technologies.
 
 There are notes (I wouldn’t call it
 documentation at this point) on the protocol at


### PR DESCRIPTION
I just moved the repo to GitHub, so I'm just updating the link 👍 