### PR TITLE
Print error if return value of a notification is not null

### DIFF
--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -61,8 +61,9 @@ impl<W: Write> Clone for PluginRef<W> {
 
 impl<W: Write + Send + 'static> Handler<ChildStdin> for PluginRef<W> {
     fn handle_notification(&mut self, _ctx: RpcCtx<ChildStdin>, method: &str, params: &Value) {
-        let _ = self.rpc_handler(method, params);
-        // TODO: should check None
+        if let Some(_) = self.rpc_handler(method, params) {
+            print_err!("Unexpected return value for notification {}", method)
+        }
     }
 
     fn handle_request(&mut self, _ctx: RpcCtx<ChildStdin>, method: &str, params: &Value) ->

--- a/rust/plugin-lib/src/plugin_base.rs
+++ b/rust/plugin-lib/src/plugin_base.rs
@@ -237,8 +237,9 @@ impl<'a, H: Handler> xi_rpc::Handler<io::Stdout> for MyHandler<'a, H> {
     fn handle_notification(&mut self, ctx: RpcCtx<io::Stdout>, method: &str, params: &Value) {
         match parse_plugin_request(method, params) {
             Ok(req) => {
-                let _ = self.0.call(&req, PluginCtx(ctx));
-                // TODO: should check None
+                if let Some(_) = self.0.call(&req, PluginCtx(ctx)) {
+                    print_err!("Unexpected return value for notification {}", method)
+                }
             }
             Err(err) => print_err!("error: {}", err)
         }


### PR DESCRIPTION
Changed `rust/core-lib/src/plugins/mod.rs` and `rust/plugin-lib/src/plugin_base.rs` checking if the result of handling a notification is Some, same as done [here](https://github.com/google/xi-editor/blob/fe7f47898c72e4fb476733eef5fd6f857ce2d369/rust/core-lib/src/lib.rs#L89-L91) acording to #280 