### PR TITLE
Add toggle_selection gesture; new movement

### DIFF
--- a/doc/frontend.md
+++ b/doc/frontend.md
@@ -141,8 +141,20 @@ click count.
 Implements dragging (extending a selection). Arguments are line,
 column, and flag as in `click`.
 
+#### gesture
+
+`gesture {"line": 42, "col": 31, "ty": "toggle_sel"}
+
+Note: both `click` and `drag` functionality will be migrated to
+additional `ty` options for `gesture`. For now, "toggle_sel" is the
+only supported option, and has the semantics of toggling one cursor
+in the selection (the usual mapping of Command-click in macOS
+front-ends).
+
 The following edit methods take no parameters, and have similar
-meanings as NSView actions. This list is expected to grow.
+meanings as NSView actions. The pure movement and selection
+modification methods will be migrated to a more general method
+that takes a "movement" enum as a parameter.
 
 ```
 delete_backward

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -38,6 +38,7 @@ mod styles;
 mod word_boundaries;
 mod index_set;
 mod selection;
+mod movement;
 
 use tabs::Tabs;
 use rpc::Request;

--- a/rust/core-lib/src/movement.rs
+++ b/rust/core-lib/src/movement.rs
@@ -1,0 +1,90 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Representation and calculation of movement within a view.
+
+use selection::{Affinity, HorizPos, Selection, SelRegion};
+use view::View;
+use xi_rope::rope::Rope;
+
+/// The specification of a movement.
+#[derive(Clone, Copy)]
+pub enum Movement {
+    /// Move to the left by one grapheme cluster.
+    Left,
+    /// Move to the right by one grapheme cluster.
+    Right,
+}
+
+/// Calculate a horizontal position in the view, based on the offset. Return
+/// value has the same type as `region_movement` for convenience.
+fn calc_horiz(view: &View, text: &Rope, offset: usize) -> (usize, Option<HorizPos>) {
+    let (_line, col) = view.offset_to_line_col(text, offset);
+    (offset, Some(col))
+}
+
+/// Compute the result of movement on one selection region.
+fn region_movement(m: Movement, r: &SelRegion, view: &View, text: &Rope, modify: bool)
+    -> (usize, Option<HorizPos>)
+{
+    match m {
+        Movement::Left => {
+            if r.is_caret() || modify {
+                if let Some(offset) = text.prev_grapheme_offset(r.end) {
+                    calc_horiz(view, text, offset)
+                } else {
+                    (0, None)
+                }
+            } else {
+                calc_horiz(view, text, r.min())
+            }
+        }
+        Movement::Right => {
+            if r.is_caret() || modify {
+                if let Some(offset) = text.next_grapheme_offset(r.end) {
+                    calc_horiz(view, text, offset)
+                } else {
+                    (r.end, None)
+                }
+            } else {
+                calc_horiz(view, text, r.max())
+            }
+        }
+        //_ => (0, None)
+    }
+}
+
+/// Compute a new selection by applying a movement to an existing selection.
+///
+/// In a multi-region selection, this function applies the movement to each
+/// region in the selection, and returns the union of the results.
+///
+/// If `modify` is `true`, the selections are modified, otherwise the results
+/// of individual region movements become carets.
+pub fn selection_movement(m: Movement, s: &Selection, view: &View, text: &Rope,
+    modify: bool) -> Selection
+{
+    let mut result = Selection::new();
+    for r in s.iter() {
+        let (offset, horiz) = region_movement(m, r, view, text, modify);
+        let new_region = SelRegion {
+            start: if modify { r.start } else { offset },
+            end: offset,
+            horiz: horiz,
+            affinity: Affinity::default(),
+        };
+        result.add_region(new_region);
+    }
+    result
+}

--- a/rust/core-lib/src/selection.rs
+++ b/rust/core-lib/src/selection.rs
@@ -14,9 +14,6 @@
 
 //! Data structures representing (multiple) selections and cursors.
 
-// TODO: actually use these
-#![allow(unused)]
-
 use std::cmp::{min, max};
 use std::ops::Deref;
 use index_set::remove_n_at;
@@ -107,6 +104,16 @@ impl Selection {
             last += 1;
         }
         &self.regions[first..last]
+    }
+
+    /// Deletes all the regions that intersect or touch the given range.
+    pub fn delete_range(&mut self, start: usize, end: usize) {
+        let first = self.search(start);
+        let mut last = self.search(end);
+        if last < self.regions.len() && self.regions[last].min() <= end {
+            last += 1;
+        }
+        remove_n_at(&mut self.regions, first, last - first);
     }
 }
 

--- a/rust/syntect-plugin/Cargo.lock
+++ b/rust/syntect-plugin/Cargo.lock
@@ -208,18 +208,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "0.9.12"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_json"
-version = "0.9.9"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -274,7 +274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "xi-plugin-lib"
 version = "0.1.0"
 dependencies = [
- "serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "xi-rpc 0.2.0",
 ]
 
@@ -283,8 +283,8 @@ name = "xi-rpc"
 version = "0.2.0"
 dependencies = [
  "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -330,8 +330,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "237546c689f20bb44980270c73c3b9edd0891c1be49cc1274406134a66d3957b"
 "checksum serde 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1b0e0732aa8ec4267f61815a396a942ba3525062e3bd5520aa8419927cfc0a92"
 "checksum serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
-"checksum serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)" = "f023838e7e1878c679322dc7f66c3648bd33763a215fad752f378a623856898d"
-"checksum serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)" = "dbc45439552eb8fb86907a2c41c1fd0ef97458efb87ff7f878db466eb581824e"
+"checksum serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3b46a59dd63931010fdb1d88538513f3279090d88b5c22ef4fe8440cfffcc6e3"
+"checksum serde_json 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1c62115693d0a9ed8c32d1c760f0fdbe7d4b05cb13c135b9b54137ac0d59fccb"
 "checksum syntect 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e9d678dfa7f7f9c90535caaa81778c971765942fcd57aceffc3acd34564fc0fd"
 "checksum time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "211b63c112206356ef1ff9b19355f43740fc3f85960c598a93d3a3d3ba7beade"
 "checksum walkdir 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c66c0b9792f0a765345452775f3adbd28dde9d33f30d13e5dcc5ae17cf6f3780"


### PR DESCRIPTION
Adding a new "gesture" RPC call, and wiring it up to
"toggle_selection" logic.

Also start new "movement" module, and start wiring existing movement
commands to use it. As of this patch, only "left" and "right" are
adapted to be multi-selection.

Progress toward #188