### PR TITLE
Make travis builds fail reliably

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,6 @@ cache:
 script:
   - cd rust
   - export CARGO_TARGET_DIR=/tmp/target
-  - cargo build && cargo build --manifest-path syntect-plugin/Cargo.toml
-  - for MANIFEST in Cargo.toml */Cargo.toml; do cargo test --manifest-path $MANIFEST || break; done
+  - cargo build || exit
+  - cargo build --manifest-path syntect-plugin/Cargo.toml || exit
+  - for MANIFEST in Cargo.toml */Cargo.toml; do cargo test --manifest-path $MANIFEST || exit; done


### PR DESCRIPTION
The build was failing to fail because bash error handling is not
intuitive.