### PR TITLE
Swap Subset::transform_shrink receiver and argument

### DIFF
--- a/rust/rope/src/delta.rs
+++ b/rust/rope/src/delta.rs
@@ -330,9 +330,6 @@ impl<N: NodeInfo> InsertDelta<N> {
     /// the same base. For example, if `self` applies to a union string, and
     /// `xform` is the deletions from that union, the resulting Delta will
     /// apply to the text.
-    ///
-    /// **Note:** this is similar to `Subset::transform_shrink` but *the argument
-    /// order is reversed* due to this being a method on `InsertDelta`.
     pub fn transform_shrink(&self, xform: &Subset) -> InsertDelta<N> {
         let mut m = xform.mapper(CountMatcher::Zero);
         let els = self.0.els.iter().map(|elem| {

--- a/rust/rope/src/multiset.rs
+++ b/rust/rope/src/multiset.rs
@@ -231,13 +231,12 @@ impl Subset {
     ///
     /// C = A.transform_expand(B)
     ///
-    /// C.transform_shrink(B).delete_from_string(C.delete_from_string(s)) =
+    /// B.transform_shrink(C).delete_from_string(C.delete_from_string(s)) =
     ///   A.delete_from_string(B.delete_from_string(s))
     pub fn transform_shrink(&self, other: &Subset) -> Subset {
         let mut sb = SubsetBuilder::new();
         // discard ZipSegments where the shrinking set has positive count
-        // TODO: this argument order seems wrong, maybe swap these in a refactor
-        for zseg in other.zip(self) {
+        for zseg in self.zip(other) {
             // TODO: should this actually do something like subtract counts?
             if zseg.b_count == 0 {
                 sb.push_segment(zseg.len, zseg.a_count);
@@ -513,7 +512,7 @@ mod tests {
         let s3 = s2.transform_expand(&s1);
         let str3 = s3.delete_from_string(TEST_STR);
         assert_eq!(result, str3);
-        assert_eq!(str2, s3.transform_shrink(&s1).delete_from_string(&str3));
+        assert_eq!(str2, s1.transform_shrink(&s3).delete_from_string(&str3));
         assert_eq!(str2, s2.transform_union(&s1).delete_from_string(TEST_STR));
     }
 


### PR DESCRIPTION
transform_expand, transform_union and Delta::transform_shrink all take the
transform as the parameter and return something with the changes of self.
Before this commit, transform_shrink was different for no apparent reason.

This weirdness has caused me lots of extra thinking and a couple bugs,
this commit fixes it.

I don't know why the argument order was what I see as reversed to begin with, perhaps @raphlinus might know why.