### PR TITLE
Plugin activations + syntax-specific syntax highlighting

### DIFF
--- a/python/xi_plugin/plugin.py
+++ b/python/xi_plugin/plugin.py
@@ -46,14 +46,17 @@ class Plugin(object):
     def __init__(self):
         self.cache = None
         self.identifier = type(self).__name__
+        self.path = None,
+        self.syntax = "plaintext"
 
     def __call__(self, method, params, peer):
         params = params or {}
         # intercept these to do bookkeeping, so subclasses don't have to call super
         self.__last_method = method
 
-        if method == "init_buf":
-            self._init_buf(peer, **params)
+        if method == "initialize":
+            params = params['buffer_info']
+            self._initialize(peer, **params)
         if method == "update":
             self._update(peer, params)
         if method == "shutdown":
@@ -72,11 +75,12 @@ class Plugin(object):
     def ping(self, peer, **kwargs):
         self.print_err("ping")
 
-    def _init_buf(self, peer, rev, buf_size):
-        self.print_err("init_buf")
+    def _initialize(self, peer, rev, buf_size, nb_lines, syntax, path=None):
         # fetch an initial chunk (this isn't great: we don't know
         # where the cursor is)
         self.lines = LineCache(buf_size, peer, rev)
+        self.path = path
+        self.syntax = syntax
 
     def _update(self, peer, params):
         self.lines.apply_update(peer, **params)

--- a/python/xi_plugin/plugin.py
+++ b/python/xi_plugin/plugin.py
@@ -50,10 +50,15 @@ class Plugin(object):
     def __call__(self, method, params, peer):
         params = params or {}
         # intercept these to do bookkeeping, so subclasses don't have to call super
+        self.__last_method = method
+
         if method == "init_buf":
             self._init_buf(peer, **params)
         if method == "update":
             self._update(peer, params)
+        if method == "shutdown":
+            peer.done = True
+
         return getattr(self, method, self.noop)(peer, **params)
 
     def print_err(self, err):
@@ -78,7 +83,7 @@ class Plugin(object):
 
     def noop(self, *args, **kwargs):
         """Default responder for unimplemented RPC methods."""
-        return None
+        return self.print_err("{} not implemented".format(self.__last_method))
 
 
 def start_plugin(plugin):

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -909,6 +909,18 @@ impl<W: Write + Send + 'static> Editor<W> {
     pub fn plugin_alert(&self, msg: &str) {
         self.doc_ctx.alert(msg);
     }
+
+    /// Notifies the client that the named plugin has started.
+    pub fn plugin_started(&self, view_id: &ViewIdentifier, plugin: &str) {
+        self.doc_ctx.plugin_started(view_id, plugin);
+    }
+
+    /// Notifies client that the named plugin has stopped.
+    ///
+    /// `code` is reserved for future use.
+    pub fn plugin_stopped(&self, view_id: &ViewIdentifier, plugin: &str, code: i32) {
+        self.doc_ctx.plugin_stopped(view_id, plugin, code);
+    }
 }
 
 // wrapper so async methods don't have to return None themselves

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -33,8 +33,8 @@ use movement::Movement;
 
 use tabs::{ViewIdentifier, DocumentCtx};
 use rpc::{EditCommand, GestureType};
-use plugins::rpc_types::{PluginUpdate, PluginEdit, Span};
 use syntax::SyntaxDefinition;
+use plugins::rpc_types::{PluginUpdate, PluginEdit, Span, PluginBufferInfo};
 
 const FLAG_SELECT: u64 = 2;
 
@@ -206,10 +206,11 @@ impl<W: Write + Send + 'static> Editor<W> {
         self.gc_undos();
     }
 
-    /// Returns metrics used to initialize plugins.
-    pub fn plugin_init_params(&self) -> (usize, usize, usize) {
+    /// Returns buffer information used to initialize plugins.
+    pub fn plugin_init_info(&self) -> PluginBufferInfo {
         let nb_lines = self.text.measure::<LinesMetric>() + 1;
-        (self.text.len(), nb_lines, self.engine.get_head_rev_id())
+        PluginBufferInfo::new(self.engine.get_head_rev_id(), self.text.len(),
+        nb_lines, self.path.clone(), self.syntax.clone())
     }
 
     fn insert(&mut self, s: &str) {

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -46,6 +46,7 @@ pub mod internal {
     pub mod index_set;
     pub mod selection;
     pub mod movement;
+    pub mod syntax;
 }
 
 use internal::tabs;
@@ -58,6 +59,7 @@ use internal::word_boundaries;
 use internal::index_set;
 use internal::selection;
 use internal::movement;
+use internal::syntax;
 
 use tabs::Documents;
 use rpc::Request;

--- a/rust/core-lib/src/plugins/manager.rs
+++ b/rust/core-lib/src/plugins/manager.rs
@@ -35,7 +35,13 @@ pub struct PluginManager<W: Write> {
     buffers: BufferContainerRef<W>,
 }
 
+// Note: In general I have adopted the pattern of putting non-threadsafe
+// API in the 'inner' type of types with a ___Ref variant. Methods on the
+// Ref variant should be minimal, and provide a threadsafe interface.
+
 impl <W: Write + Send + 'static>PluginManager<W> {
+
+    /// Returns available plugins, for populating the client menu.
     pub fn debug_available_plugins(&self) -> Vec<&str> {
         self.catalog.iter().map(|p| p.name.as_ref()).collect::<Vec<_>>()
     }
@@ -65,6 +71,58 @@ impl <W: Write + Send + 'static>PluginManager<W> {
                 None
             }
         }
+    }
+
+    /// Passes an update from a buffer to all registered plugins.
+    pub fn update(&mut self, view_id: &ViewIdentifier, update: PluginUpdate,
+                  undo_group: usize) {
+        // find all running plugins for this buffer, and send them the update
+        for (_, plugin) in self.running.iter().filter(|kv| (kv.0).0 == *view_id) {
+            self.buffers.lock().editor_for_view_mut(view_id)
+                .unwrap().increment_revs_in_flight();
+            let view_id = view_id.to_owned();
+            let buffers = self.buffers.clone().to_weak();
+            plugin.update(&update, move |response| {
+                if let Some(buffers) = buffers.upgrade() {
+                    let response = response.expect("bad plugin response");
+                    match serde_json::from_value::<UpdateResponse>(response) {
+                        Ok(UpdateResponse::Edit(edit)) => {
+                            buffers.lock().editor_for_view_mut(&view_id).unwrap()
+                                .apply_plugin_edit(edit, undo_group);
+                        }
+                        Ok(UpdateResponse::Ack(_)) => (),
+                        Err(err) => { print_err!("plugin response json err: {:?}", err); }
+                    }
+                    buffers.lock().editor_for_view_mut(&view_id)
+                        .unwrap().dec_revs_in_flight();
+                }
+            })
+        }
+        self.buffers.lock().editor_for_view_mut(view_id).unwrap().dec_revs_in_flight();
+    }
+
+    /// Launches and initializes the named plugin.
+    pub fn start_plugin(&mut self,self_ref: &PluginManagerRef<W>,
+                        buffer_id: &str, plugin_name: &str, buf_size: usize, rev: usize) {
+        //TODO: error handling: this should maybe have a completion callback with a Result
+        let key = (buffer_id.to_owned(), plugin_name.to_owned());
+        if self.running.contains_key(&key) {
+            print_err!("plugin {} already running for buffer {}", plugin_name, buffer_id);
+        }
+
+        let plugin = self.catalog.iter().find(|desc| desc.name == plugin_name)
+            .expect(&format!("no plugin found with name {}", plugin_name));
+
+        let me = self_ref.clone();
+        plugin.launch(self_ref, buffer_id, move |result| {
+            match result {
+                Ok(plugin_ref) => {
+                    plugin_ref.init_buf(buf_size, rev);
+                    me.lock().running.insert(key, plugin_ref);
+                },
+                Err(_) => panic!("error handling is not implemented"),
+            }
+        });
     }
 }
 
@@ -139,58 +197,10 @@ impl<W: Write + Send + 'static> PluginManagerRef<W> {
         print_err!("document_syntax_changed {}", view_id);
     }
 
-    /// Passes an update from a buffer to all registered plugins.
-    pub fn update(&mut self, view_id: &ViewIdentifier, update: PluginUpdate,
-                  undo_group: usize) {
-        // find all running plugins for this buffer, and send them the update
-        let inner = self.lock();
-        for (_, plugin) in inner.running.iter().filter(|kv| (kv.0).0 == *view_id) {
-            inner.buffers.lock().editor_for_view_mut(view_id)
-                .unwrap().increment_revs_in_flight();
-            let view_id = view_id.to_owned();
-            let buffers = inner.buffers.clone().to_weak();
-            plugin.update(&update, move |response| {
-                if let Some(buffers) = buffers.upgrade() {
-                    let response = response.expect("bad plugin response");
-                    match serde_json::from_value::<UpdateResponse>(response) {
-                        Ok(UpdateResponse::Edit(edit)) => {
-                            buffers.lock().editor_for_view_mut(&view_id).unwrap()
-                                .apply_plugin_edit(edit, undo_group);
-                        }
-                        Ok(UpdateResponse::Ack(_)) => (),
-                        Err(err) => { print_err!("plugin response json err: {:?}", err); }
-                    }
-                    buffers.lock().editor_for_view_mut(&view_id)
-                        .unwrap().dec_revs_in_flight();
-                }
-            })
-        }
-        inner.buffers.lock().editor_for_view_mut(view_id).unwrap().dec_revs_in_flight();
-    }
-
     /// Launches and initializes the named plugin.
-    pub fn start_plugin(&mut self, buffer_id: &str, plugin_name: &str,
+    pub fn start_plugin(&self, buffer_id: &str, plugin_name: &str,
                         buf_size: usize, rev: usize) {
-        //TODO: error handling: this should maybe have a completion callback with a Result
-        let key = (buffer_id.to_owned(), plugin_name.to_owned());
-        let inner = self.lock();
-        if inner.running.contains_key(&key) {
-            print_err!("plugin {} already running for buffer {}", plugin_name, buffer_id);
-        }
-
-        let plugin = inner.catalog.iter().find(|desc| desc.name == plugin_name)
-            .expect(&format!("no plugin found with name {}", plugin_name));
-
-        let me = self.clone();
-        plugin.launch(self, buffer_id, move |result| {
-            match result {
-                Ok(plugin_ref) => {
-                    plugin_ref.init_buf(buf_size, rev);
-                    me.lock().running.insert(key, plugin_ref);
-                },
-                Err(_) => panic!("error handling is not implemented"),
-            }
-        });
+        self.lock().start_plugin(self, buffer_id, plugin_name, buf_size, rev);
     }
 }
 

--- a/rust/core-lib/src/plugins/manager.rs
+++ b/rust/core-lib/src/plugins/manager.rs
@@ -237,7 +237,7 @@ impl<W: Write + Send + 'static> PluginManagerRef<W> {
             .collect::<BTreeSet<_>>();
 
         // stop currently running plugins that aren't on list
-        // TODO: don't stop plugins that weren't
+        // TODO: don't stop plugins that weren't started by a syntax activation
         let to_stop = self.lock().running.keys()
             .filter(|k| !start_keys.contains(k))
             .map(|k| k.1.to_owned())
@@ -258,7 +258,6 @@ impl<W: Write + Send + 'static> PluginManagerRef<W> {
     /// Launches and initializes the named plugin.
     pub fn start_plugin(&self, view_id: &ViewIdentifier, plugin_name: &str,
                         init_info: &PluginBufferInfo) {
-        //let init_info = init_info.to_owned();
         self.lock().start_plugin(self, view_id, plugin_name, init_info.to_owned());
     }
 
@@ -273,8 +272,8 @@ impl<W: Write + Send + 'static> PluginManagerRef<W> {
 
     /// Returns the plugins which want to activate for this view.
     ///
-    /// That a plugin wants to activate does not mean it will be activated. For instance,
-    /// it could have already been disabled by user preference.
+    /// That a plugin wants to activate does not mean it will be activated.
+    /// For instance, it could have already been disabled by user preference.
     fn activatable_plugins(&self, view_id: &ViewIdentifier) -> Vec<String> {
         let inner = self.lock();
         let syntax = inner.buffers.lock()
@@ -285,7 +284,7 @@ impl<W: Write + Send + 'static> PluginManagerRef<W> {
                 plug_desc.activations.iter().any(|act|{
                     match *act {
                         PluginActivation::Autorun => true,
-                        PluginActivation::OnSyntax(ref on_syntax) if *on_syntax == syntax => true,
+                        PluginActivation::OnSyntax(ref other) if *other == syntax => true,
                         _ => false,
                     }
                 })
@@ -311,4 +310,3 @@ impl<W: Write + Send + 'static> PluginManagerRef<W> {
         }
     }
 }
-

--- a/rust/core-lib/src/plugins/manager.rs
+++ b/rust/core-lib/src/plugins/manager.rs
@@ -50,10 +50,30 @@ impl<W: Write + Send + 'static> PluginManager<W> {
         self.catalog.iter().map(|p| p.name.as_ref()).collect::<Vec<_>>()
     }
 
-    //fn new_buffer(&mut self, view_id: &ViewIdentifier) {}
-    //fn file_open(&mut self, view_id: &ViewIdentifier, path: &Path) {}
-    //fn file_save(&mut self, view_id: &ViewIdentifier, path: &Path) {}
-    //fn view_close(&mut self, view_id: &ViewIdentifier) {}
+    /// Called when a new empty buffer is created.
+    pub fn document_new(&mut self, view_id: &ViewIdentifier) {
+        print_err!("document_new {}", view_id);
+    }
+
+    /// Called when an existing file is loaded into a buffer.
+    pub fn document_open(&mut self, view_id: &ViewIdentifier) {
+        print_err!("document_open {}", view_id);
+    }
+
+    /// Called when a buffer is saved to a file.
+    pub fn document_did_save(&mut self, view_id: &ViewIdentifier) {
+        print_err!("document_did_save {}", view_id);
+    }
+
+    /// Called when a buffer is closed.
+    pub fn document_close(&mut self, view_id: &ViewIdentifier) {
+        print_err!("document_close {}", view_id);
+    }
+
+    /// Called when a document's syntax definition has changed.
+    pub fn document_syntax_changed(&mut self, view_id: &ViewIdentifier) {
+        print_err!("document_syntax_changed {}", view_id);
+    }
 
     /// Passes an update from a buffer to all registered plugins.
     pub fn update(&mut self, view_id: &ViewIdentifier, update: PluginUpdate,

--- a/rust/core-lib/src/plugins/manager.rs
+++ b/rust/core-lib/src/plugins/manager.rs
@@ -133,7 +133,7 @@ impl <W: Write + Send + 'static>PluginManager<W> {
             Some(plugin) => {
                 plugin.shutdown();
                 //TODO: should we notify now, or wait until we know this worked?
-                //can this fail? How do we tell, and when do we kill the proc?
+                //can this fail? (yes.) How do we tell, and when do we kill the proc?
                 self.buffers.lock().editor_for_view(view_id)
                     .unwrap().plugin_stopped(view_id, plugin_name, 0);
             }

--- a/rust/core-lib/src/plugins/manifest.rs
+++ b/rust/core-lib/src/plugins/manifest.rs
@@ -49,7 +49,7 @@ pub fn debug_plugins() -> Vec<PluginDescription> {
         PluginDescription::new("spellcheck", "0.0", make_path("spellcheck.py"),
         vec![OnSyntax(Markdown), OnSyntax(Plaintext)]),
         PluginDescription::new("shouty", "0.0", make_path("shouty.py"),
-        vec![OnSyntax(Markdown), OnSyntax(Plaintext)])
+        Vec::new()),
     ]
 }
 

--- a/rust/core-lib/src/plugins/manifest.rs
+++ b/rust/core-lib/src/plugins/manifest.rs
@@ -25,11 +25,14 @@ use serde_json::Value;
 
 use xi_rpc::RpcLoop;
 
+use syntax::SyntaxDefinition;
 use super::PluginManager;
 use super::{Plugin, PluginRef};
 
 // example plugins. Eventually these should be loaded from disk.
 pub fn debug_plugins() -> Vec<PluginDescription> {
+    use self::PluginActivation::*;
+    use self::SyntaxDefinition::*;
     let mut path_base = env::current_exe().unwrap();
     path_base.pop();
     let make_path = |p: &str| -> PathBuf {
@@ -39,10 +42,14 @@ pub fn debug_plugins() -> Vec<PluginDescription> {
     };
 
     vec![
-        PluginDescription::new("syntect", "0.0", make_path("xi-syntect-plugin")),
-        PluginDescription::new("braces", "0.0", make_path("bracket_example.py")),
-        PluginDescription::new("spellcheck", "0.0", make_path("spellcheck.py")),
-        PluginDescription::new("shouty", "0.0", make_path("shouty.py")),
+        PluginDescription::new("syntect", "0.0", make_path("xi-syntect-plugin"),
+        vec![Autorun]),
+        PluginDescription::new("braces", "0.0", make_path("bracket_example.py"),
+        Vec::new()),
+        PluginDescription::new("spellcheck", "0.0", make_path("spellcheck.py"),
+        vec![OnSyntax(Markdown), OnSyntax(Plaintext)]),
+        PluginDescription::new("shouty", "0.0", make_path("shouty.py"),
+        vec![OnSyntax(Markdown), OnSyntax(Plaintext)])
     ]
 }
 
@@ -57,16 +64,31 @@ pub struct PluginDescription {
     // more metadata ...
     /// path to plugin executable
     pub exec_path: PathBuf,
+    /// Events that cause this plugin to run
+    activations: Vec<PluginActivation>,
+}
+
+/// `PluginActivation`s represent events that trigger running a plugin.
+#[derive(Debug, Clone)]
+pub enum PluginActivation {
+    /// Always run this plugin, when available.
+    Autorun,
+    /// Run this plugin if the provided SyntaxDefinition is active.
+    OnSyntax(SyntaxDefinition),
+    /// Run this plugin in response to a given command.
+    #[allow(dead_code)]
+    OnCommand,
 }
 
 impl PluginDescription {
-    fn new<S, P>(name: S, version: S, exec_path: P) -> Self
+    fn new<S, P>(name: S, version: S, exec_path: P, activations: Vec<PluginActivation>) -> Self
         where S: Into<String>, P: Into<PathBuf>
     {
         PluginDescription {
             name: name.into(),
             version: version.into(),
-            exec_path: exec_path.into()
+            exec_path: exec_path.into(),
+            activations: activations,
         }
     }
 

--- a/rust/core-lib/src/plugins/manifest.rs
+++ b/rust/core-lib/src/plugins/manifest.rs
@@ -26,7 +26,7 @@ use serde_json::Value;
 use xi_rpc::RpcLoop;
 
 use syntax::SyntaxDefinition;
-use super::PluginManager;
+use super::PluginManagerRef;
 use super::{Plugin, PluginRef};
 
 // example plugins. Eventually these should be loaded from disk.
@@ -93,7 +93,7 @@ impl PluginDescription {
     }
 
     /// Starts the executable described in this `PluginDescription`.
-    pub fn launch<W, C>(&self, manager_ref: &Arc<Mutex<PluginManager<W>>>, buffer_id: &str, completion: C)
+    pub fn launch<W, C>(&self, manager_ref: &PluginManagerRef<W>, buffer_id: &str, completion: C)
         where W: Write + Send + 'static,
               C: FnOnce(Result<PluginRef<W>, &'static str>) + Send + 'static
               // TODO: a real result type
@@ -120,7 +120,7 @@ impl PluginDescription {
                 //TODO: I had the bright idea of keeping this reference but
                 // I'm not sure exactly what to do with it (stopping the plugin is one thing)
                 process: child,
-                manager: Arc::downgrade(&manager_ref),
+                manager: manager_ref.to_weak(),
                 description: description,
                 buffer_id: buffer_id,
             };

--- a/rust/core-lib/src/plugins/manifest.rs
+++ b/rust/core-lib/src/plugins/manifest.rs
@@ -59,13 +59,13 @@ pub fn debug_plugins() -> Vec<PluginDescription> {
 #[derive(Debug, Clone)]
 pub struct PluginDescription {
     pub name: String,
-    version: String,
+    pub version: String,
     //scope: PluginScope,
     // more metadata ...
     /// path to plugin executable
     pub exec_path: PathBuf,
     /// Events that cause this plugin to run
-    activations: Vec<PluginActivation>,
+    pub activations: Vec<PluginActivation>,
 }
 
 /// `PluginActivation`s represent events that trigger running a plugin.
@@ -100,7 +100,7 @@ impl PluginDescription {
     {
         let path = self.exec_path.clone();
         let buffer_id = buffer_id.to_owned();
-        let manager_ref = manager_ref.clone();
+        let manager_ref = manager_ref.to_weak();
         let description = self.clone();
 
         thread::spawn(move || {
@@ -120,7 +120,7 @@ impl PluginDescription {
                 //TODO: I had the bright idea of keeping this reference but
                 // I'm not sure exactly what to do with it (stopping the plugin is one thing)
                 process: child,
-                manager: manager_ref.to_weak(),
+                manager: manager_ref,
                 description: description,
                 buffer_id: buffer_id,
             };

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -45,7 +45,7 @@ pub struct Plugin<W: Write> {
     manager: WeakPluginManagerRef<W>,
     description: PluginDescription,
     //TODO: temporary, eventually ids (view ids?) should be passed back and forth with RPCs
-    buffer_id: BufferIdentifier,
+    view_id: ViewIdentifier,
 }
 
 /// A convenience wrapper for passing around a reference to a plugin.
@@ -83,7 +83,7 @@ impl<W: Write + Send + 'static> PluginRef<W> {
                 .expect(&format!("failed to parse plugin rpc {}, params {:?}",
                         method, params));
             let result = plugin_manager.lock().handle_plugin_cmd(
-                cmd, &self.0.lock().unwrap().buffer_id);
+                cmd, &self.0.lock().unwrap().view_id);
         result
         } else {
             None

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -106,6 +106,17 @@ impl<W: Write + Send + 'static> PluginRef<W> {
         let params = serde_json::to_value(update).expect("PluginUpdate invalid");
         self.0.lock().unwrap().peer.send_rpc_request_async("update", &params, callback);
     }
+
+    /// Termination message sent to the plugin.
+    ///
+    /// The plugin is expected to clean up and close the pipe.
+    pub fn shutdown(&self) {
+        match self.0.lock() {
+            Ok(inner) => inner.peer.send_rpc_notification("shutdown", &json!({})),
+            Err(_) => print_err!("plugin mutex poisoned"),
+        }
+        self.0.lock().unwrap().peer.send_rpc_notification("shutdown", &json!({}));
+    }
 }
 
 

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -82,7 +82,7 @@ impl<W: Write + Send + 'static> PluginRef<W> {
             let cmd = serde_json::from_value::<PluginCommand>(params.to_owned())
                 .expect(&format!("failed to parse plugin rpc {}, params {:?}",
                         method, params));
-            let result = plugin_manager.handle_plugin_cmd(
+            let result = plugin_manager.lock().handle_plugin_cmd(
                 cmd, &self.0.lock().unwrap().buffer_id);
         result
         } else {

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -123,14 +123,14 @@ impl<W: Write + Send + 'static> PluginRef<W> {
 /// which forwards them to interested plugins.
 pub fn start_update_thread<W: Write + Send + 'static>(
     rx: mpsc::Receiver<(ViewIdentifier, PluginUpdate, usize)>,
-    plugins: &PluginManagerRef<W>)
+    plugins_ref: &PluginManagerRef<W>)
 {
-    let mut plugins = plugins.clone();
+    let plugins_ref = plugins_ref.clone();
     thread::spawn(move ||{
         loop {
             match rx.recv() {
                 Ok((view_id, update, undo_group)) => {
-                    plugins.update(&view_id, update, undo_group);
+                    plugins_ref.lock().update(&view_id, update, undo_group);
                 }
                 Err(_) => break,
             }

--- a/rust/core-lib/src/plugins/rpc_types.rs
+++ b/rust/core-lib/src/plugins/rpc_types.rs
@@ -19,6 +19,14 @@
 // At some point, it will be stabalized and then perhaps will live in another crate,
 // shared with the plugin lib.
 
+//TODO: very likely this should be merged with PluginDescription
+/// Describes an available plugin to the client.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ClientPluginInfo {
+    pub name: String,
+    pub running: bool,
+}
+
 /// A simple update, sent to a plugin.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PluginUpdate {

--- a/rust/core-lib/src/plugins/rpc_types.rs
+++ b/rust/core-lib/src/plugins/rpc_types.rs
@@ -14,12 +14,41 @@
 
 //! RPC types, corresponding to protocol requests, notifications & responses.
 
+use std::path::PathBuf;
+
+use syntax::SyntaxDefinition;
 
 //TODO: At the moment (May 08, 2017) this is all very much in flux.
 // At some point, it will be stabalized and then perhaps will live in another crate,
 // shared with the plugin lib.
 
+// ====================================================================
+// core -> plugin RPC method types + responses
+// ====================================================================
+
+/// Buffer information sent on plugin init.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PluginBufferInfo {
+    rev: usize,
+    buf_size: usize,
+    nb_lines: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    path: Option<String>,
+    syntax: SyntaxDefinition,
+}
+
+impl PluginBufferInfo {
+    pub fn new(rev: usize, buf_size: usize, nb_lines: usize,
+               path: Option<PathBuf>, syntax: SyntaxDefinition) -> Self {
+        //TODO: do make any current assertions about paths being valid utf-8? do we want to?
+        let path = path.map(|p| p.to_str().unwrap().to_owned());
+        PluginBufferInfo { rev, buf_size, nb_lines, path, syntax }
+    }
+}
+
+
 //TODO: very likely this should be merged with PluginDescription
+//TODO: also this does not belong here.
 /// Describes an available plugin to the client.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ClientPluginInfo {
@@ -55,6 +84,22 @@ impl PluginUpdate {
     }
 }
 
+/// A response to an `update` RPC sent to a plugin.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum UpdateResponse {
+    /// An edit to the buffer.
+    Edit(PluginEdit),
+    /// An acknowledgement with no action. A response cannot be Null, so we send a uint.
+    Ack(u64),
+}
+
+
+// ====================================================================
+// plugin -> core RPC method types
+// ====================================================================
+
+
 /// An simple edit, received from a plugin.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PluginEdit {
@@ -71,17 +116,8 @@ pub struct PluginEdit {
     pub author: String,
 }
 
-/// A response to an `update` RPC sent to a plugin.
 #[derive(Serialize, Deserialize, Debug)]
-#[serde(untagged)]
-pub enum UpdateResponse {
-    /// An edit to the buffer.
-    Edit(PluginEdit),
-    /// An acknowledgement with no action. A response cannot be Null, so we send a uint.
-    Ack(u64),
-}
-
-#[derive(Serialize, Deserialize, Debug)]
+/// A text range and style information.
 pub struct Span {
     pub start: usize,
     pub end: usize,
@@ -92,10 +128,53 @@ pub struct Span {
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(untagged)]
-/// RPC commands sent from the plugins.
+/// RPC commands sent from plugins.
 pub enum PluginCommand {
     SetFgSpans {start: usize, len: usize, spans: Vec<Span>, rev: usize },
     GetData { offset: usize, max_size: usize, rev: usize },
     Alert { msg: String },
     LineCount,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+    
+    #[test]
+    fn test_plugin_update() {
+        let json = r#"{
+            "start": 1,
+            "end": 5,
+            "new_len": 2,
+            "rev": 5,
+            "edit_type": "something",
+            "author": "me"
+    }"#;
+
+    let val: PluginUpdate = match serde_json::from_str(json) {
+        Ok(val) => val,
+        Err(err) => panic!("{:?}", err),
+    };
+    assert!(val.text.is_none());
+    assert_eq!(val.start, 1);
+    }
+
+    #[test]
+    fn test_deserde_init() {
+        let json = r#"
+            {"rev": 1,
+             "buf_size": 20,
+             "nb_lines": 5,
+             "path": "some_path",
+             "syntax": "toml"}"#;
+
+        let val: PluginBufferInfo = match serde_json::from_str(json) {
+            Ok(val) => val,
+            Err(err) => panic!("{:?}", err),
+        };
+        assert_eq!(val.rev, 1);
+        assert_eq!(val.path, Some("some_path".to_owned()));
+        assert_eq!(val.syntax, SyntaxDefinition::Toml);
+    }
 }

--- a/rust/core-lib/src/syntax.rs
+++ b/rust/core-lib/src/syntax.rs
@@ -1,0 +1,122 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Very basic syntax detection.
+
+use std::fmt;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum SyntaxDefinition {
+    Plaintext, Markdown, Python, Rust, C, Go, Dart, Swift, Toml,
+    Json, Yaml, Cpp, Objc, Shell, Ruby, Javascript, Java, Php,
+    Perl, 
+}
+
+impl Default for SyntaxDefinition {
+    fn default() -> Self {
+        SyntaxDefinition::Plaintext
+    }
+}
+
+// TODO: these should also serialize as strings, probably using this as a guide:
+
+impl SyntaxDefinition {
+    pub fn new<'a, S: Into<Option<&'a str>>>(s: S) -> Self {
+        use self::SyntaxDefinition::*;
+        if let Some(s) = s.into() {
+            match &*s.split('.').rev().nth(0).unwrap_or("").to_lowercase() {
+                "rs" => Rust,
+                "md" | "mdown" => Markdown,
+                "py" => Python,
+                "c" | "h" => C,
+                "go" => Go,
+                "dart" => Dart,
+                "swift" => Swift,
+                "toml" => Toml,
+                "json" => Json,
+                "yaml" => Yaml,
+                "cc" => Cpp,
+                "m" => Objc,
+                "sh" | "zsh" => Shell,
+                "rb" => Ruby,
+                "js" => Javascript,
+                "java" | "jav" => Java,
+                "php" => Php,
+                "pl" => Perl,
+                _ => Plaintext,
+            }
+        } else {
+            Plaintext
+        }
+    }
+
+    //TODO: this is not currently used.
+    //We might want it for language server interop?
+    /// Canonical language identifiers, used for serialization.
+    /// https://code.visualstudio.com/docs/languages/identifiers
+    pub fn identifier(&self) -> &str {
+        use self::SyntaxDefinition::*;
+        match *self {
+            Rust => "rust",
+            Markdown => "markdown",
+            //TODO: :|
+            Python => "python3",
+            C => "c" ,
+            Go => "go",
+            Dart => "dart",
+            Swift => "swift",
+            Toml => "toml",
+            Json => "json",
+            Yaml => "yaml",
+            Cpp => "cpp",
+            Objc => "objective-c",
+            Shell => "shellscript",
+            Ruby => "ruby",
+            Javascript => "javascript",
+            Java => "java",
+            Php => "php",
+            Perl => "perl",
+            Plaintext => "plaintext",
+        }
+    }
+}
+
+impl<S: AsRef<str>> From<S> for SyntaxDefinition {
+    fn from(s: S) -> Self {
+        SyntaxDefinition::new(s.as_ref())
+    }
+}
+
+impl fmt::Display for SyntaxDefinition {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.identifier())
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_syntax() {
+        assert_eq!(SyntaxDefinition::from("plugins.rs"), SyntaxDefinition::Rust);
+        assert_eq!(SyntaxDefinition::from("plugins.py"), SyntaxDefinition::Python);
+        assert_eq!(SyntaxDefinition::from("header.h"), SyntaxDefinition::C);
+        assert_eq!(SyntaxDefinition::from("main.ada"), SyntaxDefinition::Plaintext);
+        assert_eq!(SyntaxDefinition::from("build"), SyntaxDefinition::Plaintext);
+        assert_eq!(SyntaxDefinition::from("build.test.sh"), SyntaxDefinition::Shell);
+    }
+}

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -27,6 +27,7 @@ use editor::Editor;
 use rpc::{CoreCommand, EditCommand, PluginCommand};
 use styles::{Style, StyleMap};
 use MainPeer;
+
 use syntax::SyntaxDefinition;
 use plugins::{self, PluginManagerRef};
 use plugins::rpc_types::PluginUpdate;
@@ -408,12 +409,14 @@ impl<W: Write + Send + 'static> Documents<W> {
             Start { view_id, plugin_name } => {
                 // TODO: this is a hack, there are different ways a plugin might be launched
                 // and they would have different init params, this is just mimicing old api
-                let (buf_size, _, rev) = {
-                self.buffers.lock().editor_for_view(&view_id).unwrap()
-                    .plugin_init_params()
-                };
 
-                self.plugins.start_plugin(&view_id, &plugin_name, buf_size, rev);
+                // TODO: track syntax defs
+                let syntax = SyntaxDefinition::Plaintext;
+                let buffer_info = self.buffers.lock().editor_for_view(&view_id).unwrap()
+                    .plugin_init_info();
+
+                //TODO: stop passing buffer ids
+                self.plugins.start_plugin(&view_id, &plugin_name, &buffer_info);
                 None
             }
             Stop { view_id, plugin_name } => {

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -409,7 +409,11 @@ impl<W: Write + Send + 'static> Documents<W> {
                 None
             }
             //TODO: stop a plugin
-            Stop { view_id, plugin_name } => None,
+            Stop { view_id, plugin_name } => {
+                print_err!("stop plugin rpc {}", plugin_name);
+                self.plugins.stop_plugin(&view_id, &plugin_name);
+                None
+            }
         }
     }
 

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -396,7 +396,7 @@ impl<W: Write + Send + 'static> Documents<W> {
         use self::PluginCommand::*;
         match cmd {
             InitialPlugins { view_id } => Some(json!(
-                    self.plugins.lock().debug_available_plugins())),
+                    self.plugins.lock().available_plugins(&view_id))),
             Start { view_id, plugin_name } => {
                 // TODO: this is a hack, there are different ways a plugin might be launched
                 // and they would have different init params, this is just mimicing old api

--- a/rust/plugin-lib/Cargo.toml
+++ b/rust/plugin-lib/Cargo.toml
@@ -7,7 +7,9 @@ repository = "https://github.com/google/xi-editor"
 description = "The library base for implementing xi-editor plugins."
 
 [dependencies]
+serde = "1.0"
 serde_json = "1.0"
+serde_derive = "1.0"
 
 [dependencies.xi-rpc]
 path = "../rpc"

--- a/rust/plugin-lib/src/caching_plugin.rs
+++ b/rust/plugin-lib/src/caching_plugin.rs
@@ -73,7 +73,7 @@ impl<'a, H: Handler> plugin_base::Handler for MyHandler<'a, H> {
                 None
             }
             PluginRequest::Update { start, end, new_len, rev, edit_type, author, text } => {
-                print_err!("got update notification {:?}", edit_type);
+                //print_err!("got update notification {:?}", edit_type);
                 ctx.state.buf_size = ctx.state.buf_size - (end - start) + new_len;
                 ctx.state.rev = rev;
                 if let (Some(text), Some(mut cache)) = (text, ctx.state.cache.take()) {
@@ -95,7 +95,7 @@ impl<'a, H: Handler> plugin_base::Handler for MyHandler<'a, H> {
                 ctx.state.line_num = 0;
                 ctx.state.offset_of_line = 0;
                 self.handler.update(ctx);
-                Some(Value::Null)
+                Some(Value::from(0i32))
             }
         }
     }

--- a/rust/plugin-lib/src/caching_plugin.rs
+++ b/rust/plugin-lib/src/caching_plugin.rs
@@ -14,6 +14,7 @@
 
 //! A caching layer for xi plugins. Will be split out into its own crate once it's a bit more stable.
 
+use std::path::PathBuf;
 use serde_json::Value;
 
 use plugin_base;
@@ -25,7 +26,7 @@ const CHUNK_SIZE: usize = 1024 * 1024;
 
 /// A handler that the plugin needs to instantiate.
 pub trait Handler {
-    fn init_buf(&mut self, ctx: PluginCtx, buf_size: usize);
+    fn initialize(&mut self, ctx: PluginCtx, buf_size: usize);
     fn update(&mut self, ctx: PluginCtx);
     #[allow(unused_variables)]
     fn idle(&mut self, ctx: PluginCtx, token: usize) {}
@@ -42,6 +43,9 @@ struct State {
     // line iteration state
     line_num: usize,
     offset_of_line: usize,
+
+    syntax: String,
+    path: Option<PathBuf>,
 }
 
 pub struct PluginCtx<'a> {
@@ -65,11 +69,12 @@ impl<'a, H: Handler> plugin_base::Handler for MyHandler<'a, H> {
                 print_err!("got ping");
                 None
             }
-            PluginRequest::InitBuf { buf_size, rev } => {
-                print_err!("got init_buf buf_size = {}, rev = {}", buf_size, rev);
-                ctx.state.buf_size = buf_size;
-                ctx.state.rev = rev;
-                self.handler.init_buf(ctx, buf_size);
+            PluginRequest::Initialize(ref init_info) => {
+                ctx.state.buf_size = init_info.buf_size;
+                ctx.state.rev = init_info.rev;
+                ctx.state.syntax = init_info.syntax.clone();
+                ctx.state.path = init_info.path.clone().map(|p| PathBuf::from(p));
+                self.handler.initialize(ctx, init_info.buf_size);
                 None
             }
             PluginRequest::Update { start, end, new_len, rev, edit_type, author, text } => {
@@ -166,6 +171,13 @@ impl<'a> PluginCtx<'a> {
                     return Ok(Some(result));
                 }
             }
+        }
+    }
+
+    pub fn get_path(&self) -> Option<&PathBuf> {
+        match self.state.path {
+            Some(ref p) => Some(p),
+            None => None,
         }
     }
 

--- a/rust/plugin-lib/src/lib.rs
+++ b/rust/plugin-lib/src/lib.rs
@@ -17,6 +17,8 @@
 extern crate xi_rpc;
 #[macro_use]
 extern crate serde_json;
+#[macro_use]
+extern crate serde_derive;
 
 #[macro_use]
 mod macros;

--- a/rust/syntect-plugin/Cargo.lock
+++ b/rust/syntect-plugin/Cargo.lock
@@ -182,6 +182,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +217,25 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "serde_derive"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_internals 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +244,24 @@ dependencies = [
  "itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -252,6 +294,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "walkdir"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +321,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "xi-plugin-lib"
 version = "0.1.0"
 dependencies = [
+ "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "xi-rpc 0.2.0",
 ]
@@ -325,15 +374,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum onig_sys 61.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a35f2cca300f0945538564da6052a449db55e65870cf0e9d443c1bce3d5dda47"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum plist 0.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "29f7f7deddf1244a97e2771e47edb01e5b5603d133bd4a0e516ea0e6817adc64"
+"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum redox_syscall 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd35cc9a8bdec562c757e3d43c1526b5c6d2653e23e2315065bc25556550753"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "237546c689f20bb44980270c73c3b9edd0891c1be49cc1274406134a66d3957b"
 "checksum serde 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1b0e0732aa8ec4267f61815a396a942ba3525062e3bd5520aa8419927cfc0a92"
 "checksum serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 "checksum serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3b46a59dd63931010fdb1d88538513f3279090d88b5c22ef4fe8440cfffcc6e3"
+"checksum serde_derive 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9fd81eef9f0b4ec341b11095335b6a4b28ed85581b12dd27585dee1529df35e0"
+"checksum serde_derive_internals 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "021c338d22c7e30f957a6ab7e388cb6098499dda9fd4ba1661ee074ca7a180d1"
 "checksum serde_json 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1c62115693d0a9ed8c32d1c760f0fdbe7d4b05cb13c135b9b54137ac0d59fccb"
+"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum syntect 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e9d678dfa7f7f9c90535caaa81778c971765942fcd57aceffc3acd34564fc0fd"
 "checksum time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "211b63c112206356ef1ff9b19355f43740fc3f85960c598a93d3a3d3ba7beade"
+"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum walkdir 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c66c0b9792f0a765345452775f3adbd28dde9d33f30d13e5dcc5ae17cf6f3780"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/rust/syntect-plugin/src/main.rs
+++ b/rust/syntect-plugin/src/main.rs
@@ -105,8 +105,13 @@ impl<'a> PluginState<'a> {
     }
 
     fn do_highlighting(&mut self, mut ctx: PluginCtx) {
-        let syntax = self.sets.ss.find_syntax_by_extension("rs")
-            .unwrap_or_else(|| self.sets.ss.find_syntax_plain_text());
+        let syntax = match ctx.get_path() {
+            Some(ref path) => self.sets.ss.find_syntax_for_file(path).unwrap()
+                .unwrap_or_else(|| self.sets.ss.find_syntax_plain_text()),
+            None => self.sets.ss.find_syntax_plain_text(),
+        };
+        print_err!("syntect using {}", syntax.name);
+
         self.parse_state = Some(ParseState::new(syntax));
         let theme = &self.sets.ts.themes["InspiredGitHub"];
         self.highlighter = Some(Highlighter::new(theme));
@@ -121,7 +126,7 @@ impl<'a> PluginState<'a> {
 const LINES_PER_RPC: usize = 50;
 
 impl<'a> caching_plugin::Handler for PluginState<'a> {
-    fn init_buf(&mut self, ctx: PluginCtx, _buf_size: usize) {
+    fn initialize(&mut self, ctx: PluginCtx, _buf_size: usize) {
         self.do_highlighting(ctx);
     }
 


### PR DESCRIPTION
This is very rough around the edges but brings some tangible editor improvements:

- plugins now start when a new file is opened (syntect always starts, spellcheck starts if you're in plaintext or markdown, as a proof of concept)
- plugins can be _stopped_, from the dropdown menu (as well as when you close a window)
- If you open a file, syntect chooses a syntax definition based on the file path
- **saving a file does not change syntax**. Soon.

I haven't tested this super super extensively, but wanted to get it up for review sooner rather than later.

There's a compatible xi-mac PR here: https://github.com/google/xi-mac/pull/38