### PR TITLE
Fix valid lines cache for scroll updates (Fixes #241)

### DIFF
--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -299,6 +299,7 @@ impl View {
 
         let mut ops = Vec::new();
         let mut line = 0;
+        let mut valid_ranges = Vec::new();
         for (start, end) in self.valid_lines.minus_one_range(first_line, last_line) {
             // TODO: this has some duplication with send_update in the non-dirty case.
             if start > line {
@@ -317,6 +318,7 @@ impl View {
             }
             ops.push(self.build_update_op("ins", Some(rendered_lines), end - start));
             ops.push(self.build_update_op("skip", None, end - start));
+            valid_ranges.push((start, end));
             line = end;
         }
         if line == 0 {
@@ -331,7 +333,9 @@ impl View {
             "pristine": self.pristine,
         });
         tab_ctx.update_view(&self.view_id, &params);
-        self.valid_lines.union_one_range(first_line, last_line);
+        for range in valid_ranges {
+            self.valid_lines.union_one_range(range.0, range.1);
+        }
     }
 
     fn build_update_op(&self, op: &str, lines: Option<Vec<Value>>, n: usize) -> Value {


### PR DESCRIPTION
Fixes #241

The bug was in `send_update_for_scroll` in `view.rs`.

(I have ignored the scroll slop in the following examples)

When first requesting `[0, 10]`, the lines `[0, 10]` will go into `valid_lines`. When requesting `[100000,100010]`, all lines not in `valid_lines` will be send, i.e. `[10, 100010]`. However, only  `[100000,100010]` will make it into `valid_lines`. That is, the next request of `[100001,100011]` will send lines `[10, 100000]` (because not added to the line cache previously) and `[100010,100011]`.

(`valid_lines` ... are  Ranges of lines held by the line cache in the front-end that are considered valid)

Re-running @bvinc test (thanks for the excellent instructions to reproduce the issue)

```bash
% cat test1
{"id":0,"method":"new_view","params":{ "file_path": "/Users/markus/Downloads/big.txt"}}
{"method":"edit","params": {"view_id": "view-id-1", "method": "scroll", "params":[0,10] }}
{"method":"edit","params": {"view_id": "view-id-1", "method": "scroll", "params":[100000,100010] }}

% cat test1 | cargo run | wc
       5  820735 7827012
```

```bash
% cat test1
{"id":0,"method":"new_view","params":{ "file_path": "/Users/markus/Downloads/big.txt"}}
{"method":"edit","params": {"view_id": "view-id-1", "method": "scroll", "params":[0,10] }}
{"method":"edit","params": {"view_id": "view-id-1", "method": "scroll", "params":[100000,100010] }}
{"method":"edit","params": {"view_id": "view-id-1", "method": "scroll", "params":[100001,100011] }}
{"method":"edit","params": {"view_id": "view-id-1", "method": "scroll", "params":[100002,100012] }}
{"method":"edit","params": {"view_id": "view-id-1", "method": "scroll", "params":[100003,100013] }}

% cat test1 | cargo run | wc
       8  820771 7827847
```

I cannot use `self.valid_lines.union_one_range` in the for loop directly (mutable borrow, but immutable borrow happens before), which is why I had to create a temporary Vec. If there is a better way then creating this temporary variable, I am happy to hear about it!