### PR TITLE
Refactor Engine, fixes #256

### DIFF
--- a/rust/rope/src/delta.rs
+++ b/rust/rope/src/delta.rs
@@ -259,7 +259,7 @@ impl<N: NodeInfo> InsertDelta<N> {
 
     /// Return a Subset containing the inserted ranges.
     ///
-    /// `d.inserted_subset().delete_in_string(d.apply_to_string(s)) == s`
+    /// `d.inserted_subset().delete_from_string(d.apply_to_string(s)) == s`
     pub fn inserted_subset(&self) -> Subset {
         let mut sb = SubsetBuilder::new();
         let mut x = 0;
@@ -456,7 +456,7 @@ mod tests {
         let d = Delta::simple_edit(Interval::new_closed_open(1, 9), Rope::from("era"), 11);
         let (d1, ss) = d.factor();
         assert_eq!("heraello world", d1.apply_to_string("hello world"));
-        assert_eq!("hld", ss.delete_in_string("hello world"));
+        assert_eq!("hld", ss.delete_from_string("hello world"));
     }
 
     #[test]
@@ -476,7 +476,7 @@ mod tests {
     fn inserted_subset() {
         let d = Delta::simple_edit(Interval::new_closed_open(1, 9), Rope::from("era"), 11);
         let (d1, _ss) = d.factor();
-        assert_eq!("hello world", d1.inserted_subset().delete_in_string("heraello world"));
+        assert_eq!("hello world", d1.inserted_subset().delete_from_string("heraello world"));
     }
 
     #[test]

--- a/rust/rope/src/delta.rs
+++ b/rust/rope/src/delta.rs
@@ -22,10 +22,16 @@ use subset::{Subset, SubsetBuilder};
 use std::cmp::min;
 
 enum DeltaElement<N: NodeInfo> {
+    /// Represents the text in a range of the base document. Includes beginning, excludes end.
     Copy(usize, usize),  // note: for now, we lose open/closed info at interval endpoints
     Insert(Node<N>),
 }
 
+/// Represents an entire new document as a sequence of sections copied from
+/// the old document and of new inserted text.
+///
+/// For example, Editing "abcd" into "acde" could be represented as:
+/// `[Copy(0,1),Copy(2,4),Insert("e")]`
 pub struct Delta<N: NodeInfo> {
     els: Vec<DeltaElement<N>>,
     base_len: usize,

--- a/rust/rope/src/delta.rs
+++ b/rust/rope/src/delta.rs
@@ -22,13 +22,15 @@ use subset::{Subset, SubsetBuilder};
 use std::cmp::min;
 
 enum DeltaElement<N: NodeInfo> {
-    /// Represents the text in a range of the base document. Includes beginning, excludes end.
+    /// Represents a range of text in the base document. Includes beginning, excludes end.
     Copy(usize, usize),  // note: for now, we lose open/closed info at interval endpoints
     Insert(Node<N>),
 }
 
-/// Represents an entire new document as a sequence of sections copied from
-/// the old document and of new inserted text.
+/// Represents changes to a document by describing the new document as a
+/// sequence of sections copied from the old document and of new inserted
+/// text. Deletions are represented by gaps in the ranges copied from the old
+/// document.
 ///
 /// For example, Editing "abcd" into "acde" could be represented as:
 /// `[Copy(0,1),Copy(2,4),Insert("e")]`

--- a/rust/rope/src/delta.rs
+++ b/rust/rope/src/delta.rs
@@ -182,10 +182,15 @@ impl<N: NodeInfo> Delta<N> {
                 els = init;
             }
         }
-        (Interval::new_closed_open(iv_start, iv_end), Delta::els_len(els))
+        (Interval::new_closed_open(iv_start, iv_end), Delta::new_document_len(els))
     }
 
-    fn els_len(els: &[DeltaElement<N>]) -> usize {
+    /// Returns the length of the new document given the internal
+    /// representation of it. In other words, the length of the transformed
+    /// string after this Delta is applied.
+    ///
+    /// d.apply(r).len() == new_document_len(d.els)
+    fn new_document_len(els: &[DeltaElement<N>]) -> usize {
         els.iter().fold(0, |sum, el|
             sum + match *el {
                 DeltaElement::Copy(beg, end) => end - beg,

--- a/rust/rope/src/engine.rs
+++ b/rust/rope/src/engine.rs
@@ -89,20 +89,20 @@ impl Engine {
         let mut from_union = Cow::Borrowed(&self.revs[rev_index].from_union);
         for rev in &self.revs[rev_index + 1..] {
             if let Edit { ref inserts, .. } = rev.edit {
-                if !inserts.is_trivial() {
-                    from_union = Cow::Owned(from_union.transform_intersect(inserts));
+                if !inserts.is_empty() {
+                    from_union = Cow::Owned(from_union.transform_union(inserts));
                 }
             }
         }
-        from_union.apply(&self.union_str)
+        from_union.delete_in(&self.union_str)
     }
 
     fn get_subset_from_index(&self, rev_index: usize) -> Cow<Subset> {
         let mut from_union = Cow::Borrowed(&self.revs[rev_index].from_union);
         for rev in &self.revs[rev_index + 1..] {
             if let Edit { ref inserts, .. } = rev.edit {
-                if !inserts.is_trivial() {
-                    from_union = Cow::Owned(from_union.transform_intersect(inserts));
+                if !inserts.is_empty() {
+                    from_union = Cow::Owned(from_union.transform_union(inserts));
                 }
             }
         }
@@ -132,8 +132,8 @@ impl Engine {
         let mut prev_from_union = Cow::Borrowed(&rev.from_union);
         for r in &self.revs[ix + 1..] {
             if let Edit { ref inserts, .. } = r.edit {
-                if !inserts.is_trivial() {
-                    prev_from_union = Cow::Owned(prev_from_union.transform_intersect(inserts));
+                if !inserts.is_empty() {
+                    prev_from_union = Cow::Owned(prev_from_union.transform_union(inserts));
                 }
             }
         }
@@ -150,30 +150,30 @@ impl Engine {
         let mut new_deletes = deletes.transform_expand(&rev.from_union);
         for r in &self.revs[ix + 1..] {
             if let Edit { priority, ref inserts, .. } = r.edit {
-                if !inserts.is_trivial() {
+                if !inserts.is_empty() {
                     let after = new_priority >= priority;  // should never be ==
                     union_ins_delta = union_ins_delta.transform_expand(inserts, r.union_str_len, after);
                     new_deletes = new_deletes.transform_expand(inserts);
                 }
             }
         }
-        let new_inserts = union_ins_delta.invert_insert();
-        if !new_inserts.is_trivial() {
+        let new_inserts = union_ins_delta.inserted_subset();
+        if !new_inserts.is_empty() {
             new_deletes = new_deletes.transform_expand(&new_inserts);
         }
         let new_union_str = union_ins_delta.apply(&self.union_str);
         let undone = self.get_current_undo().map_or(false, |undos| undos.contains(&undo_group));
         let mut new_from_union = Cow::Borrowed(&self.revs.last().unwrap().from_union);
         if undone {
-            if !new_inserts.is_trivial() {
-                new_from_union = Cow::Owned(new_from_union.transform_intersect(&new_inserts));
+            if !new_inserts.is_empty() {
+                new_from_union = Cow::Owned(new_from_union.transform_union(&new_inserts));
             }
         } else {
-            if !new_inserts.is_trivial() {
+            if !new_inserts.is_empty() {
                 new_from_union = Cow::Owned(new_from_union.transform_expand(&new_inserts));
             }
-            if !new_deletes.is_trivial() {
-                new_from_union = Cow::Owned(new_from_union.intersect(&new_deletes));
+            if !new_deletes.is_empty() {
+                new_from_union = Cow::Owned(new_from_union.union(&new_deletes));
             }
         }
         (Revision {
@@ -205,15 +205,15 @@ impl Engine {
         for rev in &self.revs {
             if let Edit { ref undo_group, ref inserts, ref deletes, .. } = rev.edit {
                 if groups.contains(undo_group) {
-                    if !inserts.is_trivial() {
-                        from_union = from_union.transform_intersect(inserts);
+                    if !inserts.is_empty() {
+                        from_union = from_union.transform_union(inserts);
                     }
                 } else {
-                    if !inserts.is_trivial() {
+                    if !inserts.is_empty() {
                         from_union = from_union.transform_expand(inserts);
                     }
-                    if !deletes.is_trivial() {
-                        from_union = from_union.intersect(deletes);
+                    if !deletes.is_empty() {
+                        from_union = from_union.union(deletes);
                     }
                 }
             }
@@ -262,43 +262,43 @@ impl Engine {
                 if let Edit { ref undo_group, ref inserts, ref deletes, .. } = rev.edit {
                     if !retain_revs.contains(&rev.rev_id) && gc_groups.contains(undo_group) {
                         if cur_undo.map_or(false, |undos| undos.contains(undo_group)) {
-                            if !inserts.is_trivial() {
-                                gc_dels = gc_dels.transform_intersect(inserts);
+                            if !inserts.is_empty() {
+                                gc_dels = gc_dels.transform_union(inserts);
                             }
                         } else {
-                            if !inserts.is_trivial() {
+                            if !inserts.is_empty() {
                                 gc_dels = gc_dels.transform_expand(inserts);
                             }
-                            if !deletes.is_trivial() {
-                                gc_dels = gc_dels.intersect(deletes);
+                            if !deletes.is_empty() {
+                                gc_dels = gc_dels.union(deletes);
                             }
                         }
-                    } else if !inserts.is_trivial() {
+                    } else if !inserts.is_empty() {
                         gc_dels = gc_dels.transform_expand(inserts);
                     }
                 }
             }
         }
-        if !gc_dels.is_trivial() {
-            self.union_str = gc_dels.apply(&self.union_str);
+        if !gc_dels.is_empty() {
+            self.union_str = gc_dels.delete_in(&self.union_str);
         }
         let old_revs = std::mem::replace(&mut self.revs, Vec::new());
         for rev in old_revs.into_iter().rev() {
             match rev.edit {
                 Edit { priority, undo_group, inserts, deletes } => {
-                    let new_gc_dels = if inserts.is_trivial() {
+                    let new_gc_dels = if inserts.is_empty() {
                         None
                     } else {
                         Some(inserts.transform_shrink(&gc_dels))
                     };
                     if retain_revs.contains(&rev.rev_id) || !gc_groups.contains(&undo_group) {
-                        let (inserts, deletes, from_union, len) = if gc_dels.is_trivial() {
+                        let (inserts, deletes, from_union, len) = if gc_dels.is_empty() {
                             (inserts, deletes, rev.from_union, rev.union_str_len)
                         } else {
                             (gc_dels.transform_shrink(&inserts),
                                 gc_dels.transform_shrink(&deletes),
                                 gc_dels.transform_shrink(&rev.from_union),
-                                gc_dels.len(rev.union_str_len))
+                                gc_dels.len_after_delete(rev.union_str_len))
                         };
                         self.revs.push(Revision {
                             rev_id: rev.rev_id,
@@ -320,11 +320,11 @@ impl Engine {
                     // We're super-aggressive about dropping these; after gc, the history
                     // of which undos were used to compute from_union in edits may be lost.
                     if retain_revs.contains(&rev.rev_id) {
-                        let (from_union, len) = if gc_dels.is_trivial() {
+                        let (from_union, len) = if gc_dels.is_empty() {
                             (rev.from_union, rev.union_str_len)
                         } else {
                             (gc_dels.transform_shrink(&rev.from_union),
-                                gc_dels.len(rev.union_str_len))
+                                gc_dels.len_after_delete(rev.union_str_len))
                         };
                         self.revs.push(Revision {
                             rev_id: rev.rev_id,

--- a/rust/rope/src/engine.rs
+++ b/rust/rope/src/engine.rs
@@ -86,12 +86,12 @@ impl Engine {
     }
 
     /// Get the contents of the document at a given revision number
-    fn get_rev_from_index(&self, rev_index: usize) -> Rope {
-        self.get_subset_from_index(rev_index).delete_from(&self.union_str)
+    fn rev_content_for_index(&self, rev_index: usize) -> Rope {
+        self.deletes_from_union_for_index(rev_index).delete_from(&self.union_str)
     }
 
     /// Get the Subset to delete from the current union string in order to obtain a revision's content
-    fn get_subset_from_index(&self, rev_index: usize) -> Cow<Subset> {
+    fn deletes_from_union_for_index(&self, rev_index: usize) -> Cow<Subset> {
         let mut deletes_from_union = Cow::Borrowed(&self.revs[rev_index].deletes_from_union);
         for rev in &self.revs[rev_index + 1..] {
             if let Edit { ref inserts, .. } = rev.edit {
@@ -110,12 +110,12 @@ impl Engine {
 
     /// Get text of head revision.
     pub fn get_head(&self) -> Rope {
-        self.get_rev_from_index(self.revs.len() - 1)
+        self.rev_content_for_index(self.revs.len() - 1)
     }
 
     /// Get text of a given revision, if it can be found.
     pub fn get_rev(&self, rev: usize) -> Option<Rope> {
-        self.find_rev(rev).map(|rev_index| self.get_rev_from_index(rev_index))
+        self.find_rev(rev).map(|rev_index| self.rev_content_for_index(rev_index))
     }
 
     /// A delta that, when applied to previous head, results in the current head. Panics
@@ -229,8 +229,8 @@ impl Engine {
     }
 
     pub fn is_equivalent_revision(&self, base_rev: usize, other_rev: usize) -> bool {
-        let base_subset = self.find_rev(base_rev).map(|rev_index| self.get_subset_from_index(rev_index));
-        let other_subset = self.find_rev(other_rev).map(|rev_index| self.get_subset_from_index(rev_index));
+        let base_subset = self.find_rev(base_rev).map(|rev_index| self.deletes_from_union_for_index(rev_index));
+        let other_subset = self.find_rev(other_rev).map(|rev_index| self.deletes_from_union_for_index(rev_index));
 
         base_subset.is_some() && base_subset == other_subset
     }

--- a/rust/rope/src/engine.rs
+++ b/rust/rope/src/engine.rs
@@ -33,7 +33,7 @@ pub struct Engine {
 
 struct Revision {
     rev_id: usize,
-    from_union: Subset,
+    deletes_from_union: Subset,
     union_str_len: usize,
     edit: Contents,
 }
@@ -56,7 +56,7 @@ impl Engine {
     pub fn new(initial_contents: Rope) -> Engine {
         let rev = Revision {
             rev_id: 0,
-            from_union: Subset::default(),
+            deletes_from_union: Subset::default(),
             union_str_len: initial_contents.len(),
             edit: Undo { groups: BTreeSet::default() },
         };
@@ -86,27 +86,27 @@ impl Engine {
     }
 
     fn get_rev_from_index(&self, rev_index: usize) -> Rope {
-        let mut from_union = Cow::Borrowed(&self.revs[rev_index].from_union);
+        let mut deletes_from_union = Cow::Borrowed(&self.revs[rev_index].deletes_from_union);
         for rev in &self.revs[rev_index + 1..] {
             if let Edit { ref inserts, .. } = rev.edit {
                 if !inserts.is_empty() {
-                    from_union = Cow::Owned(from_union.transform_union(inserts));
+                    deletes_from_union = Cow::Owned(deletes_from_union.transform_union(inserts));
                 }
             }
         }
-        from_union.delete_in(&self.union_str)
+        deletes_from_union.delete_in(&self.union_str)
     }
 
     fn get_subset_from_index(&self, rev_index: usize) -> Cow<Subset> {
-        let mut from_union = Cow::Borrowed(&self.revs[rev_index].from_union);
+        let mut deletes_from_union = Cow::Borrowed(&self.revs[rev_index].deletes_from_union);
         for rev in &self.revs[rev_index + 1..] {
             if let Edit { ref inserts, .. } = rev.edit {
                 if !inserts.is_empty() {
-                    from_union = Cow::Owned(from_union.transform_union(inserts));
+                    deletes_from_union = Cow::Owned(deletes_from_union.transform_union(inserts));
                 }
             }
         }
-        from_union
+        deletes_from_union
     }
 
     /// Get revision id of head revision.
@@ -129,7 +129,7 @@ impl Engine {
     pub fn delta_rev_head(&self, base_rev: usize) -> Delta<RopeInfo> {
         let ix = self.find_rev(base_rev).expect("base revision not found");
         let rev = &self.revs[ix];
-        let mut prev_from_union = Cow::Borrowed(&rev.from_union);
+        let mut prev_from_union = Cow::Borrowed(&rev.deletes_from_union);
         for r in &self.revs[ix + 1..] {
             if let Edit { ref inserts, .. } = r.edit {
                 if !inserts.is_empty() {
@@ -138,7 +138,7 @@ impl Engine {
             }
         }
         let head_rev = &self.revs.last().unwrap();
-        Delta::synthesize(&self.union_str, &prev_from_union, &head_rev.from_union)
+        Delta::synthesize(&self.union_str, &prev_from_union, &head_rev.deletes_from_union)
     }
 
     fn mk_new_rev(&self, new_priority: usize, undo_group: usize,
@@ -146,8 +146,8 @@ impl Engine {
         let ix = self.find_rev(base_rev).expect("base revision not found");
         let rev = &self.revs[ix];
         let (ins_delta, deletes) = delta.factor();
-        let mut union_ins_delta = ins_delta.transform_expand(&rev.from_union, rev.union_str_len, true);
-        let mut new_deletes = deletes.transform_expand(&rev.from_union);
+        let mut union_ins_delta = ins_delta.transform_expand(&rev.deletes_from_union, rev.union_str_len, true);
+        let mut new_deletes = deletes.transform_expand(&rev.deletes_from_union);
         for r in &self.revs[ix + 1..] {
             if let Edit { priority, ref inserts, .. } = r.edit {
                 if !inserts.is_empty() {
@@ -163,7 +163,7 @@ impl Engine {
         }
         let new_union_str = union_ins_delta.apply(&self.union_str);
         let undone = self.get_current_undo().map_or(false, |undos| undos.contains(&undo_group));
-        let mut new_from_union = Cow::Borrowed(&self.revs.last().unwrap().from_union);
+        let mut new_from_union = Cow::Borrowed(&self.revs.last().unwrap().deletes_from_union);
         if undone {
             if !new_inserts.is_empty() {
                 new_from_union = Cow::Owned(new_from_union.transform_union(&new_inserts));
@@ -178,7 +178,7 @@ impl Engine {
         }
         (Revision {
             rev_id: self.rev_id_counter,
-            from_union: new_from_union.into_owned(),
+            deletes_from_union: new_from_union.into_owned(),
             union_str_len: new_union_str.len(),
             edit: Edit {
                 priority: new_priority,
@@ -201,26 +201,26 @@ impl Engine {
     // recompute the prefix up to where the history diverges, but it's not clear that's
     // even worth the code complexity.
     fn compute_undo(&self, groups: BTreeSet<usize>) -> Revision {
-        let mut from_union = Subset::default();
+        let mut deletes_from_union = Subset::default();
         for rev in &self.revs {
             if let Edit { ref undo_group, ref inserts, ref deletes, .. } = rev.edit {
                 if groups.contains(undo_group) {
                     if !inserts.is_empty() {
-                        from_union = from_union.transform_union(inserts);
+                        deletes_from_union = deletes_from_union.transform_union(inserts);
                     }
                 } else {
                     if !inserts.is_empty() {
-                        from_union = from_union.transform_expand(inserts);
+                        deletes_from_union = deletes_from_union.transform_expand(inserts);
                     }
                     if !deletes.is_empty() {
-                        from_union = from_union.union(deletes);
+                        deletes_from_union = deletes_from_union.union(deletes);
                     }
                 }
             }
         }
         Revision {
             rev_id: self.rev_id_counter,
-            from_union: from_union,
+            deletes_from_union: deletes_from_union,
             union_str_len: self.union_str.len(),
             edit: Undo {
                 groups: groups
@@ -292,17 +292,17 @@ impl Engine {
                         Some(inserts.transform_shrink(&gc_dels))
                     };
                     if retain_revs.contains(&rev.rev_id) || !gc_groups.contains(&undo_group) {
-                        let (inserts, deletes, from_union, len) = if gc_dels.is_empty() {
-                            (inserts, deletes, rev.from_union, rev.union_str_len)
+                        let (inserts, deletes, deletes_from_union, len) = if gc_dels.is_empty() {
+                            (inserts, deletes, rev.deletes_from_union, rev.union_str_len)
                         } else {
                             (gc_dels.transform_shrink(&inserts),
                                 gc_dels.transform_shrink(&deletes),
-                                gc_dels.transform_shrink(&rev.from_union),
+                                gc_dels.transform_shrink(&rev.deletes_from_union),
                                 gc_dels.len_after_delete(rev.union_str_len))
                         };
                         self.revs.push(Revision {
                             rev_id: rev.rev_id,
-                            from_union: from_union,
+                            deletes_from_union: deletes_from_union,
                             union_str_len: len,
                             edit: Edit {
                                 priority: priority,
@@ -318,17 +318,17 @@ impl Engine {
                 }
                 Undo { groups } => {
                     // We're super-aggressive about dropping these; after gc, the history
-                    // of which undos were used to compute from_union in edits may be lost.
+                    // of which undos were used to compute deletes_from_union in edits may be lost.
                     if retain_revs.contains(&rev.rev_id) {
-                        let (from_union, len) = if gc_dels.is_empty() {
-                            (rev.from_union, rev.union_str_len)
+                        let (deletes_from_union, len) = if gc_dels.is_empty() {
+                            (rev.deletes_from_union, rev.union_str_len)
                         } else {
-                            (gc_dels.transform_shrink(&rev.from_union),
+                            (gc_dels.transform_shrink(&rev.deletes_from_union),
                                 gc_dels.len_after_delete(rev.union_str_len))
                         };
                         self.revs.push(Revision {
                             rev_id: rev.rev_id,
-                            from_union: from_union,
+                            deletes_from_union: deletes_from_union,
                             union_str_len: len,
                             edit: Undo {
                                 groups: &groups - gc_groups,

--- a/rust/rope/src/engine.rs
+++ b/rust/rope/src/engine.rs
@@ -85,18 +85,12 @@ impl Engine {
         None
     }
 
+    /// Get the contents of the document at a given revision number
     fn get_rev_from_index(&self, rev_index: usize) -> Rope {
-        let mut deletes_from_union = Cow::Borrowed(&self.revs[rev_index].deletes_from_union);
-        for rev in &self.revs[rev_index + 1..] {
-            if let Edit { ref inserts, .. } = rev.edit {
-                if !inserts.is_empty() {
-                    deletes_from_union = Cow::Owned(deletes_from_union.transform_union(inserts));
-                }
-            }
-        }
-        deletes_from_union.delete_in(&self.union_str)
+        self.get_subset_from_index(rev_index).delete_in(&self.union_str)
     }
 
+    /// Get the Subset to delete from the current union string in order to obtain a revision's content
     fn get_subset_from_index(&self, rev_index: usize) -> Cow<Subset> {
         let mut deletes_from_union = Cow::Borrowed(&self.revs[rev_index].deletes_from_union);
         for rev in &self.revs[rev_index + 1..] {

--- a/rust/rope/src/engine.rs
+++ b/rust/rope/src/engine.rs
@@ -87,7 +87,7 @@ impl Engine {
 
     /// Get the contents of the document at a given revision number
     fn get_rev_from_index(&self, rev_index: usize) -> Rope {
-        self.get_subset_from_index(rev_index).delete_in(&self.union_str)
+        self.get_subset_from_index(rev_index).delete_from(&self.union_str)
     }
 
     /// Get the Subset to delete from the current union string in order to obtain a revision's content
@@ -274,7 +274,7 @@ impl Engine {
             }
         }
         if !gc_dels.is_empty() {
-            self.union_str = gc_dels.delete_in(&self.union_str);
+            self.union_str = gc_dels.delete_from(&self.union_str);
         }
         let old_revs = std::mem::replace(&mut self.revs, Vec::new());
         for rev in old_revs.into_iter().rev() {

--- a/rust/rope/src/subset.rs
+++ b/rust/rope/src/subset.rs
@@ -55,7 +55,7 @@ impl SubsetBuilder {
 }
 
 impl Subset {
-    // mostly for testing
+    /// Mostly for testing.
     pub fn delete_from_string(&self, s: &str) -> String {
         let mut result = String::new();
         for (b, e) in self.complement_iter(s.len()) {
@@ -66,6 +66,7 @@ impl Subset {
 
     // Maybe Subset should be a pure data structure and this method should
     // be a method of Node.
+    /// Builds a version of `s` with all the elements in this `Subset` deleted from it.
     pub fn delete_from<N: NodeInfo>(&self, s: &Node<N>) -> Node<N> {
         let mut b = TreeBuilder::new();
         for (beg, end) in self.complement_iter(s.len()) {

--- a/rust/rope/src/subset.rs
+++ b/rust/rope/src/subset.rs
@@ -56,7 +56,7 @@ impl SubsetBuilder {
 
 impl Subset {
     // mostly for testing
-    pub fn delete_in_string(&self, s: &str) -> String {
+    pub fn delete_from_string(&self, s: &str) -> String {
         let mut result = String::new();
         for (b, e) in self.complement_iter(s.len()) {
             result.push_str(&s[b..e]);
@@ -66,7 +66,7 @@ impl Subset {
 
     // Maybe Subset should be a pure data structure and this method should
     // be a method of Node.
-    pub fn delete_in<N: NodeInfo>(&self, s: &Node<N>) -> Node<N> {
+    pub fn delete_from<N: NodeInfo>(&self, s: &Node<N>) -> Node<N> {
         let mut b = TreeBuilder::new();
         for (beg, end) in self.complement_iter(s.len()) {
             s.push_subseq(&mut b, Interval::new_closed_open(beg, end));
@@ -76,7 +76,7 @@ impl Subset {
 
     /// The length of the resulting sequence after deleting this subset.
     ///
-    /// `self.delete_in_string(s).len() = self.len(s.len())`
+    /// `self.delete_from_string(s).len() = self.len(s.len())`
     pub fn len_after_delete(&self, base_len: usize) -> usize {
         self.0.iter().fold(base_len, |acc, &(b, e)| acc - (e - b))
     }
@@ -138,11 +138,11 @@ impl Subset {
     /// Transform through coordinate transform represented by other.
     /// The equation satisfied is as follows:
     ///
-    /// s1 = other.delete_in_string(s0)
+    /// s1 = other.delete_from_string(s0)
     ///
-    /// s2 = self.delete_in_string(s1)
+    /// s2 = self.delete_from_string(s1)
     ///
-    /// element in self.transform_expand(other).delete_in_string(s0) if (not in s1) or in s2
+    /// element in self.transform_expand(other).delete_from_string(s0) if (not in s1) or in s2
     pub fn transform_expand(&self, other: &Subset) -> Subset {
         let mut sb = SubsetBuilder::new();
         let mut last = 0;
@@ -210,8 +210,8 @@ impl Subset {
     ///
     /// C = A.transform_expand(B)
     ///
-    /// C.transform_shrink(B).delete_in_string(C.delete_in_string(s)) =
-    ///   A.delete_in_string(B.delete_in_string(s))
+    /// C.transform_shrink(B).delete_from_string(C.delete_from_string(s)) =
+    ///   A.delete_from_string(B.delete_from_string(s))
     pub fn transform_shrink(&self, other: &Subset) -> Subset {
         let mut sb = SubsetBuilder::new();
         let mut last = 0;
@@ -317,7 +317,7 @@ mod tests {
             sb.add_range(b, e);
         }
         let s = sb.build();
-        assert_eq!("145BCEINQRSTUWZbcdimpvxyz", s.delete_in_string(TEST_STR));
+        assert_eq!("145BCEINQRSTUWZbcdimpvxyz", s.delete_from_string(TEST_STR));
     }
 
     #[test]
@@ -330,7 +330,7 @@ mod tests {
     fn test_mk_subset() {
         let substr = "015ABDFHJOPQVYdfgloprsuvz";
         let s = mk_subset(substr, TEST_STR);
-        assert_eq!(substr, s.delete_in_string(TEST_STR));
+        assert_eq!(substr, s.delete_from_string(TEST_STR));
         assert!(!s.is_empty())
     }
 
@@ -338,17 +338,17 @@ mod tests {
     fn union() {
         let s1 = mk_subset("024AEGHJKNQTUWXYZabcfgikqrvy", TEST_STR);
         let s2 = mk_subset("14589DEFGIKMOPQRUXZabcdefglnpsuxyz", TEST_STR);
-        assert_eq!("4EGKQUXZabcfgy", s1.union(&s2).delete_in_string(TEST_STR));
+        assert_eq!("4EGKQUXZabcfgy", s1.union(&s2).delete_from_string(TEST_STR));
     }
 
     fn transform_case(str1: &str, str2: &str, result: &str) {
         let s1 = mk_subset(str1, TEST_STR);
         let s2 = mk_subset(str2, str1);
         let s3 = s2.transform_expand(&s1);
-        let str3 = s3.delete_in_string(TEST_STR);
+        let str3 = s3.delete_from_string(TEST_STR);
         assert_eq!(result, str3);
-        assert_eq!(str2, s3.transform_shrink(&s1).delete_in_string(&str3));
-        assert_eq!(str2, s2.transform_union(&s1).delete_in_string(TEST_STR));
+        assert_eq!(str2, s3.transform_shrink(&s1).delete_from_string(&str3));
+        assert_eq!(str2, s2.transform_union(&s1).delete_from_string(TEST_STR));
     }
 
     #[test]

--- a/rust/rope/src/subset.rs
+++ b/rust/rope/src/subset.rs
@@ -26,7 +26,7 @@ pub struct Subset(Vec<(usize, usize)>);
 
 #[derive(Default)]
 pub struct SubsetBuilder {
-    dels: Vec<(usize, usize)>,
+    ranges: Vec<(usize, usize)>,
     b: usize,
     e: usize,
 }
@@ -36,10 +36,10 @@ impl SubsetBuilder {
         SubsetBuilder::default()
     }
 
-    pub fn add_deletion(&mut self, beg: usize, end: usize) {
+    pub fn add_range(&mut self, beg: usize, end: usize) {
         if beg > self.e {
             if self.e > self.b {
-                self.dels.push((self.b, self.e));
+                self.ranges.push((self.b, self.e));
             }
             self.b = beg
         }
@@ -48,17 +48,17 @@ impl SubsetBuilder {
 
     pub fn build(mut self) -> Subset {
         if self.e > self.b {
-            self.dels.push((self.b, self.e));
+            self.ranges.push((self.b, self.e));
         }
-        Subset(self.dels)
+        Subset(self.ranges)
     }
 }
 
 impl Subset {
     // mostly for testing
-    pub fn apply_to_string(&self, s: &str) -> String {
+    pub fn delete_in_string(&self, s: &str) -> String {
         let mut result = String::new();
-        for (b, e) in self.range_iter(s.len()) {
+        for (b, e) in self.complement_iter(s.len()) {
             result.push_str(&s[b..e]);
         }
         result
@@ -66,39 +66,36 @@ impl Subset {
 
     // Maybe Subset should be a pure data structure and this method should
     // be a method of Node.
-    pub fn apply<N: NodeInfo>(&self, s: &Node<N>) -> Node<N> {
+    pub fn delete_in<N: NodeInfo>(&self, s: &Node<N>) -> Node<N> {
         let mut b = TreeBuilder::new();
-        for (beg, end) in self.range_iter(s.len()) {
+        for (beg, end) in self.complement_iter(s.len()) {
             s.push_subseq(&mut b, Interval::new_closed_open(beg, end));
         }
         b.build()
     }
 
-    /// The length of the resulting sequence.
+    /// The length of the resulting sequence after deleting this subset.
     ///
-    /// `self.apply_to_string(s).len() = self.len(s.len())`
-    pub fn len(&self, base_len: usize) -> usize {
+    /// `self.delete_in_string(s).len() = self.len(s.len())`
+    pub fn len_after_delete(&self, base_len: usize) -> usize {
         self.0.iter().fold(base_len, |acc, &(b, e)| acc - (e - b))
     }
 
-    /// Determine whether the subset is trivial, ie applying it does not
-    /// change the sequence. In purely set theoretic terms, this is the
-    /// same as testing equality with the universal set.
-    pub fn is_trivial(&self) -> bool {
+    /// Determine whether the subset is empty.
+    /// In this case deleting it would do nothing.
+    pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
     #[doc(hidden)]
     // Access to internal state, shouldn't really be part of public API
-    // Perhaps exposing an iterator over deleted regions would be more suitable,
-    // but it's more of a hassle.
-    pub fn _deletions(&self) -> &[(usize, usize)] {
+    pub fn _ranges(&self) -> &[(usize, usize)] {
         &self.0
     }
 
-    /// Compute the intersection of two subsets. In other words, an element exists in the
-    /// resulting subset iff it exists in both inputs.
-    pub fn intersect(&self, other: &Subset) -> Subset {
+    /// Compute the union of two subsets. In other words, an element exists in the
+    /// resulting subset if it exists either input.
+    pub fn union(&self, other: &Subset) -> Subset {
         let mut sb = SubsetBuilder::new();
         let mut i = 0;
         let mut j = 0;
@@ -133,7 +130,7 @@ impl Subset {
                     break;
                 }
             }
-            sb.add_deletion(next_beg, next_end);
+            sb.add_range(next_beg, next_end);
         }
         sb.build()
     }
@@ -141,11 +138,11 @@ impl Subset {
     /// Transform through coordinate transform represented by other.
     /// The equation satisfied is as follows:
     ///
-    /// s1 = other.apply_to_string(s0)
+    /// s1 = other.delete_in_string(s0)
     ///
-    /// s2 = self.apply_to_string(s1)
+    /// s2 = self.delete_in_string(s1)
     ///
-    /// element in self.transform_expand(other).apply_to_string(s0) if (not in s1) or in s2
+    /// element in self.transform_expand(other).delete_in_string(s0) if (not in s1) or in s2
     pub fn transform_expand(&self, other: &Subset) -> Subset {
         let mut sb = SubsetBuilder::new();
         let mut last = 0;
@@ -158,52 +155,52 @@ impl Subset {
                     return sb.build();
                 }
                 if self.0[i].1 + delta < b {
-                    sb.add_deletion(max(last, self.0[i].0 + delta), self.0[i].1 + delta);
+                    sb.add_range(max(last, self.0[i].0 + delta), self.0[i].1 + delta);
                     i += 1;
                 } else {
                     break;
                 }
             }
             if self.0[i].0 + delta < b {
-                sb.add_deletion(max(last, self.0[i].0 + delta), b);
+                sb.add_range(max(last, self.0[i].0 + delta), b);
             }
             last = e;
             delta += e - b;
         }
         if i < self.0.len() && self.0[i].0 + delta < last {
-            sb.add_deletion(last, self.0[i].1 + delta);
+            sb.add_range(last, self.0[i].1 + delta);
             i += 1;
         }
         for &(b, e) in &self.0[i..] {
-            sb.add_deletion(b + delta, e + delta);
+            sb.add_range(b + delta, e + delta);
         }
         sb.build()
     }
 
-    /// The same as taking transform_expand and then intersecting with `other`.
-    pub fn transform_intersect(&self, other: &Subset) -> Subset {
+    /// The same as taking transform_expand and then unioning with `other`.
+    pub fn transform_union(&self, other: &Subset) -> Subset {
         let mut sb = SubsetBuilder::new();
         let mut last = 0;
         let mut i = 0;
         let mut delta = 0;
         for &(b, e) in &other.0 {
             while i < self.0.len() && self.0[i].1 + delta < b {
-                sb.add_deletion(max(last, self.0[i].0 + delta), self.0[i].1 + delta);
+                sb.add_range(max(last, self.0[i].0 + delta), self.0[i].1 + delta);
                 i += 1;
             }
             if i < self.0.len() && self.0[i].0 + delta < b {
-                sb.add_deletion(max(last, self.0[i].0 + delta), b);
+                sb.add_range(max(last, self.0[i].0 + delta), b);
             }
-            sb.add_deletion(b, e);
+            sb.add_range(b, e);
             last = e;
             delta += e - b;
         }
         if i < self.0.len() && self.0[i].0 + delta < last {
-            sb.add_deletion(last, self.0[i].1 + delta);
+            sb.add_range(last, self.0[i].1 + delta);
             i += 1;
         }
         for &(b, e) in &self.0[i..] {
-            sb.add_deletion(b + delta, e + delta);
+            sb.add_range(b + delta, e + delta);
         }
         sb.build()
     }
@@ -213,8 +210,8 @@ impl Subset {
     ///
     /// C = A.transform_expand(B)
     ///
-    /// C.transform_shrink(B).apply_to_string(C.apply_to_string(s)) =
-    ///   A.apply_to_string(B.apply_to_string(s))
+    /// C.transform_shrink(B).delete_in_string(C.delete_in_string(s)) =
+    ///   A.delete_in_string(B.delete_in_string(s))
     pub fn transform_shrink(&self, other: &Subset) -> Subset {
         let mut sb = SubsetBuilder::new();
         let mut last = 0;
@@ -222,15 +219,15 @@ impl Subset {
         let mut y = 0;
         for &(b, e) in &self.0 {
             if i < other.0.len() && other.0[i].0 < last && other.0[i].1 < b {
-                sb.add_deletion(y, other.0[i].1 + y - last);
+                sb.add_range(y, other.0[i].1 + y - last);
                 i += 1;
             }
             while i < other.0.len() && other.0[i].1 < b {
-                sb.add_deletion(other.0[i].0 + y - last, other.0[i].1 + y - last);
+                sb.add_range(other.0[i].0 + y - last, other.0[i].1 + y - last);
                 i += 1;
             }
             if i < other.0.len() && other.0[i].0 < b {
-                sb.add_deletion(max(last, other.0[i].0) + y - last, b + y - last);
+                sb.add_range(max(last, other.0[i].0) + y - last, b + y - last);
             }
             while i < other.0.len() && other.0[i].1 < e {
                 i += 1;
@@ -239,19 +236,19 @@ impl Subset {
             last = e;
         }
         if i < other.0.len() && other.0[i].0 < last {
-            sb.add_deletion(y, other.0[i].1 + y - last);
+            sb.add_range(y, other.0[i].1 + y - last);
             i += 1;
         }
         for &(b, e) in &other.0[i..] {
-            sb.add_deletion(b + y - last, e + y - last);
+            sb.add_range(b + y - last, e + y - last);
         }
         sb.build()
     }
 
-    /// Return an iterator over ranges retained from the source sequence. These will
-    /// often be easier to work with than the raw deletions in the representation.
-    pub fn range_iter(&self, base_len: usize) -> RangeIter {
-        RangeIter {
+    /// Return an iterator over the ranges not in the Subset. These will
+    /// often be easier to work with if the raw ranges are deletions.
+    pub fn complement_iter(&self, base_len: usize) -> ComplementIter {
+        ComplementIter {
             deletions: &self.0,
             base_len: base_len,
             i: 0,
@@ -260,14 +257,14 @@ impl Subset {
     }
 }
 
-pub struct RangeIter<'a> {
+pub struct ComplementIter<'a> {
     deletions: &'a [(usize, usize)],
     base_len: usize,
     i: usize,
     last: usize,
 }
 
-impl<'a> Iterator for RangeIter<'a> {
+impl<'a> Iterator for ComplementIter<'a> {
     type Item = (usize, usize);
 
     fn next(&mut self) -> Option<(usize, usize)> {
@@ -306,7 +303,7 @@ mod tests {
             if j < substr.len() && substr.as_bytes()[j] == s.as_bytes()[i] {
                 j += 1;
             } else {
-                sb.add_deletion(i, i + 1);
+                sb.add_range(i, i + 1);
             }
         }
         sb.build()
@@ -317,41 +314,41 @@ mod tests {
         let mut sb = SubsetBuilder::new();
         for &(b, e) in &[(0, 1), (2, 4), (6, 11), (13, 14), (15, 18), (19, 23), (24, 26), (31, 32),
                 (33, 35), (36, 37), (40, 44), (45, 48), (49, 51), (52, 57), (58, 59)] {
-            sb.add_deletion(b, e);
+            sb.add_range(b, e);
         }
         let s = sb.build();
-        assert_eq!("145BCEINQRSTUWZbcdimpvxyz", s.apply_to_string(TEST_STR));
+        assert_eq!("145BCEINQRSTUWZbcdimpvxyz", s.delete_in_string(TEST_STR));
     }
 
     #[test]
     fn trivial() {
         let s = SubsetBuilder::new().build();
-        assert!(s.is_trivial());
+        assert!(s.is_empty());
     }
 
     #[test]
     fn test_mk_subset() {
         let substr = "015ABDFHJOPQVYdfgloprsuvz";
         let s = mk_subset(substr, TEST_STR);
-        assert_eq!(substr, s.apply_to_string(TEST_STR));
-        assert!(!s.is_trivial())
+        assert_eq!(substr, s.delete_in_string(TEST_STR));
+        assert!(!s.is_empty())
     }
 
     #[test]
-    fn intersect() {
+    fn union() {
         let s1 = mk_subset("024AEGHJKNQTUWXYZabcfgikqrvy", TEST_STR);
         let s2 = mk_subset("14589DEFGIKMOPQRUXZabcdefglnpsuxyz", TEST_STR);
-        assert_eq!("4EGKQUXZabcfgy", s1.intersect(&s2).apply_to_string(TEST_STR));
+        assert_eq!("4EGKQUXZabcfgy", s1.union(&s2).delete_in_string(TEST_STR));
     }
 
     fn transform_case(str1: &str, str2: &str, result: &str) {
         let s1 = mk_subset(str1, TEST_STR);
         let s2 = mk_subset(str2, str1);
         let s3 = s2.transform_expand(&s1);
-        let str3 = s3.apply_to_string(TEST_STR);
+        let str3 = s3.delete_in_string(TEST_STR);
         assert_eq!(result, str3);
-        assert_eq!(str2, s3.transform_shrink(&s1).apply_to_string(&str3));
-        assert_eq!(str2, s2.transform_intersect(&s1).apply_to_string(TEST_STR));
+        assert_eq!(str2, s3.transform_shrink(&s1).delete_in_string(&str3));
+        assert_eq!(str2, s2.transform_union(&s1).delete_in_string(TEST_STR));
     }
 
     #[test]

--- a/rust/rope/src/subset.rs
+++ b/rust/rope/src/subset.rs
@@ -145,7 +145,7 @@ impl Subset {
     ///
     /// s2 = self.apply_to_string(s1)
     ///
-    /// element in self.transform_expand(other).apply_to_string(s0) if not in s1 or in s2
+    /// element in self.transform_expand(other).apply_to_string(s0) if (not in s1) or in s2
     pub fn transform_expand(&self, other: &Subset) -> Subset {
         let mut sb = SubsetBuilder::new();
         let mut last = 0;

--- a/rust/rope/src/subset.rs
+++ b/rust/rope/src/subset.rs
@@ -95,7 +95,7 @@ impl Subset {
     }
 
     /// Compute the union of two subsets. In other words, an element exists in the
-    /// resulting subset if it exists either input.
+    /// resulting subset iff it exists in at least one of the inputs.
     pub fn union(&self, other: &Subset) -> Subset {
         let mut sb = SubsetBuilder::new();
         let mut i = 0;


### PR DESCRIPTION
This PR contains a number of related refactorings to the `Engine`, `Delta` and `Subset` classes. It is entirely re-namings, doc comment changes, and one removal of a duplicate method. Split into multiple commits according to which refactors must occur together, you may want to review each commit individually. Fixes #256, see discussion there for context.

cc @raphlinus 

I've pasted the commit message of the most significant refactoring below:

### Rename methods of Subset to be more consistent.

There was previously an inconsistency in the naming in Engine and the naming
in Subset. See #256

The naming of the methods of Subset was as if the Subset represented
the complement of the ranges it contained, which if the ranges were deletions
meant it represented the elements that were kept.

However, this was inconsistent with the naming in Engine which had subsets like
`inserts` and `deletes` that according to the concept of Subset actually represented
the non-inserted and non-deleted ranges.

This fixes the inconsistency by renaming methods as if Subset just represents the
ranges it contains, which eliminates having to reason about the complement when
thinking about the entire system.