### PR TITLE
Improve the worst case performance of Cursor::next()

### DIFF
--- a/rust/rope/benches/cursors.rs
+++ b/rust/rope/benches/cursors.rs
@@ -1,0 +1,80 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![feature(test)]
+
+extern crate test;
+extern crate xi_rope;
+
+use test::Bencher;
+use xi_rope::tree::*;
+use xi_rope::rope::{LinesMetric, Rope};
+
+
+fn run_down_rope(text: &Rope) {
+    let mut cursor = Cursor::new(&text, 0);
+
+    while cursor.pos() < text.len() - 2 {
+        cursor.next::<LinesMetric>();
+    }
+}
+
+fn build_triangle(n: usize) -> String {
+    let mut s = String::new();
+    let mut line = String::new();
+    for _ in 0 .. n {
+        s += &line;
+        s += "\n";
+        line += "a";
+    }
+    s
+}
+
+fn build_short_lines(n: usize) -> String {
+    let line = "match s.as_bytes()[minsplit - 1..splitpoint].iter().rposition(|&c| c == b'\n') {";
+    let mut s = String::new();
+    for _ in 0..n {
+        s += line;
+    }
+    s
+}
+
+fn build_few_big_lines(size: usize) -> String {
+    let mut s = String::with_capacity(size * 10 + 20);
+    for _ in 0 .. 10 {
+        for _ in 0..size {
+            s += "a";
+        }
+        s += "\n";
+    }
+    s
+}
+
+#[bench]
+fn benchmark_triangle(b: &mut Bencher) {
+    let text = Rope::from(build_triangle(50_000));
+    b.iter(|| run_down_rope(&text));
+}
+
+#[bench]
+fn benchmark_short_lines(b: &mut Bencher) {
+    let text = Rope::from(build_short_lines(1_000_000));
+    b.iter(|| run_down_rope(&text));
+}
+
+#[bench]
+fn benchmark_few_big_lines(b: &mut Bencher) {
+    let text = Rope::from(build_short_lines(1_000_000));
+    b.iter(|| run_down_rope(&text));
+}

--- a/rust/rope/benches/cursors.rs
+++ b/rust/rope/benches/cursors.rs
@@ -75,6 +75,6 @@ fn benchmark_short_lines(b: &mut Bencher) {
 
 #[bench]
 fn benchmark_few_big_lines(b: &mut Bencher) {
-    let text = Rope::from(build_short_lines(1_000_000));
+    let text = Rope::from(build_few_big_lines(1_000_000));
     b.iter(|| run_down_rope(&text));
 }

--- a/rust/rope/src/tree.rs
+++ b/rust/rope/src/tree.rs
@@ -630,6 +630,7 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
     }
 
     /// Tries to find the next boundary in the leaf the cursor is currently in.
+    #[inline(always)]
     fn next_inside_leaf<M: Metric<N>>(&mut self) -> Option<usize> {
         if let Some(l) = self.leaf {
             let offset_in_leaf = self.position - self.offset_of_leaf;

--- a/rust/rope/src/tree.rs
+++ b/rust/rope/src/tree.rs
@@ -831,3 +831,43 @@ impl Metric<BytesInfo> for BytesMetric {
 }
 
 */
+
+#[cfg(test)]
+mod test {
+    use ::rope::*;
+    use super::*;
+
+    fn build_triangle(n: u32) -> String {
+        let mut s = String::new();
+        let mut line = String::new();
+        for _ in 0 .. n {
+            s += &line;
+            s += "\n";
+            line += "a";
+        }
+        s
+    }
+
+    #[test]
+    fn cursor_next_triangle() {
+        let n = 10_000;
+        let text = Rope::from(build_triangle(n));
+
+        let mut cursor = Cursor::new(&text, 0);
+        let mut prev_offset = cursor.pos();
+        for i in 1..(n+1) as usize {
+            let offset = cursor.next::<LinesMetric>().expect("arrived at the end too soon");
+            assert_eq!(offset - prev_offset, i);
+            prev_offset = offset;
+        }
+        assert_eq!(cursor.next::<LinesMetric>(), None);
+    }
+
+    #[test]
+    fn cursor_next_empty() {
+        let text = Rope::from(String::new());
+        let mut cursor = Cursor::new(&text, 0);
+        assert_eq!(cursor.next::<LinesMetric>(), None);
+        assert_eq!(cursor.pos(), 0);
+    }
+}

--- a/rust/rope/src/tree.rs
+++ b/rust/rope/src/tree.rs
@@ -196,6 +196,8 @@ impl<N: NodeInfo> Node<N> {
         }
     }
 
+    /// Returns the fist child with a positive measure, starting from the `j`th.
+    /// Also, returns the offset we have skipped; note that if it returns `None`in the first component, we skip all the children.
     fn next_positive_measure_child<M: Metric<N>>(&self, j: usize) -> (Option<usize>, usize) {
         let children = self.get_children();
         let mut offset = 0;
@@ -579,9 +581,9 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
         }
     }
 
-    // Moves the cursor to the next discontinuity, or to the end
-    // of the rope. In the former case, returns the offset of said
-    // discontinuity.
+    /// Moves the cursor to the next discontinuity, or to the end
+    /// of the rope. In the former case, returns the offset of said
+    /// discontinuity.
     pub fn next<M: Metric<N>>(&mut self) -> Option<(usize)> {
         if self.position >= self.root.len() || self.leaf.is_none() {
             self.leaf = None;
@@ -617,9 +619,9 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
                     return self.next_inside_leaf::<M>();
                 }
             }
-            // At this point, we know that (1) the next discontinuity is not not in the
-            // cached subtree, (2) self.position corresponds to the begining of the firt
-            // leaf after the cached subtree.
+            // At this point, we know that (1) the next boundary is not not in
+            // the cached subtree, (2) self.position corresponds to the begining
+            // of the first leaf after the cached subtree.
             self.descend();
             return self.next::<M>();
         } else {
@@ -627,6 +629,7 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
         }
     }
 
+    /// Tries to find the next boundary in the leaf the cursor is currently in.
     fn next_inside_leaf<M: Metric<N>>(&mut self) -> Option<usize> {
         if let Some(l) = self.leaf {
             let offset_in_leaf = self.position - self.offset_of_leaf;
@@ -646,7 +649,7 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
         } else {
             panic!("inconsistent, shouldn't get here");
         }
-        return None;
+        None
     }
 
     // same return as get_leaf, moves to beginning of next leaf


### PR DESCRIPTION
As mentioned in a TODO, try to walk up the cached subtree and skip the 0-measure
nodes. I checked that the two implementations coincide by walking line by line some
files.

It degrades a little the performance when the lines are short, for example in
the case of the sqlite source:
```
after    ... bench:   4,530,490 ns/iter (+/- 733,470)
before   ... bench:   4,128,834 ns/iter (+/- 411,246)
```
However, for a ~30MB file with a single newline at the end, it is significantly faster:
```
after    ... bench:       9,794 ns/iter (+/- 596)
before   ... bench:   2,388,631 ns/iter (+/- 318,327)
```