### PR TITLE
Rationalize file_name state, plus tests

### DIFF
--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -169,7 +169,8 @@ impl<W: Write + Send + 'static> Editor<W> {
         self.views.len() > 0
     }
 
-    pub fn set_path<P: AsRef<Path>>(&mut self, path: P) {
+    /// should only ever be called from `BufferContainerRef::set_path`
+    pub fn _set_path<P: AsRef<Path>>(&mut self, path: P) {
         self.path = Some(path.as_ref().to_owned());
     }
 
@@ -603,7 +604,6 @@ impl<W: Write + Send + 'static> Editor<W> {
         }
         // TODO: we should probably bubble up this error now. in the meantime always set path,
         // because the caller has updated the open_files list
-        self.path = Some(path.as_ref().to_owned());
         self.pristine_rev_id = self.last_rev_id;
         self.view.set_pristine();
         self.view.set_dirty();

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -170,6 +170,7 @@ impl<W: Write + Send + 'static> Editor<W> {
     }
 
     /// should only ever be called from `BufferContainerRef::set_path`
+    #[doc(hidden)]
     pub fn _set_path<P: AsRef<Path>>(&mut self, path: P) {
         self.path = Some(path.as_ref().to_owned());
     }

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -261,7 +261,7 @@ impl<W: Write + Send + 'static> Documents<W> {
 
         match cmd {
             CloseView { view_id } => {
-                self.close_view(&view_id.to_owned());
+                self.do_close_view(&view_id.to_owned());
                 None
             },
 
@@ -308,7 +308,7 @@ impl<W: Write + Send + 'static> Documents<W> {
         json!(view_id)
     }
 
-    fn close_view(&mut self, view_id: &ViewIdentifier) {
+    fn do_close_view(&mut self, view_id: &ViewIdentifier) {
         self.buffers.close_view(view_id);
     }
 
@@ -337,7 +337,7 @@ impl<W: Write + Send + 'static> Documents<W> {
                     self.buffers.add_editor(view_id, &buffer_id, ed, Some(path));
                 }
             }
-        }; 
+        }
     }
 
     /// Adds a new view to an existing editor instance.
@@ -497,7 +497,7 @@ mod tests {
         container_ref.add_editor(&view_id_1, &buf_id_1, editor, None);
         assert_eq!(container_ref.lock().editors.len(), 1);
 
-        // save this somewhere:
+        // set path (as if on save)
         container_ref.set_path(&path_1, &view_id_1);
         assert_eq!(container_ref.has_open_file(&path_1), true);
         assert_eq!(
@@ -521,5 +521,14 @@ mod tests {
         assert_eq!(container_ref.lock().editors.len(), 2);
         assert_eq!(container_ref.has_open_file(&path_1), true);
         assert_eq!(container_ref.has_open_file(&path_2), true);
+
+        container_ref.close_view(&view_id_1);
+        assert_eq!(container_ref.lock().editors.len(), 1);
+        assert_eq!(container_ref.has_open_file(&path_2), false);
+        assert_eq!(container_ref.has_open_file(&path_1), true);
+
+        container_ref.close_view(&view_id_2);
+        assert_eq!(container_ref.has_open_file(&path_2), false);
+        assert_eq!(container_ref.lock().editors.len(), 0);
     }
 }


### PR DESCRIPTION
This is progress towards the next step of plugins stuff, but can stand alone as a PR.

- it fixes an issue where, if we failed to open an existing file, we would create an empty buffer associated with that file's path, which could cause data loss.

- it cleans up lifecycle stuff a bunch, moving more responsibility into the `BufferContainer` types. Most importantly, there is now a single function responsible for updating a buffer's associated filepath. (This will enable syntax-specific plugin activations).

- It adds a test for some basic file saving behaviour.