### PR TITLE
Soft spans

### DIFF
--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -73,6 +73,7 @@ pub struct Editor<W: Write> {
     scroll_to: Option<usize>,
 
     style_spans: Spans<Style>,
+    soft_spans: Spans<()>,
     tab_ctx: TabCtx<W>,
     plugins: Vec<PluginRef<W>>,
     revs_in_flight: usize,
@@ -131,6 +132,7 @@ impl<W: Write + Send + 'static> Editor<W> {
             new_cursor: None,
             scroll_to: Some(0),
             style_spans: Spans::default(),
+            soft_spans: Spans::default(),
             tab_ctx: tab_ctx,
             plugins: Vec::new(),
             revs_in_flight: 0,
@@ -183,8 +185,33 @@ impl<W: Write + Send + 'static> Editor<W> {
     }
 
     fn insert(&mut self, s: &str) {
-        let sel_interval = Interval::new_closed_open(self.view.sel_min(), self.view.sel_max());
-        let new_cursor = self.view.sel_min() + s.len();
+        let start = self.view.sel_min();
+        let mut end = self.view.sel_max();
+        let new_cursor = start + s.len();
+
+        // process soft spans in front of the cursor
+        let iv_ahead = Interval::new_closed_open(start, self.soft_spans.len());
+        let soft_spans = self.soft_spans.subseq(iv_ahead);
+        if let Some((interval, _)) = soft_spans.iter().next() {
+            // only interested in soft spans that are directly in front of the cursor
+            if interval.start() == 0 {
+                let mut cursor = Cursor::new(&self.text, start);
+                let are_eql = compare_cursor_str(&mut cursor, s);
+
+                // are_eql is checked for 1 codepoint long inserts and cursor position is checked
+                // to also match longer inserts partially
+                if are_eql || cursor.pos() > start + 1 {
+                    self.soft_spans.clear_left(cursor.pos());
+
+                    // update selection interval to replace matching part of soft span
+                    end += cursor.pos() - start;
+                } else {
+                    self.soft_spans.shift_right(s.len());
+                }
+            }
+        }
+
+        let sel_interval = Interval::new_closed_open(start, end);
         self.add_delta(sel_interval, Rope::from(s), new_cursor, new_cursor);
     }
 
@@ -200,6 +227,9 @@ impl<W: Write + Send + 'static> Editor<W> {
         }
         self.view.scroll_to_cursor(&self.text);
         self.view.set_old_sel_dirty();
+
+        // remove soft spans before cursor
+        self.soft_spans.clear_left(self.view.sel_start);
     }
 
     // Apply the delta to the buffer, and store the new cursor so that it gets
@@ -342,7 +372,7 @@ impl<W: Write + Send + 'static> Editor<W> {
 
     // render if needed, sending to ui
     pub fn render(&mut self) {
-        self.view.render_if_dirty(&self.text, &self.tab_ctx, &self.style_spans);
+        self.view.render_if_dirty(&self.text, &self.tab_ctx, &self.style_spans, &self.soft_spans);
         if let Some(scrollto) = self.scroll_to {
             let (line, col) = self.view.offset_to_line_col(&self.text, scrollto);
             self.tab_ctx.scroll_to(&self.view.view_id, line, col);
@@ -389,6 +419,8 @@ impl<W: Write + Send + 'static> Editor<W> {
             self.this_edit_type = EditType::Delete;
             let del_interval = Interval::new_closed_open(start, self.view.sel_max());
             self.add_delta(del_interval, Rope::from(""), start, start);
+
+            self.soft_spans.shift_left(del_interval.size());
         }
     }
 
@@ -709,7 +741,7 @@ impl<W: Write + Send + 'static> Editor<W> {
         let first = max(first, 0) as usize;
         let last = last as usize;
         self.view.set_scroll(first, last);
-        self.view.send_update_for_scroll(&self.text, &self.tab_ctx, &self.style_spans, first, last);
+        self.view.send_update_for_scroll(&self.text, &self.tab_ctx, &self.style_spans, &self.soft_spans, first, last);
     }
 
     /// Sets the cursor and scrolls to the beginning of the given line.
@@ -719,7 +751,7 @@ impl<W: Write + Send + 'static> Editor<W> {
     }
 
     fn do_request_lines(&mut self, first: i64, last: i64) {
-        self.view.send_update(&self.text, &self.tab_ctx, &self.style_spans, first as usize, last as usize);
+        self.view.send_update(&self.text, &self.tab_ctx, &self.style_spans, &self.soft_spans, first as usize, last as usize);
     }
 
     fn do_click(&mut self, line: u64, col: u64, flags: u64, click_count: u64) {
@@ -765,6 +797,21 @@ impl<W: Write + Send + 'static> Editor<W> {
         self.style_spans = sb.build();
 
         self.view.set_dirty();
+    }
+
+    fn debug_test_soft_spans(&mut self) {
+        print_err!("adding soft spans example");
+
+        let sel_interval = Interval::new_closed_open(self.view.sel_start, self.view.sel_end);
+        let text = Rope::from("soft spans!");
+        let new_cursor = self.view.sel_start;
+
+        let end = new_cursor + text.len();
+        let mut sb = SpansBuilder::new(end);
+        sb.add_span(Interval::new_closed_open(new_cursor, end), ());
+        self.soft_spans = sb.build();
+
+        self.add_delta(sel_interval, text, new_cursor, new_cursor);
     }
 
     fn debug_run_plugin(&mut self, self_ref: &Arc<Mutex<Editor<W>>>) {
@@ -933,6 +980,7 @@ impl<W: Write + Send + 'static> Editor<W> {
             DebugRewrap => async(self.debug_rewrap()),
             DebugTestFgSpans => async(self.debug_test_fg_spans()),
             DebugRunPlugin => async(self.debug_run_plugin(self_ref)),
+            DebugTestSoftSpans => async(self.debug_test_soft_spans()),
         };
 
         // TODO: could defer this until input quiesces - will this help?
@@ -1029,4 +1077,17 @@ fn n_spaces(n: usize) -> &'static str {
     let spaces = "                                ";
     assert!(n <= spaces.len());
     &spaces[..n]
+}
+
+use xi_rope::rope::RopeInfo;
+fn compare_cursor_str(cursor: &mut Cursor<RopeInfo>, pat: &str) -> bool {
+    for c in pat.chars() {
+        if let Some(rope_c) = cursor.next_codepoint() {
+            if rope_c != c { return false; }
+        } else {
+            // end of string before pattern is complete
+            return false;
+        }
+    }
+    true
 }

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -101,6 +101,7 @@ pub enum EditCommand<'a> {
     DebugRewrap,
     DebugTestFgSpans,
     DebugRunPlugin,
+    DebugTestSoftSpans,
 }
 
 impl<'a> CoreCommand<'a> {
@@ -240,6 +241,7 @@ impl<'a> EditCommand<'a> {
             "debug_rewrap" => Ok(DebugRewrap),
             "debug_test_fg_spans" => Ok(DebugTestFgSpans),
             "debug_run_plugin" => Ok(DebugRunPlugin),
+            "debug_test_soft_spans" => Ok(DebugTestSoftSpans),
 
             _ => Err(UnknownEditMethod(method.to_string())),
         }

--- a/rust/core-lib/src/styles.rs
+++ b/rust/core-lib/src/styles.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 
 use serde_json::value::Value;
 
-const N_RESERVED_STYLES: usize = 1;
+const N_RESERVED_STYLES: usize = 2;
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Style {
@@ -49,7 +49,7 @@ impl Style {
         if self.italic {
             json["italic"] = json!(self.italic);
         }
-        json 
+        json
     }
 }
 

--- a/rust/rope/src/tree.rs
+++ b/rust/rope/src/tree.rs
@@ -184,7 +184,7 @@ impl<N: NodeInfo> Node<N> {
         self.0.height == 0
     }
 
-    fn interval(&self) -> Interval {
+    pub fn interval(&self) -> Interval {
         self.0.info.interval(self.0.len)
     }
 


### PR DESCRIPTION
This PR implements soft spans (an idea of @raphlinus). Soft spans are maybe best shown with an example of an actual use case:

![2017-04-25 16 58 24](https://cloud.githubusercontent.com/assets/409021/25394596/c57cd650-29de-11e7-8f30-9a8fd09210bc.gif)

In this example I am not using arrow keys to move the cursor over the closing parenthesis, I am inserting an actual closing parenthesis instead

Here are some characteristics I've implemented:

![2017-04-25 16 59 18](https://cloud.githubusercontent.com/assets/409021/25394803/55b8d818-29df-11e7-88ac-2603ffbd269c.gif)

- if a character is inserted before a soft span and the character matches with the first character of the soft span, the cursor is shifted over this character (implementation-wise the existing value of the soft span is overridden)
- if more than one character is inserted (e.g. using paste), it works according the point above, but shifts the cursor for as long as the input string matches the soft span string
- if the cursor is moved (arrow keys, mouse click, ...), all soft spans before the cursor are removed
- if text is deleted, soft spans are shifted accordingly

The implementation of soft spans is similar to style spans, with the difference that the editor keeps the soft spans in place (instead of relying on the plugin to handle the lifetime of the soft span).

However, merging asynchronous inserts that come in late, is not implemented yet, e.g.:

![2017-04-25 16 58 49](https://cloud.githubusercontent.com/assets/409021/25394634/e82aa218-29de-11e7-934b-a82b4f02a5b7.gif)

While adding soft spans at the correct position is easy (since it is already implemented for style spans), as a user I would expect the additional plugin-inserted closing parenthesis to not show up at all.

This brings me to the main open question of this PR: How and where to implement the merging of soft spans? I kind of have the feeling that something like this should actual go into `engine.rs`?

A quick'n'dirty branch of xi-mac for testing purposes can be found [here](https://github.com/rkusa/xi-mac/tree/soft_spans) (I have added an entry into the Debug menu).

_(commits will be squashed once the PR is ready to go)_


