### PR TITLE
Fix end-of-line movement when on last line (Fixes #261)

### DIFF
--- a/rust/core-lib/src/movement.rs
+++ b/rust/core-lib/src/movement.rs
@@ -176,6 +176,8 @@ fn region_movement(m: Movement, r: &SelRegion, view: &View, text: &Rope, modify:
                     if let Some(eol) = text.prev_grapheme_offset(next_para_offset) {
                         offset = eol;
                     }
+                } else if cursor.pos() == text.len() {
+                    offset = text.len();
                 }
             }
             (offset, None)


### PR DESCRIPTION
Xi used to go to one grapheme before the next discontinuity for LineMetrics.
This is not correct when on the last line.