### PR TITLE
Identifiers are now real types

### DIFF
--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -344,7 +344,7 @@ impl<W: Write + Send + 'static> Editor<W> {
         // plugins get updated. This ensures that gc runs.
         self.increment_revs_in_flight();
 
-        let author = author.unwrap_or(&self.view.view_id);
+        let author = author.unwrap_or(&self.view.view_id.as_str());
         let text = match new_len < MAX_SIZE_LIMIT {
             true => Some(self.text.slice_to_string(iv.start(), iv.start() + new_len)),
             false => None

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -103,12 +103,12 @@ impl EditType {
 
 impl<W: Write + Send + 'static> Editor<W> {
     /// Creates a new `Editor` with a new empty buffer.
-    pub fn new(doc_ctx: DocumentCtx<W>, initial_view_id: &str) -> Editor<W> {
+    pub fn new(doc_ctx: DocumentCtx<W>, initial_view_id: &ViewIdentifier) -> Editor<W> {
         Self::with_text(doc_ctx, initial_view_id, "".to_owned())
     }
 
     /// Creates a new `Editor`, loading text into a new buffer.
-    pub fn with_text(doc_ctx: DocumentCtx<W>, initial_view_id: &str, text: String) -> Editor<W> {
+    pub fn with_text(doc_ctx: DocumentCtx<W>, initial_view_id: &ViewIdentifier, text: String) -> Editor<W> {
 
         let engine = Engine::new(Rope::from(text));
         let buffer = engine.get_head();
@@ -141,10 +141,10 @@ impl<W: Write + Send + 'static> Editor<W> {
 
 
     #[allow(unreachable_code, unused_variables)]
-    pub fn add_view(&mut self, view_id: &str) {
+    pub fn add_view(&mut self, view_id: &ViewIdentifier) {
         panic!("multi-view support is not currently implemented");
         assert!(!self.views.contains_key(view_id), "view_id already exists");
-        self.views.insert(view_id.to_owned(), View::new(view_id.to_owned()));
+        self.views.insert(view_id.to_owned(), View::new(view_id));
     }
 
     /// Removes a view from this editor's stack, if this editor has multiple views.
@@ -152,8 +152,8 @@ impl<W: Write + Send + 'static> Editor<W> {
     /// If the editor only has a single view this is a no-op. After removing a view the caller must
     /// always call Editor::has_views() to determine whether or not the editor should be cleaned up.
     #[allow(unreachable_code)]
-    pub fn remove_view(&mut self, view_id: &str) {
-        if self.view.view_id == view_id {
+    pub fn remove_view(&mut self, view_id: &ViewIdentifier) {
+        if self.view.view_id == *view_id {
             if self.views.len() > 0 {
                 panic!("multi-view support is not currently implemented");
                 //set some other view as active. This will be reset on the next EditCommand
@@ -774,12 +774,12 @@ impl<W: Write + Send + 'static> Editor<W> {
         self.insert(&*String::from(kill_ring_string));
     }
 
-    pub fn do_rpc(&mut self, view_id: &str, cmd: EditCommand) -> Option<Value> {
+    pub fn do_rpc(&mut self, view_id: &ViewIdentifier, cmd: EditCommand) -> Option<Value> {
 
         use rpc::EditCommand::*;
 
         // if the rpc's originating view is different from current self.view, swap it in
-        if self.view.view_id != view_id {
+        if self.view.view_id != *view_id {
             let mut temp = self.views.remove(view_id).expect("no view for provided view_id");
             mem::swap(&mut temp, &mut self.view);
             self.views.insert(temp.view_id.clone(), temp);

--- a/rust/core-lib/src/plugins/manager.rs
+++ b/rust/core-lib/src/plugins/manager.rs
@@ -44,7 +44,8 @@ impl <W: Write + Send + 'static>PluginManager<W> {
     /// Returns plugins available to this view.
     pub fn available_plugins(&self, view_id: &ViewIdentifier) -> Vec<ClientPluginInfo> {
         self.catalog.iter().map(|p| {
-            let key = (view_id.to_owned(), p.name.clone());
+            let buffer_id = self.buffer_for_view(view_id);
+            let key = (buffer_id, p.name.clone());
             let running = self.running.contains_key(&key);
             let name = key.1;
             ClientPluginInfo { name, running }
@@ -82,7 +83,8 @@ impl <W: Write + Send + 'static>PluginManager<W> {
     pub fn update(&mut self, view_id: &ViewIdentifier, update: PluginUpdate,
                   undo_group: usize) {
         // find all running plugins for this buffer, and send them the update
-        for (_, plugin) in self.running.iter().filter(|kv| (kv.0).0 == *view_id) {
+        let buffer_id = self.buffer_for_view(view_id);
+        for (_, plugin) in self.running.iter().filter(|kv| (kv.0).0 == buffer_id) {
             self.buffers.lock().editor_for_view_mut(view_id)
                 .unwrap().increment_revs_in_flight();
             let view_id = view_id.to_owned();
@@ -110,42 +112,66 @@ impl <W: Write + Send + 'static>PluginManager<W> {
     pub fn start_plugin(&mut self, self_ref: &PluginManagerRef<W>,
                           view_id: &ViewIdentifier, plugin_name: &str, init_info: PluginBufferInfo) {
         //TODO: error handling: this should maybe have a completion callback with a Result
-        let key = (view_id.to_owned(), plugin_name.to_owned());
-        if self.running.contains_key(&key) {
-            return print_err!("plugin {} already running for buffer {}", plugin_name, view_id);
-        }
-
-        let plugin = self.catalog.iter().find(|desc| desc.name == plugin_name)
-            .expect(&format!("no plugin found with name {}", plugin_name));
-
-        let me = self_ref.clone();
-        plugin.launch(self_ref, view_id, move |result| {
-            match result {
-                Ok(plugin_ref) => {
-                    plugin_ref.initialize(&init_info);
-                    let mut inner = me.lock();
-                    inner.buffers.lock().editor_for_view(&key.0).unwrap().plugin_started(&key.0, &key.1);
-                    inner.running.insert(key, plugin_ref);
-                },
-                Err(_) => panic!("error handling is not implemented"),
+        let buffer_id = self.buffers.buffer_for_view(view_id);
+        if let Some(buffer_id) = buffer_id {
+            let key = (buffer_id.to_owned(), plugin_name.to_owned());
+            if self.running.contains_key(&key) {
+                return print_err!("plugin {} already running for buffer {}", plugin_name, key.0);
             }
-        });
+
+            let plugin = self.catalog.iter().find(|desc| desc.name == plugin_name)
+                .expect(&format!("no plugin found with name {}", plugin_name));
+
+            let me = self_ref.clone();
+            let view_id2 = view_id.to_owned();
+            plugin.launch(self_ref, view_id, move |result| {
+                match result {
+                    Ok(plugin_ref) => {
+                        plugin_ref.initialize(&init_info);
+                        let mut inner = me.lock();
+                        let mut running = false;
+
+                        if let Some(ed) = inner.buffers.lock()
+                            .editor_for_view(&view_id2) {
+                                ed.plugin_started(&view_id2, &key.1);
+                                running = true;
+                            }
+                        if running {
+                            inner.running.insert(key, plugin_ref);
+                        }
+                    }
+                    Err(_) => panic!("error handling is not implemented"),
+                }
+            });
+        }
+        else {
+            print_err!("couldn't start plugin {}, no buffer found for view {}",
+                       plugin_name, view_id)
+        }
     }
 
     fn stop_plugin(&mut self, view_id: &ViewIdentifier, plugin_name: &str) {
-        let key = (view_id.to_owned(), plugin_name.to_owned());
-        match self.running.remove(&key) {
-            Some(plugin) => {
-                plugin.shutdown();
-                //TODO: should we notify now, or wait until we know this worked?
-                //can this fail? (yes.) How do we tell, and when do we kill the proc?
-                if let Some(editor) = self.buffers.lock().editor_for_view(view_id) {
-                    editor.plugin_stopped(view_id, plugin_name, 0);
+        if let Some(buffer_id) = self.buffers.buffer_for_view(view_id) {
+            let key = (buffer_id.to_owned(), plugin_name.to_owned());
+            match self.running.remove(&key) {
+                Some(plugin) => {
+                    plugin.shutdown();
+                    //TODO: should we notify now, or wait until we know this worked?
+                    //can this fail? (yes.) How do we tell, and when do we kill the proc?
+                    if let Some(editor) = self.buffers.lock().editor_for_view(view_id) {
+                        editor.plugin_stopped(view_id, plugin_name, 0);
+                    }
                 }
+                None => print_err!("stop_plugin: plugin not running for buffer {} {}",
+                                   plugin_name, view_id),
             }
-            None => print_err!("stop_plugin: plugin not running for buffer {} {}",
-                               plugin_name, view_id),
         }
+    }
+
+    fn buffer_for_view(&self, view_id: &ViewIdentifier) -> BufferIdentifier {
+        let buffer_id = self.buffers.buffer_for_view(view_id);
+        if buffer_id.is_none() { print_err!("no buffer for view {}", view_id) }
+        buffer_id.unwrap_or(BufferIdentifier::from("null-id"))
     }
 }
 
@@ -218,8 +244,9 @@ impl<W: Write + Send + 'static> PluginManagerRef<W> {
 
     /// Called when a buffer is closed.
     pub fn document_close(&mut self, view_id: &ViewIdentifier) {
+        let buffer_id = self.lock().buffer_for_view(view_id);
         let to_stop = self.lock().running.keys()
-            .filter(|k| k.0 == *view_id)
+            .filter(|k| k.0 == buffer_id)
             .map(|k| k.1.to_owned())
             .collect::<Vec<_>>();
         for plugin_name in to_stop {
@@ -231,9 +258,11 @@ impl<W: Write + Send + 'static> PluginManagerRef<W> {
     /// Called when a document's syntax definition has changed.
     pub fn document_syntax_changed(&mut self, view_id: &ViewIdentifier) {
         print_err!("document_syntax_changed {}", view_id);
+        let buffer_id = self.lock().buffer_for_view(view_id);
+
         let start_keys = self.activatable_plugins(view_id)
             .iter()
-            .map(|plg| (view_id.to_owned(), plg.to_owned()))
+            .map(|plg| (buffer_id.clone(), plg.to_owned()))
             .collect::<BTreeSet<_>>();
 
         // stop currently running plugins that aren't on list

--- a/rust/core-lib/src/plugins/manager.rs
+++ b/rust/core-lib/src/plugins/manager.rs
@@ -135,7 +135,7 @@ impl <W: Write + Send + 'static>PluginManager<W> {
                             .editor_for_view(&view_id2) {
                                 ed.plugin_started(&view_id2, &key.1);
                                 running = true;
-                            }
+                        }
                         if running {
                             inner.running.insert(key, plugin_ref);
                         }

--- a/rust/core-lib/src/plugins/manifest.rs
+++ b/rust/core-lib/src/plugins/manifest.rs
@@ -36,7 +36,6 @@ static PLUGIN_DIR: &'static str = "XI_PLUGIN_DIR";
 // example plugins. Eventually these should be loaded from disk.
 pub fn debug_plugins() -> Vec<PluginDescription> {
     use self::PluginActivation::*;
-    use self::SyntaxDefinition::*;
     let plugin_dir = match env::var(PLUGIN_DIR).map(PathBuf::from) {
         Ok(p) => p,
         Err(_) => env::current_exe().unwrap().parent().unwrap().to_owned(),
@@ -92,6 +91,7 @@ pub enum PluginActivation {
     /// Always run this plugin, when available.
     Autorun,
     /// Run this plugin if the provided SyntaxDefinition is active.
+    #[allow(dead_code)]
     OnSyntax(SyntaxDefinition),
     /// Run this plugin in response to a given command.
     #[allow(dead_code)]

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -15,6 +15,8 @@
 //! A container for all the documents being edited. Also functions as main dispatch for RPC.
 
 use std::collections::BTreeMap;
+use std::fmt;
+use std::ops::Deref;
 use std::io::{self, Read, Write};
 use std::path::{PathBuf, Path};
 use std::fs::File;
@@ -33,11 +35,51 @@ use plugins::{self, PluginManagerRef};
 use plugins::rpc_types::PluginUpdate;
 
 /// ViewIdentifiers are the primary means of routing messages between xi-core and a client view.
-pub type ViewIdentifier = String;
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ViewIdentifier(String);
+
+impl fmt::Display for ViewIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0) 
+    }
+}
+
+impl Deref for ViewIdentifier {
+    type Target = String;
+    fn deref(&self) -> &String {
+        &self.0
+    }
+}
+
+impl<T: AsRef<str>> From<T> for ViewIdentifier {
+    fn from(s: T) -> Self {
+        ViewIdentifier(String::from(s.as_ref()))
+    }
+}
+
 
 /// BufferIdentifiers uniquely identify open buffers.
-pub type BufferIdentifier = String;
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct BufferIdentifier(String);
 
+impl fmt::Display for BufferIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0) 
+    }
+}
+
+impl Deref for BufferIdentifier {
+    type Target = String;
+    fn deref(&self) -> &String {
+        &self.0
+    }
+}
+
+impl<T: AsRef<str>> From<T> for BufferIdentifier {
+    fn from(s: T) -> Self {
+        BufferIdentifier(String::from(s.as_ref()))
+    }
+}
 
 /// Tracks open buffers, and relationships between buffers and views.
 pub struct BufferContainer<W: Write> {
@@ -69,7 +111,7 @@ pub struct BufferContainerRef<W: Write>(Arc<Mutex<BufferContainer<W>>>);
 /// [BufferContainer]: struct.BufferContainer.html
 pub struct WeakBufferContainerRef<W: Write>(Weak<Mutex<BufferContainer<W>>>);
 
-impl <W:Write>BufferContainer<W> {
+impl<W:Write> BufferContainer<W> {
     /// Returns a reference to the `Editor` instance owning `view_id`'s view.
     ///
     /// Panics if no buffer is associated with `view_id`.
@@ -97,7 +139,7 @@ impl <W:Write>BufferContainer<W> {
     }
 }
 
-impl <W: Write + Send + 'static>BufferContainerRef<W> {
+impl<W: Write + Send + 'static> BufferContainerRef<W> {
     pub fn new() -> Self {
         BufferContainerRef(Arc::new(Mutex::new(
                     BufferContainer {
@@ -121,6 +163,11 @@ impl <W: Write + Send + 'static>BufferContainerRef<W> {
     /// Returns `true` if `file_path` is already open, else `false`.
     pub fn has_open_file<P: AsRef<Path>>(&self, file_path: P) -> bool {
         self.lock().open_files.contains_key(file_path.as_ref())
+    }
+
+    /// Returns a copy of the BufferIdentifier associated with a given view.
+    pub fn buffer_for_view(&self, view_id: &ViewIdentifier) -> Option<BufferIdentifier> {
+        self.lock().views.get(view_id).map(|id| id.to_owned())
     }
 
     /// Adds a new editor, associating it with the provided identifiers.
@@ -255,12 +302,12 @@ impl<W: Write + Send + 'static> Documents<W> {
 
     fn next_view_id(&mut self) -> ViewIdentifier {
         self.id_counter += 1;
-        format!("view-id-{}", self.id_counter)
+        ViewIdentifier::from(format!("view-id-{}", self.id_counter))
     }
 
     fn next_buffer_id(&mut self) -> BufferIdentifier {
         self.id_counter += 1;
-        format!("buffer-id-{}", self.id_counter)
+        BufferIdentifier::from(format!("buffer-id-{}", self.id_counter))
     }
 
     pub fn do_rpc(&mut self, cmd: CoreCommand, rpc_peer: &MainPeer<W>) -> Option<Value> {
@@ -268,13 +315,13 @@ impl<W: Write + Send + 'static> Documents<W> {
 
         match cmd {
             CloseView { view_id } => {
-                self.do_close_view(&view_id.to_owned());
+                self.do_close_view(&view_id);
                 None
             },
 
             NewView { file_path } => Some(self.do_new_view(rpc_peer, file_path)),
-            Save { view_id, file_path } => self.do_save(&view_id.to_owned(), file_path),
-            Edit { view_id, edit_command } => self.do_edit(&view_id.to_owned(), edit_command),
+            Save { view_id, file_path } => self.do_save(&view_id, file_path),
+            Edit { view_id, edit_command } => self.do_edit(&view_id, edit_command),
             Plugin { plugin_command } => self.do_plugin_cmd(plugin_command),
         }
     }
@@ -316,8 +363,8 @@ impl<W: Write + Send + 'static> Documents<W> {
     }
 
     fn do_close_view(&mut self, view_id: &ViewIdentifier) {
-        self.buffers.close_view(view_id);
         self.plugins.document_close(view_id);
+        self.buffers.close_view(view_id);
     }
 
     fn new_empty_view(&mut self, rpc_peer: &MainPeer<W>, view_id: &ViewIdentifier,
@@ -518,6 +565,7 @@ mod tests {
     use xi_rpc::{RpcLoop};
     use std::env;
     use std::fs::File;
+    use serde_json;
 
     // a bit of gymnastics to let us instantiate an Editor instance
     fn mock_doc_ctx(tempfile: &str) -> DocumentCtx<File> {
@@ -541,8 +589,8 @@ mod tests {
     fn test_save_as() {
         let container_ref = BufferContainerRef::new();
         assert!(!container_ref.has_open_file("a fake file, for sure"));
-        let view_id_1 = "view-id-1".to_owned();
-        let buf_id_1 = "buf-id-1".to_owned();
+        let view_id_1 = ViewIdentifier::from("view-id-1");
+        let buf_id_1 = BufferIdentifier::from("buf-id-1");
         let path_1 = PathBuf::from("a_path");
         let path_2 = PathBuf::from("a_different_path");
         let editor = Editor::new(mock_doc_ctx(&view_id_1), &view_id_1);
@@ -566,8 +614,8 @@ mod tests {
             Some(path_2.as_ref()));
 
         // reopen the original file:
-        let view_id_2 = "view-id-2".to_owned();
-        let buf_id_2 = "buf-id-2".to_owned();
+        let view_id_2 = ViewIdentifier::from("view-id-2");
+        let buf_id_2 = BufferIdentifier::from("buf-id-2");
         let editor = Editor::new(mock_doc_ctx(&view_id_2), &view_id_2);
         container_ref.add_editor(&view_id_2, &buf_id_2, editor);
         container_ref.set_path(&path_1, &view_id_2);
@@ -583,5 +631,13 @@ mod tests {
         container_ref.close_view(&view_id_2);
         assert_eq!(container_ref.has_open_file(&path_2), false);
         assert_eq!(container_ref.lock().editors.len(), 0);
+    }
+
+    #[test]
+    fn test_id_serde() {
+        // check to see that struct with single string member serializes as string
+        let view_id = ViewIdentifier::from("hello-id-8");
+        let as_val = serde_json::to_value(&view_id).unwrap();
+        assert_eq!(as_val.to_string(), "\"hello-id-8\"");
     }
 }

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -76,9 +76,9 @@ pub struct View {
 }
 
 impl View {
-    pub fn new<S: AsRef<str>>(view_id: S) -> View {
+    pub fn new(view_id: &ViewIdentifier) -> View {
         View {
-            view_id: view_id.as_ref().to_owned(),
+            view_id: view_id.to_owned(),
             sel_start: 0,
             sel_end: 0,
             // used to maintain preferred hpos during vertical movement


### PR DESCRIPTION
This patch makes better use of the type system to distinguish between `BufferIdentifier` and `ViewIdentifier`. 

There were a few spots in the plugin code where this was poorly distinguished, and this change makes me a bit more considered about those places. It also will make it easier to use some value type as an identifier in the future.