### PR TITLE
Wire up additional movements to new scheme

### DIFF
--- a/rust/core-lib/src/movement.rs
+++ b/rust/core-lib/src/movement.rs
@@ -14,9 +14,13 @@
 
 //! Representation and calculation of movement within a view.
 
+use std::cmp::max;
+
 use selection::{Affinity, HorizPos, Selection, SelRegion};
 use view::View;
-use xi_rope::rope::Rope;
+use word_boundaries::WordCursor;
+use xi_rope::rope::{LinesMetric, Rope};
+use xi_rope::tree::Cursor;
 
 /// The specification of a movement.
 #[derive(Clone, Copy)]
@@ -25,6 +29,30 @@ pub enum Movement {
     Left,
     /// Move to the right by one grapheme cluster.
     Right,
+    /// Move to the left by one word.
+    LeftWord,
+    /// Move to the right by one word.
+    RightWord,
+    /// Move to left end of visible line.
+    LeftOfLine,
+    /// Move to right end of visible line.
+    RightOfLine,
+    /// Move up one visible line.
+    Up,
+    /// Move down one visible line.
+    Down,
+    /// Move up one viewport height.
+    UpPage,
+    /// Move down one viewport height.
+    DownPage,
+    /// Move to the start of the text line.
+    StartOfParagraph,
+    /// Move to the end of the text line.
+    EndOfParagraph,
+    /// Move to the start of the document.
+    StartOfDocument,
+    /// Move to the end of the document
+    EndOfDocument,
 }
 
 /// Calculate a horizontal position in the view, based on the offset. Return
@@ -34,7 +62,60 @@ fn calc_horiz(view: &View, text: &Rope, offset: usize) -> (usize, Option<HorizPo
     (offset, Some(col))
 }
 
+/// Compute movement based on vertical motion by the given number of lines.
+///
+/// Note: in non-exceptional cases, this function preserves the `horiz`
+/// field of the selection region.
+fn vertical_motion(r: &SelRegion, view: &View, text: &Rope, line_delta: isize,
+    modify: bool) -> (usize, Option<HorizPos>)
+{
+    // The active point of the selection
+    let active = if modify {
+        r.end
+    } else if line_delta < 0 {
+        r.min()
+    } else {
+        r.max()
+    };
+    let col = if let Some(col) = r.horiz {
+        col
+    } else {
+        view.offset_to_line_col(text, active).1
+    };
+    // This code is quite careful to avoid integer overflow.
+    // TODO: write tests to verify
+    let line = view.line_of_offset(text, active);
+    if line_delta < 0 && (-line_delta as usize) > line {
+        return (0, Some(col));
+    }
+    let line = if line_delta < 0 {
+        line - (-line_delta as usize)
+    } else {
+        line.saturating_add(line_delta as usize)
+    };
+    let n_lines = view.line_of_offset(text, text.len());
+    if line > n_lines {
+        return (text.len(), Some(col));
+    }
+    let new_offset = view.line_col_to_offset(text, line, col);
+    if new_offset == active {
+        calc_horiz(view, text, new_offset)
+    } else {
+        (new_offset, Some(col))
+    }
+}
+
+/// Computes the actual desired amount of scrolling (generally slightly
+/// less than the height of the viewport, to allow overlap).
+fn scroll_height(view: &View) -> isize {
+    max(view.scroll_height() as isize - 2, 1)
+}
+
 /// Compute the result of movement on one selection region.
+
+// Note: most of these calls to calc_horiz could be eliminated (just use
+// None). That would cause the column to be calculated lazily on vertical
+// motion, rather than eagerly.
 fn region_movement(m: Movement, r: &SelRegion, view: &View, text: &Rope, modify: bool)
     -> (usize, Option<HorizPos>)
 {
@@ -44,7 +125,7 @@ fn region_movement(m: Movement, r: &SelRegion, view: &View, text: &Rope, modify:
                 if let Some(offset) = text.prev_grapheme_offset(r.end) {
                     calc_horiz(view, text, offset)
                 } else {
-                    (0, None)
+                    (0, r.horiz)
                 }
             } else {
                 calc_horiz(view, text, r.min())
@@ -55,13 +136,65 @@ fn region_movement(m: Movement, r: &SelRegion, view: &View, text: &Rope, modify:
                 if let Some(offset) = text.next_grapheme_offset(r.end) {
                     calc_horiz(view, text, offset)
                 } else {
-                    (r.end, None)
+                    (r.end, r.horiz)
                 }
             } else {
                 calc_horiz(view, text, r.max())
             }
         }
-        //_ => (0, None)
+        Movement::LeftWord => {
+            let mut word_cursor = WordCursor::new(text, r.end);
+            let offset = word_cursor.prev_boundary().unwrap_or(0);
+            calc_horiz(view, text, offset)
+        }
+        Movement::RightWord => {
+            let mut word_cursor = WordCursor::new(text, r.end);
+            let offset = word_cursor.next_boundary().unwrap_or_else(|| text.len());
+            calc_horiz(view, text, offset)
+        }
+        Movement::LeftOfLine => {
+            let line = view.line_of_offset(text, r.end);
+            let offset = view.offset_of_line(text, line);
+            calc_horiz(view, text, offset)
+        }
+        Movement::RightOfLine => {
+            let line = view.line_of_offset(text, r.end);
+            let mut offset = text.len();
+
+            // calculate end of line
+            let next_line_offset = view.offset_of_line(text, line + 1);
+            if line < view.line_of_offset(text, offset) {
+                if let Some(prev) = text.prev_grapheme_offset(next_line_offset) {
+                    offset = prev;
+                }
+            }
+            calc_horiz(view, text, offset)
+        }
+        Movement::Up => vertical_motion(r, view, text, -1, modify),
+        Movement::Down => vertical_motion(r, view, text, 1, modify),
+        Movement::StartOfParagraph => {
+            // Note: TextEdit would start at modify ? r.end : r.min()
+            let mut cursor = Cursor::new(&text, r.end);
+            let offset = cursor.prev::<LinesMetric>().unwrap_or(0);
+            calc_horiz(view, text, offset)
+        }
+        Movement::EndOfParagraph => {
+            // Note: TextEdit would start at modify ? r.end : r.max()
+            let mut offset = r.end;
+            let mut cursor = Cursor::new(&text, offset);
+            if let Some(next_para_offset) = cursor.next::<LinesMetric>() {
+                if cursor.is_boundary::<LinesMetric>() {
+                    if let Some(eol) = text.prev_grapheme_offset(next_para_offset) {
+                        offset = eol;
+                    }
+                }
+            }
+            calc_horiz(view, text, offset)
+        }
+        Movement::UpPage => vertical_motion(r, view, text, -scroll_height(view), modify),
+        Movement::DownPage => vertical_motion(r, view, text, scroll_height(view), modify),
+        Movement::StartOfDocument => calc_horiz(view, text, 0),
+        Movement::EndOfDocument => calc_horiz(view, text, text.len()),
     }
 }
 

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -423,30 +423,10 @@ impl View {
         offset
     }
 
-    // Move up or down by `line_delta` lines and return offset where the
-    // cursor lands.
-    pub fn vertical_motion(&self, text: &Rope, line_delta: isize) -> usize {
-        // This code is quite careful to avoid integer overflow.
-        // TODO: write tests to verify
-        let line = self.line_of_offset(text, self.sel_end);
-        if line_delta < 0 && (-line_delta as usize) > line {
-            return 0;
-        }
-        let line = if line_delta < 0 {
-            line - (-line_delta as usize)
-        } else {
-            line.saturating_add(line_delta as usize)
-        };
-        let n_lines = self.line_of_offset(text, text.len());
-        if line > n_lines {
-            return text.len();
-        }
-        self.line_col_to_offset(text, line, self.cursor_col)
-    }
-
     // use own breaks if present, or text if not (no line wrapping)
 
-    fn line_of_offset(&self, text: &Rope, offset: usize) -> usize {
+    /// Returns the visible line number containing the given offset.
+    pub fn line_of_offset(&self, text: &Rope, offset: usize) -> usize {
         match self.breaks {
             Some(ref breaks) => {
                 breaks.convert_metrics::<BreaksBaseMetric, BreaksMetric>(offset)
@@ -455,13 +435,13 @@ impl View {
         }
     }
 
-    /// Return the byte offset corresponding to the line `line`.
-    fn offset_of_line(&self, text: &Rope, offset: usize) -> usize {
+    /// Returns the byte offset corresponding to the line `line`.
+    pub fn offset_of_line(&self, text: &Rope, line: usize) -> usize {
         match self.breaks {
             Some(ref breaks) => {
-                breaks.convert_metrics::<BreaksMetric, BreaksBaseMetric>(offset)
+                breaks.convert_metrics::<BreaksMetric, BreaksBaseMetric>(line)
             }
-            None => text.offset_of_line(offset)
+            None => text.offset_of_line(line)
         }
     }
 

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -138,7 +138,6 @@ impl View {
         let region = SelRegion {
             start: offset,
             end: offset,
-            // TODO: might want to set horiz to some meaningful value.
             horiz: None,
             affinity: Affinity::default(),
         };
@@ -355,7 +354,7 @@ impl View {
             let region = SelRegion {
                 start: self.sel_start,
                 end: self.sel_end,
-                horiz: Some(self.cursor_col),
+                horiz: None,
                 affinity: Affinity::default(),
             };
             self.selection.add_region(region);


### PR DESCRIPTION
Movements now multi-selection capable: word_left, word_right, up,
down, left_of_line, right_of_line, beginning_of_paragraph,
end_of_paragraph, beginning_of_document, end_of_document, page_up,
page_down.

Also fixed a subtle bug in right_of_line (would move down on next to
last line when last line was empty).

Fixed the bug that beginning_of_paragraph was only going to beginning
of visible line.

Also compute HorizPos lazily (see internal commit)

Progress towards #188