### PR TITLE
[WIP] Experimenting with mpsc

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -43,6 +43,14 @@ version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "memchr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +162,7 @@ name = "xi-rope"
 version = "0.2.0"
 dependencies = [
  "bytecount 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -176,6 +185,7 @@ version = "0.1.0"
 "checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)" = "babb8281da88cba992fa1f4ddec7d63ed96280a1a53ec9b919fd37b53d71e502"
+"checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
 "checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum redox_syscall 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "29dbdfd4b9df8ab31dec47c6087b7b13cbf4a776f335e4de8efba8288dda075b"

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -18,7 +18,6 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::io::Write;
 use std::collections::{BTreeMap, BTreeSet};
-use std::sync::{Arc, Mutex};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::thread;
 use std::mem;
@@ -35,7 +34,7 @@ use word_boundaries::WordCursor;
 use movement::Movement;
 
 use tabs::{ViewIdentifier, TabCtx};
-use rpc::{EditorCommand, EditCommand, GestureType};
+use rpc::{EditCommand, GestureType};
 use run_plugin::{start_plugin, PluginRef, UpdateResponse, PluginEdit};
 
 const FLAG_SELECT: u64 = 2;
@@ -46,6 +45,23 @@ const TAB_SIZE: usize = 4;
 
 // Maximum returned result from plugin get_data RPC.
 const MAX_SIZE_LIMIT: usize = 1024 * 1024;
+
+pub enum EditorCommand<W: Write> {
+    SetPath { file_path: PathBuf },
+    AddView { view_id: String },
+    RemoveView { view_id: String },
+    Edit { view_id: String, edit_command: EditCommand },
+    DoSave { file_path: PathBuf },
+    ApplyPluginEdit { edit: PluginEdit, undo_group: usize },
+    DecRevsInFlight,
+    Render,
+    OnPluginConnect { plugin: PluginRef<W> },
+    PluginNLines { sender: Sender<usize> },
+    PluginGetLine { line: usize, sender: Sender<String> },
+    PluginGetData { offset: usize, max_size: usize, rev: usize, sender: Sender<Option<String>> },
+    PluginSetFgSpans { start: usize, len: usize, spans: Value, rev: usize },
+    PluginAlert { msg: String },
+}
 
 pub struct Editor<W: Write> {
     text: Rope,
@@ -79,7 +95,8 @@ pub struct Editor<W: Write> {
     tab_ctx: TabCtx<W>,
     plugins: Vec<PluginRef<W>>,
     revs_in_flight: usize,
-    receiver: Receiver<EditorCommand>,
+    receiver: Receiver<EditorCommand<W>>,
+    sender: Sender<EditorCommand<W>>,
 }
 
 #[derive(PartialEq, Eq, Clone, Copy)]
@@ -106,7 +123,7 @@ impl EditType {
 
 impl<W: Write + Send + 'static> Editor<W> {
     /// Creates a new `Editor` with a new empty buffer.
-    pub fn new(tab_ctx: TabCtx<W>, initial_view_id: &str) -> Sender<EditorCommand> {
+    pub fn new(tab_ctx: TabCtx<W>, initial_view_id: &str) -> Sender<EditorCommand<W>> {
         Self::with_text(tab_ctx, initial_view_id, "".to_owned())
     }
 
@@ -114,9 +131,10 @@ impl<W: Write + Send + 'static> Editor<W> {
     pub fn with_text(tab_ctx: TabCtx<W>,
                      initial_view_id: &str,
                      text: String)
-                     -> Sender<EditorCommand> {
+                     -> Sender<EditorCommand<W>> {
         let initial_view_id = initial_view_id.to_owned();
         let (tx, rx) = channel();
+        let editor_tx = tx.clone();
         thread::spawn(move || {
             let engine = Engine::new(Rope::from(text));
             let buffer = engine.get_head();
@@ -144,6 +162,7 @@ impl<W: Write + Send + 'static> Editor<W> {
                 plugins: Vec::new(),
                 revs_in_flight: 0,
                 receiver: rx,
+                sender: editor_tx,
             };
 
             editor.mainloop();
@@ -256,9 +275,9 @@ impl<W: Write + Send + 'static> Editor<W> {
     }
 
     // commit the current delta, updating views, plugins, and other invariants as needed
-    fn commit_delta(&mut self,/* self_ref: &Arc<Mutex<Editor<W>>>,*/ author: Option<&str>) {
+    fn commit_delta(&mut self, author: Option<&str>) {
         if self.engine.get_head_rev_id() != self.last_rev_id {
-            self.update_after_revision(/*self_ref, */author);
+            self.update_after_revision(author);
             if let Some((start, end)) = self.new_cursor.take() {
                 self.set_cursor(end, true);
                 self.view.sel_start = start;
@@ -267,8 +286,7 @@ impl<W: Write + Send + 'static> Editor<W> {
     }
 
     // generates a delta from a plugin's response and applies it to the buffer.
-    fn apply_plugin_edit(&mut self,/* self_ref: &Arc<Mutex<Editor<W>>>,*/
-                         edit: PluginEdit, undo_group: usize) {
+    fn apply_plugin_edit(&mut self, edit: PluginEdit, undo_group: usize) {
         let interval = Interval::new_closed_open(edit.start as usize, edit.end as usize);
         let text = Rope::from(&edit.text);
         let rev_len = self.engine.get_rev(edit.rev as usize).unwrap().len();
@@ -284,17 +302,17 @@ impl<W: Write + Send + 'static> Editor<W> {
             self.new_cursor = Some((self.view.sel_start, self.view.sel_end));
         }
 
-        self.commit_delta(/*self_ref, */Some(&edit.author));
+        self.commit_delta(Some(&edit.author));
         self.render();
     }
 
-    fn update_undos(&mut self/*, self_ref: &Arc<Mutex<Editor<W>>>*/) {
+    fn update_undos(&mut self) {
         self.engine.undo(self.undos.clone());
         self.text = self.engine.get_head();
-        self.update_after_revision(/*self_ref, */None);
+        self.update_after_revision(None);
     }
 
-    fn update_after_revision(&mut self,/* self_ref: &Arc<Mutex<Editor<W>>>,*/ author: Option<&str>) {
+    fn update_after_revision(&mut self, author: Option<&str>) {
         let delta = self.engine.delta_rev_head(self.last_rev_id);
         let is_pristine = self.is_pristine();
         self.view.after_edit(&self.text, &delta, is_pristine);
@@ -311,33 +329,31 @@ impl<W: Write + Send + 'static> Editor<W> {
         let undo_group = *self.live_undos.last().unwrap();
 
         //print_err!("delta {}:{} +{} {}", iv.start(), iv.end(), new_len, self.this_edit_type.json_string());
-        // for plugin in &self.plugins {
-        //     self.revs_in_flight += 1;
-        //     let editor = Arc::downgrade(self_ref);
-        //     let text = if new_len < MAX_SIZE_LIMIT {
-        //         Some(self.text.slice_to_string(iv.start(), iv.start() + new_len))
-        //     } else {
-        //         None
-        //     };
-        //     plugin.update(iv.start(), iv.end(), new_len,
-        //                   text.as_ref().map(|s| s.as_str()),
-        //                   self.engine.get_head_rev_id(),
-        //                   self.this_edit_type.json_string(), author,
-        //                   move |response| {
-        //                       if let Some(editor) = editor.upgrade() {
-        //                           let response = response.expect("bad plugin response");
-        //                           match serde_json::from_value::<UpdateResponse>(response) {
-        //                               Ok(UpdateResponse::Edit(edit)) => {
-        //                                   //print_err!("got response {:?}", edit);
-        //                                   editor.lock().unwrap().apply_plugin_edit(&editor, edit, undo_group);
-        //                               }
-        //                               Ok(UpdateResponse::Ack(_)) => (),
-        //                               Err(err) => { print_err!("plugin response json err: {:?}", err); }
-        //             };
-        //             editor.lock().unwrap().dec_revs_in_flight();
-        //         }
-        //     });
-        // }
+        for plugin in &self.plugins {
+            self.revs_in_flight += 1;
+            let editor = self.sender.clone();
+            let text = if new_len < MAX_SIZE_LIMIT {
+                Some(self.text.slice_to_string(iv.start(), iv.start() + new_len))
+            } else {
+                None
+            };
+            plugin.update(iv.start(), iv.end(), new_len,
+                          text.as_ref().map(|s| s.as_str()),
+                          self.engine.get_head_rev_id(),
+                          self.this_edit_type.json_string(), author,
+                          move |response| {
+                            let response = response.expect("bad plugin response");
+                            match serde_json::from_value::<UpdateResponse>(response) {
+                                Ok(UpdateResponse::Edit(edit)) => {
+                                    //print_err!("got response {:?}", edit);
+                                    let _ = editor.send(EditorCommand::ApplyPluginEdit { edit: edit, undo_group: undo_group});
+                                }
+                                Ok(UpdateResponse::Ack(_)) => (),
+                                Err(err) => { print_err!("plugin response json err: {:?}", err); }
+                            };
+                            let _ = editor.send(EditorCommand::DecRevsInFlight);
+                        });
+        }
         self.last_rev_id = self.engine.get_head_rev_id();
     }
 
@@ -681,9 +697,9 @@ impl<W: Write + Send + 'static> Editor<W> {
         self.view.set_dirty();
     }
 
-    fn debug_run_plugin(&mut self, self_ref: &Arc<Mutex<Editor<W>>>) {
+    fn debug_run_plugin(&mut self) {
         print_err!("running plugin");
-        start_plugin(self_ref.clone());
+        start_plugin(self.sender.clone());
     }
 
     pub fn on_plugin_connect(&mut self, plugin_ref: PluginRef<W>) {
@@ -712,21 +728,21 @@ impl<W: Write + Send + 'static> Editor<W> {
         }
     }
 
-    fn do_undo(&mut self/*, self_ref: &Arc<Mutex<Editor<W>>>*/) {
+    fn do_undo(&mut self) {
         if self.cur_undo > 0 {
             self.cur_undo -= 1;
             assert!(self.undos.insert(self.live_undos[self.cur_undo]));
             self.this_edit_type = EditType::Undo;
-            self.update_undos(/*self_ref*/);
+            self.update_undos();
         }
     }
 
-    fn do_redo(&mut self/*, self_ref: &Arc<Mutex<Editor<W>>>*/) {
+    fn do_redo(&mut self) {
         if self.cur_undo < self.live_undos.len() {
             assert!(self.undos.remove(&self.live_undos[self.cur_undo]));
             self.cur_undo += 1;
             self.this_edit_type = EditType::Redo;
-            self.update_undos(/*self_ref*/);
+            self.update_undos();
         }
     }
 
@@ -778,19 +794,29 @@ impl<W: Write + Send + 'static> Editor<W> {
             match cmd {
                 EditorCommand::SetPath { file_path } => self.set_path(file_path),
                 EditorCommand::AddView { view_id } => self.add_view(&view_id),
-                EditorCommand::Edit { view_id, edit_command } => self.do_rpc_with_self_ref(&view_id, edit_command),
+                EditorCommand::Edit { view_id, edit_command } => self.do_rpc(&view_id, edit_command),
                 EditorCommand::DoSave { file_path } => self.do_save(file_path),
                 EditorCommand::RemoveView { view_id } => self.remove_view(&view_id),
+                EditorCommand::ApplyPluginEdit { edit, undo_group } => self.apply_plugin_edit(edit, undo_group),
+                EditorCommand::DecRevsInFlight => self.dec_revs_in_flight(),
                 EditorCommand::Render => self.render(),
+                EditorCommand::OnPluginConnect { plugin } => self.on_plugin_connect(plugin),
+                EditorCommand::PluginNLines { sender } => {
+                    let _ = sender.send(self.plugin_n_lines());
+                },
+                EditorCommand::PluginGetLine { line, sender } => {
+                    let _ = sender.send(self.plugin_get_line(line));
+                },
+                EditorCommand::PluginGetData { offset, max_size, rev, sender } => {
+                    let _ = sender.send(self.plugin_get_data(offset, max_size, rev));
+                },
+                EditorCommand::PluginSetFgSpans { start, len, spans, rev } => self.plugin_set_fg_spans(start, len, &spans, rev),
+                EditorCommand::PluginAlert { msg } => self.plugin_alert(&msg),
             }
         }
     }
 
-    // pub fn do_rpc(self_ref: &Arc<Mutex<Editor<W>>>, view_id: &str, cmd: EditCommand) {
-    //     self_ref.lock().unwrap().do_rpc_with_self_ref(view_id, cmd, self_ref)
-    // }
-
-    fn do_rpc_with_self_ref(&mut self, view_id: &str, cmd: EditCommand) {
+    fn do_rpc(&mut self, view_id: &str, cmd: EditCommand) {
 
         use rpc::EditCommand::*;
 
@@ -851,19 +877,18 @@ impl<W: Write + Send + 'static> Editor<W> {
             }
             Drag { line, column, flags } => self.do_drag(line, column, flags),
             Gesture { line, column, ty } => self.do_gesture(line, column, ty),
-            Undo => self.do_undo(/*self_ref*/),
-            Redo => self.do_redo(/*self_ref*/),
+            Undo => self.do_undo(),
+            Redo => self.do_redo(),
             // TODO: SYNC RETURN
             Cut => {self.do_cut();},
             Copy => {self.do_copy();},
             DebugRewrap => self.debug_rewrap(),
             DebugTestFgSpans => self.debug_test_fg_spans(),
-            // DebugRunPlugin => self.debug_run_plugin(self_ref),
-            _ => (),
+            DebugRunPlugin => self.debug_run_plugin(),
         }
 
         // TODO: could defer this until input quiesces - will this help?
-        self.commit_delta(/*self_ref,*/ None);
+        self.commit_delta(None);
         self.render();
         self.last_edit_type = self.this_edit_type;
         self.gc_undos();
@@ -944,11 +969,6 @@ impl<W: Write + Send + 'static> Editor<W> {
     pub fn plugin_alert(&self, msg: &str) {
         self.tab_ctx.alert(msg);
     }
-}
-
-// wrapper so async methods don't have to return None themselves
-fn async(_: ()) -> Option<Value> {
-    None
 }
 
 fn n_spaces(n: usize) -> &'static str {

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -83,7 +83,7 @@ impl<W: Write + Send + 'static> MainState<W> {
 }
 
 impl<W: Write + Send + 'static> Handler<W> for MainState<W> {
-    fn handle_notification(&mut self, ctx: RpcCtx<W>, method: &str, params: &Value) {
+    fn handle_notification(&mut self, ctx: RpcCtx<W>, method: &str, params: Value) {
         match Request::from_json(method, params) {
             Ok(req) => {
                 let _ = self.handle_req(req, ctx.get_peer());
@@ -93,7 +93,7 @@ impl<W: Write + Send + 'static> Handler<W> for MainState<W> {
         }
     }
 
-    fn handle_request(&mut self, mut ctx: RpcCtx<W>, method: &str, params: &Value) ->
+    fn handle_request(&mut self, mut ctx: RpcCtx<W>, method: &str, params: Value) ->
         Result<Value, Value> {
         match Request::from_json(method, params) {
             Ok(req) => {

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -16,7 +16,6 @@
 
 use std::error;
 use std::fmt;
-use std::path::PathBuf;
 use serde_json::Value;
 use xi_rpc::{dict_get_u64, dict_get_string, arr_get_u64, arr_get_i64};
 
@@ -48,16 +47,6 @@ pub enum CoreCommand {
     NewView { file_path: Option<String> },
     CloseView { view_id: String },
     Save { view_id: String, file_path: String },
-}
-
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub enum EditorCommand {
-    SetPath { file_path: PathBuf },
-    AddView { view_id: String },
-    RemoveView { view_id: String },
-    Edit { view_id: String, edit_command: EditCommand },
-    DoSave { file_path: PathBuf },
-    Render,
 }
 
 /// An enum representing touch and mouse gestures applied to the text.

--- a/rust/core-lib/src/run_plugin.rs
+++ b/rust/core-lib/src/run_plugin.rs
@@ -109,12 +109,12 @@ pub fn start_plugin<W: Write + Send + 'static>(editor: Arc<Mutex<Editor<W>>>) {
 }
 
 impl<W: Write + Send + 'static> Handler<ChildStdin> for PluginRef<W> {
-    fn handle_notification(&mut self, _ctx: RpcCtx<ChildStdin>, method: &str, params: &Value) {
+    fn handle_notification(&mut self, _ctx: RpcCtx<ChildStdin>, method: &str, params: Value) {
         let _ = self.rpc_handler(method, params);
         // TODO: should check None
     }
 
-    fn handle_request(&mut self, _ctx: RpcCtx<ChildStdin>, method: &str, params: &Value) ->
+    fn handle_request(&mut self, _ctx: RpcCtx<ChildStdin>, method: &str, params: Value) ->
         Result<Value, Value> {
         let result = self.rpc_handler(method, params);
         result.ok_or_else(|| Value::String("missing return value".to_string()))
@@ -122,7 +122,7 @@ impl<W: Write + Send + 'static> Handler<ChildStdin> for PluginRef<W> {
 }
 
 impl<W: Write + Send + 'static> PluginRef<W> {
-    fn rpc_handler(&self, method: &str, params: &Value) -> Option<Value> {
+    fn rpc_handler(&self, method: &str, params: Value) -> Option<Value> {
         let editor = {
             self.0.lock().unwrap().editor.upgrade()
         };

--- a/rust/core-lib/src/run_plugin.rs
+++ b/rust/core-lib/src/run_plugin.rs
@@ -18,20 +18,21 @@ use std::io::{BufReader, Write};
 use std::env;
 use std::path::PathBuf;
 use std::process::{Command,Stdio,ChildStdin};
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Arc, Mutex};
+use std::sync::mpsc::{channel, Sender};
 use std::thread;
 use serde_json;
 use serde_json::value::Value;
 
 use xi_rpc::{RpcLoop, RpcPeer, RpcCtx, Handler, Error, dict_get_u64};
-use editor::Editor;
+use editor::EditorCommand;
 
 pub type PluginPeer = RpcPeer<ChildStdin>;
 
 pub struct PluginRef<W: Write>(Arc<Mutex<Plugin<W>>>);
 
 pub struct Plugin<W: Write> {
-    editor: Weak<Mutex<Editor<W>>>,
+    editor: Sender<EditorCommand<W>>,
     peer: PluginPeer,
 }
 
@@ -82,7 +83,7 @@ fn plugin_path() -> PathBuf {
     }
 }
 
-pub fn start_plugin<W: Write + Send + 'static>(editor: Arc<Mutex<Editor<W>>>) {
+pub fn start_plugin<W: Write + Send + 'static>(editor: Sender<EditorCommand<W>>) {
     thread::spawn(move || {
         let pathbuf = plugin_path();
             print_err!("starting plugin at path {:?}", pathbuf);
@@ -97,11 +98,11 @@ pub fn start_plugin<W: Write + Send + 'static>(editor: Arc<Mutex<Editor<W>>>) {
         let peer = looper.get_peer();
         peer.send_rpc_notification("ping", &Value::Array(Vec::new()));
         let plugin = Plugin {
-            editor: Arc::downgrade(&editor),
+            editor: editor.clone(),
             peer: peer,
         };
         let mut plugin_ref = PluginRef(Arc::new(Mutex::new(plugin)));
-        editor.lock().unwrap().on_plugin_connect(plugin_ref.clone());
+        let _ = editor.send(EditorCommand::OnPluginConnect { plugin: plugin_ref.clone() });
         looper.mainloop(|| BufReader::new(child_stdout), &mut plugin_ref);
         let status = child.wait();
         print_err!("child exit = {:?}", status);
@@ -123,57 +124,54 @@ impl<W: Write + Send + 'static> Handler<ChildStdin> for PluginRef<W> {
 
 impl<W: Write + Send + 'static> PluginRef<W> {
     fn rpc_handler(&self, method: &str, params: Value) -> Option<Value> {
-        let editor = {
-            self.0.lock().unwrap().editor.upgrade()
-        };
-        if let Some(editor) = editor {
-            let mut editor = editor.lock().unwrap();
-            match method {
-                // TODO: parse json into enum first, just like front-end RPC
-                // (this will also improve error handling, no panic on malformed request from plugin)
-                "n_lines" => Some(serde_json::to_value(editor.plugin_n_lines() as u64).unwrap()),
-                "get_line" => {
-                    let line = params.as_object().and_then(|dict| dict.get("line").and_then(Value::as_u64)).unwrap();
-                    let result = editor.plugin_get_line(line as usize);
-                    Some(Value::String(result))
-                }
-                "get_data" => {
-                    params.as_object().and_then(|dict|
-                        dict_get_u64(dict, "offset").and_then(|offset|
-                            dict_get_u64(dict, "max_size").and_then(|max_size|
-                                dict_get_u64(dict, "rev").and_then(|rev| {
-                                    let result = editor.plugin_get_data(offset as usize,
-                                            max_size as usize, rev as usize);
-                                    result.map(|s| Value::String(s))
-                                })
-                            )
+        let plugin = self.0.lock().unwrap();
+        let editor = &plugin.editor;
+        match method {
+            // TODO: parse json into enum first, just like front-end RPC
+            // (this will also improve error handling, no panic on malformed request from plugin)
+            "n_lines" => {
+                let (tx, rx) = channel();
+                let _ = editor.send(EditorCommand::PluginNLines { sender: tx });
+                Some(serde_json::to_value(rx.recv().unwrap() as u64).unwrap())
+            },
+            "get_line" => {
+                let line = params.as_object().and_then(|dict| dict.get("line").and_then(Value::as_u64)).unwrap();
+                let (tx, rx) = channel();
+                let _ = editor.send(EditorCommand::PluginGetLine { line: line as usize, sender: tx });
+                Some(Value::String(rx.recv().unwrap()))
+            }
+            "get_data" => {
+                params.as_object().and_then(|dict|
+                    dict_get_u64(dict, "offset").and_then(|offset|
+                        dict_get_u64(dict, "max_size").and_then(|max_size|
+                            dict_get_u64(dict, "rev").and_then(|rev| {
+                                let (tx, rx) = channel();
+                                let _ = editor.send(EditorCommand::PluginGetData { offset: offset as usize, max_size: max_size as usize, rev: rev as usize, sender: tx });
+                                rx.recv().unwrap().map(|s| Value::String(s))
+                            })
                         )
                     )
-                }
-                "set_fg_spans" => {
-                    if let Some(dict) = params.as_object() {
-                        if let (Some(start), Some(len), Some(spans), Some(rev)) =
-                            (dict_get_u64(dict, "start"), dict_get_u64(dict, "len"),
-                                dict.get("spans"), dict_get_u64(dict, "rev")) {
-                            editor.plugin_set_fg_spans(start as usize, len as usize, spans,
-                                rev as usize);
-                        }
-                    }
-                    None
-                }
-                "alert" => {
-                    let msg = params.as_object().and_then(|dict| dict.get("msg").and_then(Value::as_str)).unwrap();
-                    editor.plugin_alert(msg);
-                    None
-                }
-                _ => {
-                    print_err!("unknown plugin callback method: {}", method);
-                    None
-                }
+                )
             }
-        } else {
-            // connection to editor lost
-            None  // TODO: return error value
+            "set_fg_spans" => {
+                if let Some(dict) = params.as_object() {
+                    if let (Some(start), Some(len), Some(spans), Some(rev)) =
+                        (dict_get_u64(dict, "start"), dict_get_u64(dict, "len"),
+                            dict.get("spans"), dict_get_u64(dict, "rev")) {
+                        let _ = editor.send(EditorCommand::PluginSetFgSpans { start: start as usize, len: len as usize, spans: spans.clone(), rev: rev as usize});
+                    }
+                }
+                None
+            }
+            "alert" => {
+                let msg = params.as_object().and_then(|dict| dict.get("msg").and_then(Value::as_str)).unwrap();
+                let _ = editor.send(EditorCommand::PluginAlert { msg: msg.to_owned() });
+                None
+            }
+            _ => {
+                print_err!("unknown plugin callback method: {}", method);
+                None
+            }
         }
     }
 

--- a/rust/plugin-lib/src/plugin_base.rs
+++ b/rust/plugin-lib/src/plugin_base.rs
@@ -200,7 +200,7 @@ fn parse_plugin_request<'a>(method: &str, params: &'a Value) ->
         "ping" => Ok(PluginRequest::Ping),
         "init_buf" => {
             params.as_object().and_then(|dict|
-                if let (Some(buf_size), Some(rev)) = 
+                if let (Some(buf_size), Some(rev)) =
                     (dict_get_u64(dict, "buf_size"), dict_get_u64(dict, "rev")) {
                         Some(PluginRequest::InitBuf {
                             buf_size: buf_size as usize,
@@ -234,8 +234,8 @@ fn parse_plugin_request<'a>(method: &str, params: &'a Value) ->
 struct MyHandler<'a, H: 'a>(&'a mut H);
 
 impl<'a, H: Handler> xi_rpc::Handler<io::Stdout> for MyHandler<'a, H> {
-    fn handle_notification(&mut self, ctx: RpcCtx<io::Stdout>, method: &str, params: &Value) {
-        match parse_plugin_request(method, params) {
+    fn handle_notification(&mut self, ctx: RpcCtx<io::Stdout>, method: &str, params: Value) {
+        match parse_plugin_request(method, &params) {
             Ok(req) => {
                 let _ = self.0.call(&req, PluginCtx(ctx));
                 // TODO: should check None
@@ -244,9 +244,9 @@ impl<'a, H: Handler> xi_rpc::Handler<io::Stdout> for MyHandler<'a, H> {
         }
     }
 
-    fn handle_request(&mut self, ctx: RpcCtx<io::Stdout>, method: &str, params: &Value) ->
+    fn handle_request(&mut self, ctx: RpcCtx<io::Stdout>, method: &str, params: Value) ->
         Result<Value, Value> {
-        match parse_plugin_request(method, params) {
+        match parse_plugin_request(method, &params) {
             Ok(req) => {
                 let result = self.0.call(&req, PluginCtx(ctx));
                 result.ok_or_else(|| Value::String("return value missing".to_string()))


### PR DESCRIPTION
This is far from complete, but is just a sample proof of concepts of using mpsc rather than using `Arc<Mutex<...>>`.

This will require a bit of reworking with plugins as `self_ref` can no longer be used.

Using mpsc, each `Editor` will run in its own thread. This means we can fire off messages to an `Editor` without worrying about any operation blocking another `Editor`.

For cases where we need a synchronous response, we can create another mpsc channel that can be sent through the channel itself. The receiving end will send back the value we need.

I did have to make messages own Strings and Paths, I am unsure if we can make it just use references or not. This was just a quick and dirty experiment.