### PR TITLE
Store separate tombstones and text instead of a union string

### DIFF
--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -111,7 +111,7 @@ impl<W: Write + Send + 'static> Editor<W> {
     pub fn with_text(doc_ctx: DocumentCtx<W>, initial_view_id: &ViewIdentifier, text: String) -> Editor<W> {
 
         let engine = Engine::new(Rope::from(text));
-        let buffer = engine.get_head();
+        let buffer = engine.get_head().clone();
         let last_rev_id = engine.get_head_rev_id();
 
         let editor = Editor {
@@ -285,7 +285,7 @@ impl<W: Write + Send + 'static> Editor<W> {
         self.last_edit_type = self.this_edit_type;
         let priority = 0x10000;
         self.engine.edit_rev(priority, undo_group, head_rev_id, delta);
-        self.text = self.engine.get_head();
+        self.text = self.engine.get_head().clone();
     }
 
     /// Commits the current delta, updating views, plugins, and other invariants as needed.
@@ -308,7 +308,7 @@ impl<W: Write + Send + 'static> Editor<W> {
         let prev_head_rev_id = self.engine.get_head_rev_id();
         //self.engine.edit_rev(0x100000, undo_group, edit.rev as usize, delta);
         self.engine.edit_rev(edit.priority as usize, undo_group, edit.rev as usize, delta);
-        self.text = self.engine.get_head();
+        self.text = self.engine.get_head().clone();
 
         // adjust cursor position so that the cursor is not moved by the plugin edit
         let (changed_interval, _) = self.engine.delta_rev_head(prev_head_rev_id).summary();
@@ -322,7 +322,7 @@ impl<W: Write + Send + 'static> Editor<W> {
 
     fn update_undos(&mut self) {
         self.engine.undo(self.undos.clone());
-        self.text = self.engine.get_head();
+        self.text = self.engine.get_head().clone();
         self.update_after_revision(None);
     }
 

--- a/rust/rope/src/engine.rs
+++ b/rust/rope/src/engine.rs
@@ -118,8 +118,8 @@ impl Engine {
     }
 
     /// Get text of head revision.
-    pub fn get_head(&self) -> Rope {
-        self.text.clone()
+    pub fn get_head(&self) -> &Rope {
+        &self.text
     }
 
     /// Get text of a given revision, if it can be found.


### PR DESCRIPTION
This PR refactors the representation of `Engine` to store the text and tombstones separately. At the moment this has no significant effect on behaviour or time complexity, other than making retrieving the head revision instant. It paves the way however for a tree/rope based representation of subsets to make many other operations much faster.

This PR does the refactoring using changes from #297.

It also adds some more tests that weren't added in #297 due to me being too lazy to extricate them with advanced Git.

This PR should not be merged before #297 and you should probably review that first if you are thinking of reading this. I've targeted this PR at the branch of #297 so that the diff on top of that is easier to look at.

@raphlinus 