### PR TITLE
Prepare Engine code for switch to separate tombstones

### DIFF
--- a/rust/rope/src/delta.rs
+++ b/rust/rope/src/delta.rs
@@ -21,6 +21,7 @@ use tree::{Node, NodeInfo, TreeBuilder};
 use subset::{Subset, SubsetBuilder};
 use std::cmp::min;
 use std::ops::Deref;
+use std::fmt;
 
 #[derive(Clone)]
 enum DeltaElement<N: NodeInfo> {
@@ -230,6 +231,24 @@ impl<N: NodeInfo> Delta<N> {
                 DeltaElement::Insert(ref n) => n.len()
             }
         )
+    }
+}
+
+impl<N: NodeInfo> fmt::Debug for Delta<N> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        try!(write!(f, "Delta("));
+        for el in &self.els {
+            match *el {
+                DeltaElement::Copy(beg,end) => {
+                    try!(write!(f, "[{},{}) ", beg, end));
+                }
+                DeltaElement::Insert(ref node) => {
+                    try!(write!(f, "<ins:{}> ", node.len()));
+                }
+            }
+        }
+        try!(write!(f, ")"));
+        Ok(())
     }
 }
 

--- a/rust/rope/src/delta.rs
+++ b/rust/rope/src/delta.rs
@@ -158,7 +158,7 @@ impl<N: NodeInfo> Delta<N> {
                 if last_old.is_some() && last_old.unwrap().0 <= beg {
                     let (ib, ie) = last_old.unwrap();
                     let end = min(e, ie);
-                    // Try to merge contigous Copys in the output
+                    // Try to merge contiguous Copys in the output
                     let xbeg = beg + x - ib;  // "beg - ib + x" better for overflow?
                     let xend = end + x - ib;  // ditto
                     let merged = if let Some(&mut DeltaElement::Copy(_, ref mut le)) = els.last_mut() {
@@ -502,7 +502,7 @@ mod tests {
     use rope::Rope;
     use delta::{Delta};
     use interval::Interval;
-    use test_helpers::{find_deletions};
+    use test_helpers::find_deletions;
 
     const TEST_STR: &'static str = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 

--- a/rust/rope/src/engine.rs
+++ b/rust/rope/src/engine.rs
@@ -351,3 +351,97 @@ impl Engine {
         self.revs.reverse();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use engine::Engine;
+    use rope::{Rope, RopeInfo};
+    use delta::{Builder, Delta};
+    use interval::Interval;
+    use std::collections::BTreeSet;
+
+    const TEST_STR: &'static str = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+    fn build_delta_1() -> Delta<RopeInfo> {
+        let mut d_builder = Builder::new(TEST_STR.len());
+        d_builder.delete(Interval::new_closed_open(10, 36));
+        d_builder.replace(Interval::new_closed_open(39, 42), Rope::from("DEEF"));
+        d_builder.replace(Interval::new_closed_open(54, 54), Rope::from("999"));
+        d_builder.delete(Interval::new_closed_open(58, 61));
+        d_builder.build()
+    }
+
+    fn build_delta_2() -> Delta<RopeInfo> {
+        let mut d_builder = Builder::new(TEST_STR.len());
+        d_builder.replace(Interval::new_closed_open(1, 3), Rope::from("!"));
+        d_builder.delete(Interval::new_closed_open(10, 36));
+        d_builder.replace(Interval::new_closed_open(42, 45), Rope::from("GI"));
+        d_builder.replace(Interval::new_closed_open(54, 54), Rope::from("888"));
+        d_builder.replace(Interval::new_closed_open(59, 60), Rope::from("HI"));
+        d_builder.build()
+    }
+
+    #[test]
+    fn edit_rev_simple() {
+        let mut engine = Engine::new(Rope::from(TEST_STR));
+        engine.edit_rev(0, 0, 0, build_delta_1());
+        assert_eq!("0123456789abcDEEFghijklmnopqr999stuvz", String::from(engine.get_head()));
+    }
+
+    #[test]
+    fn edit_rev_concurrent() {
+        let mut engine = Engine::new(Rope::from(TEST_STR));
+        engine.edit_rev(1, 0, 0, build_delta_1());
+        engine.edit_rev(0, 1, 0, build_delta_2());
+        assert_eq!("0!3456789abcDEEFGIjklmnopqr888999stuvHIz", String::from(engine.get_head()));
+    }
+
+    fn edit_rev_undo_test(undos : BTreeSet<usize>, output: &str) {
+        let mut engine = Engine::new(Rope::from(TEST_STR));
+        engine.undo(undos);
+        engine.edit_rev(1, 0, 0, build_delta_1());
+        engine.edit_rev(0, 1, 0, build_delta_2());
+        assert_eq!(output, String::from(engine.get_head()));
+    }
+
+    #[test]
+    fn edit_rev_undo() {
+        edit_rev_undo_test([0,1].iter().cloned().collect(), TEST_STR);
+    }
+
+    #[test]
+    fn edit_rev_undo_2() {
+        edit_rev_undo_test([1].iter().cloned().collect(), "0123456789abcDEEFghijklmnopqr999stuvz");
+    }
+
+    #[test]
+    fn edit_rev_undo_3() {
+        edit_rev_undo_test([0].iter().cloned().collect(), "0!3456789abcdefGIjklmnopqr888stuvwHIyz");
+    }
+
+    #[test]
+    fn delta_rev_head() {
+        let mut engine = Engine::new(Rope::from(TEST_STR));
+        engine.edit_rev(1, 0, 0, build_delta_1());
+        let d = engine.delta_rev_head(0);
+        assert_eq!(String::from(engine.get_head()), d.apply_to_string(TEST_STR));
+    }
+
+    #[test]
+    fn delta_rev_head_2() {
+        let mut engine = Engine::new(Rope::from(TEST_STR));
+        engine.edit_rev(1, 0, 0, build_delta_1());
+        engine.edit_rev(0, 1, 0, build_delta_2());
+        let d = engine.delta_rev_head(0);
+        assert_eq!(String::from(engine.get_head()), d.apply_to_string(TEST_STR));
+    }
+
+    #[test]
+    fn delta_rev_head_3() {
+        let mut engine = Engine::new(Rope::from(TEST_STR));
+        engine.edit_rev(1, 0, 0, build_delta_1());
+        engine.edit_rev(0, 1, 0, build_delta_2());
+        let d = engine.delta_rev_head(1);
+        assert_eq!(String::from(engine.get_head()), d.apply_to_string("0123456789abcDEEFghijklmnopqr999stuvz"));
+    }
+}

--- a/rust/rope/src/engine.rs
+++ b/rust/rope/src/engine.rs
@@ -118,7 +118,6 @@ impl Engine {
         self.find_rev(rev).map(|rev_index| self.rev_content_for_index(rev_index))
     }
 
-    // TODO: doesn't this totally break in the presence of Undo currently?
     /// A delta that, when applied to `base_rev`, results in the current head. Panics
     /// if there is not at least one edit.
     pub fn delta_rev_head(&self, base_rev: usize) -> Delta<RopeInfo> {

--- a/rust/rope/src/lib.rs
+++ b/rust/rope/src/lib.rs
@@ -26,6 +26,8 @@ pub mod spans;
 pub mod subset;
 pub mod engine;
 pub mod find;
+#[cfg(test)]
+mod test_helpers;
 
 // TODO: "pub use" the types we want to export publicly
 

--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -19,6 +19,7 @@ use std::cmp::{min,max};
 use std::borrow::Cow;
 use std::str::FromStr;
 use std::string::ParseError;
+use std::fmt;
 
 use tree::{Leaf, Node, NodeInfo, Metric, TreeBuilder, Cursor};
 use interval::Interval;
@@ -411,6 +412,12 @@ impl From<Rope> for String {
 impl<'a> From<&'a Rope> for String {
     fn from(r: &Rope) -> String {
         r.slice_to_string(0, r.len())
+    }
+}
+
+impl fmt::Debug for Rope {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Rope({:?})", String::from(self))
     }
 }
 

--- a/rust/rope/src/subset.rs
+++ b/rust/rope/src/subset.rs
@@ -22,7 +22,7 @@ use interval::Interval;
 use std::slice;
 
 // Internally, a sorted list of (begin, end) ranges.
-#[derive(Clone, Default, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq, Debug)]
 pub struct Subset(Vec<(usize, usize)>);
 
 #[derive(Default)]

--- a/rust/rope/src/subset.rs
+++ b/rust/rope/src/subset.rs
@@ -362,22 +362,10 @@ impl<'a> Mapper<'a> {
 
 #[cfg(test)]
 mod tests {
-    use subset::{Subset, SubsetBuilder};
+    use subset::{SubsetBuilder};
+    use test_helpers::find_deletions;
 
     const TEST_STR: &'static str = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-
-    fn find_deletions(substr: &str, s: &str) -> Subset {
-        let mut sb = SubsetBuilder::new();
-        let mut j = 0;
-        for i in 0..s.len() {
-            if j < substr.len() && substr.as_bytes()[j] == s.as_bytes()[i] {
-                j += 1;
-            } else {
-                sb.add_range(i, i + 1);
-            }
-        }
-        sb.build()
-    }
 
     #[test]
     fn test_apply() {

--- a/rust/rope/src/test_helpers.rs
+++ b/rust/rope/src/test_helpers.rs
@@ -1,0 +1,22 @@
+use subset::{SubsetBuilder, Subset};
+use delta::Delta;
+use rope::{Rope, RopeInfo};
+
+pub fn find_deletions(substr: &str, s: &str) -> Subset {
+    let mut sb = SubsetBuilder::new();
+    let mut j = 0;
+    for i in 0..s.len() {
+        if j < substr.len() && substr.as_bytes()[j] == s.as_bytes()[i] {
+            j += 1;
+        } else {
+            sb.add_range(i, i + 1);
+        }
+    }
+    sb.build()
+}
+
+impl Delta<RopeInfo> {
+    pub fn apply_to_string(&self, s: &str) -> String {
+        String::from(self.apply(&Rope::from(s)))
+    }
+}

--- a/rust/rope/src/test_helpers.rs
+++ b/rust/rope/src/test_helpers.rs
@@ -1,7 +1,24 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use subset::{SubsetBuilder, Subset};
 use delta::Delta;
 use rope::{Rope, RopeInfo};
 
+/// Creates a `Subset` of `s` by scanning through `substr` and finding which
+/// characters of `s` are missing from it in order. Returns a `Subset` which
+/// when deleted from `s` yields `substr`.
 pub fn find_deletions(substr: &str, s: &str) -> Subset {
     let mut sb = SubsetBuilder::new();
     let mut j = 0;


### PR DESCRIPTION
This PR contains most of the refactoring work I did in order to switch `Engine` to use separate tombstones.

It contains the following changes:
- Improves documentation comments on a number of functions, including using Rust's example compilation checking.
- Add a `Mapper` API for mapping coordinates in string to coordinates in a `Subset`.
- Add a `transform_shrink` method to InsertDelta.
- Add `Debug` implementations for a number of structures.
- Move test helper functions that are conceivably useful in multiple places into their own private module.
- Add a bunch of tests for `Engine`. I also wrote tests for `undo` and `gc` but unfortunately tied the commits to my separation of tombstones so I couldn't easily re-order them here via rebase.

There's also one more refactoring which I think should be done and I could either add to this PR or create a new PR for: I think `Subset::transform_shrink` has its arguments in the wrong order. For `InsertDelta::transform_shrink` I had to use a different order because of the type difference, but I think that's indicative that `Subset::transform_shrink` has the wrong order.

`Subset::transform_expand` returns the subset from `self` transformed (expanded) by the parameter, and so does `InsertDelta::transform_shrink`, but `Subset::transform_shrink` currently returns the subset from the parameter transformed (shrunk) by `self`. This seems weird and counterintuitive for me, in fact when I called it with the wrong order because of this I didn't even notice it when I looked for the bug in exactly that code.

After this PR is merged I'll submit another PR with the rest of the work from the [separate-tombstones branch](https://github.com/google/xi-editor/compare/separate-tombstones)