### PR TITLE
Only store deletes_from_union in Engine

### DIFF
--- a/rust/rope/src/delta.rs
+++ b/rust/rope/src/delta.rs
@@ -270,7 +270,7 @@ impl<N: NodeInfo> InsertDelta<N> {
     //
     // TODO: write accurate equations
     // TODO: can we infer l from the other inputs?
-    pub fn transform_expand(&self, xform: &Subset, l: usize, after: bool) -> InsertDelta<N> {
+    pub fn transform_expand(&self, xform: &Subset, after: bool) -> InsertDelta<N> {
         let cur_els = &self.0.els;
         let mut els = Vec::new();
         let mut x = 0;  // coordinate within self
@@ -279,6 +279,7 @@ impl<N: NodeInfo> InsertDelta<N> {
         let mut b1 = 0;
         let mut xform_ranges = xform.complement_iter();
         let mut last_xform = xform_ranges.next();
+        let l = xform.count(CountMatcher::All);
         while y < l || i < cur_els.len() {
             let next_iv_beg = if let Some((xb, _)) = last_xform { xb } else { l };
             if after && y < next_iv_beg {
@@ -556,9 +557,9 @@ mod tests {
         assert_eq!("01259DGJKN+UVWXYcdefghkmopqrstvwxy", d.apply_to_string(str1));
         let (d2, _ss) = d.factor();
         assert_eq!("01259DGJKN+QTUVWXYcdefghkmopqrstvwxy", d2.apply_to_string(str1));
-        let d3 = d2.transform_expand(&s1, TEST_STR.len(), false);
+        let d3 = d2.transform_expand(&s1, false);
         assert_eq!("0123456789ABCDEFGHIJKLMN+OPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", d3.apply_to_string(TEST_STR));
-        let d4 = d2.transform_expand(&s1, TEST_STR.len(), true);
+        let d4 = d2.transform_expand(&s1, true);
         assert_eq!("0123456789ABCDEFGHIJKLMNOP+QRSTUVWXYZabcdefghijklmnopqrstuvwxyz", d4.apply_to_string(TEST_STR));
     }
 

--- a/rust/rope/src/delta.rs
+++ b/rust/rope/src/delta.rs
@@ -269,7 +269,6 @@ impl<N: NodeInfo> InsertDelta<N> {
     /// coordinate transform.
     //
     // TODO: write accurate equations
-    // TODO: can we infer l from the other inputs?
     pub fn transform_expand(&self, xform: &Subset, after: bool) -> InsertDelta<N> {
         let cur_els = &self.0.els;
         let mut els = Vec::new();

--- a/rust/rope/src/engine.rs
+++ b/rust/rope/src/engine.rs
@@ -117,16 +117,6 @@ impl Engine {
         deletes_from_union
     }
 
-    /// Test that the result of the new method of finding deletes_from_union for a revision
-    /// produces the same result as the stored version.
-    pub fn check_integrity(&self) {
-        for (i,rev) in self.revs.iter().enumerate() {
-            let new_dels = self.deletes_from_union_for_index(i);
-            let new_dels_ref: &Subset = &new_dels;
-            assert_eq!(&rev.deletes_from_union_old, new_dels_ref);
-        }
-    }
-
     /// Get the contents of the document at a given revision number
     fn rev_content_for_index(&self, rev_index: usize) -> Rope {
         let old_deletes_from_union = self.deletes_from_cur_union_for_index(rev_index);
@@ -479,7 +469,6 @@ mod tests {
         let mut engine = Engine::new(Rope::from(TEST_STR));
         engine.edit_rev(0, 0, 0, build_delta_1());
         assert_eq!("0123456789abcDEEFghijklmnopqr999stuvz", String::from(engine.get_head()));
-        engine.check_integrity();
     }
 
     #[test]
@@ -488,7 +477,6 @@ mod tests {
         engine.edit_rev(1, 0, 0, build_delta_1());
         engine.edit_rev(0, 1, 0, build_delta_2());
         assert_eq!("0!3456789abcDEEFGIjklmnopqr888999stuvHIz", String::from(engine.get_head()));
-        engine.check_integrity();
     }
 
     fn undo_test(before: bool, undos : BTreeSet<usize>, output: &str) {
@@ -502,7 +490,6 @@ mod tests {
             engine.undo(undos);
         }
         assert_eq!(output, String::from(engine.get_head()));
-        engine.check_integrity();
     }
 
     #[test]
@@ -574,7 +561,6 @@ mod tests {
         engine.edit_rev(1, 2, new_head, d3);
         engine.undo([0,2].iter().cloned().collect());
         assert_eq!("a0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", String::from(engine.get_head()));
-        engine.check_integrity();
     }
 
     #[test]
@@ -589,7 +575,6 @@ mod tests {
         assert_eq!(TEST_STR, String::from(engine.get_head()));
         engine.undo([].iter().cloned().collect());
         assert_eq!("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", String::from(engine.get_head()));
-        engine.check_integrity();
     }
 
     #[test]
@@ -607,7 +592,6 @@ mod tests {
         engine.edit_rev(1, 2, new_head, d3);
         engine.undo([2].iter().cloned().collect());
         assert_eq!("a0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", String::from(engine.get_head()));
-        engine.check_integrity();
     }
 
     /// This case is a regression test reproducing a panic I found while using the UI.
@@ -653,7 +637,6 @@ mod tests {
         }
         soln.push('f');
         assert_eq!(soln, String::from(engine.get_head()));
-        engine.check_integrity();
     }
 
     #[test]
@@ -679,6 +662,5 @@ mod tests {
         // shouldn't do anything since it was double-deleted and one was GC'd
         engine.undo([0,1].iter().cloned().collect());
         assert_eq!("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", String::from(engine.get_head()));
-        engine.check_integrity();
     }
 }

--- a/rust/rope/src/engine.rs
+++ b/rust/rope/src/engine.rs
@@ -175,7 +175,7 @@ impl Engine {
 
     // TODO: don't construct transform if subsets are empty
     /// Retuns a tuple of a new `Revision` representing the edit based on the
-    /// current head, a new text `Rope`, and a new tombstones `Rope`.
+    /// current head, a new text `Rope`, a new tombstones `Rope` and a new `deletes_from_union`.
     fn mk_new_rev(&self, new_priority: usize, undo_group: usize,
             base_rev: usize, delta: Delta<RopeInfo>) -> (Revision, Rope, Rope, Subset) {
         let ix = self.find_rev(base_rev).expect("base revision not found");

--- a/rust/rope/src/engine.rs
+++ b/rust/rope/src/engine.rs
@@ -163,7 +163,7 @@ impl Engine {
         let (ins_delta, deletes) = delta.factor();
 
         // rebase delta to be on the base_rev union instead of the text
-        let mut union_ins_delta = ins_delta.transform_expand(&rev.deletes_from_union, rev.union_str_len, true);
+        let mut union_ins_delta = ins_delta.transform_expand(&rev.deletes_from_union, true);
         let mut new_deletes = deletes.transform_expand(&rev.deletes_from_union);
 
         // rebase the delta to be on the head union instead of the base_rev union
@@ -171,7 +171,7 @@ impl Engine {
             if let Edit { priority, ref inserts, .. } = r.edit {
                 if !inserts.is_empty() {
                     let after = new_priority >= priority;  // should never be ==
-                    union_ins_delta = union_ins_delta.transform_expand(inserts, r.union_str_len, after);
+                    union_ins_delta = union_ins_delta.transform_expand(inserts, after);
                     new_deletes = new_deletes.transform_expand(inserts);
                 }
             }

--- a/rust/rope/src/engine.rs
+++ b/rust/rope/src/engine.rs
@@ -117,6 +117,16 @@ impl Engine {
         deletes_from_union
     }
 
+    /// Test that the result of the new method of finding deletes_from_union for a revision
+    /// produces the same result as the stored version.
+    pub fn check_integrity(&self) {
+        for (i,rev) in self.revs.iter().enumerate() {
+            let new_dels = self.deletes_from_union_for_index(i);
+            let new_dels_ref: &Subset = &new_dels;
+            assert_eq!(&rev.deletes_from_union_old, new_dels_ref);
+        }
+    }
+
     /// Get the contents of the document at a given revision number
     fn rev_content_for_index(&self, rev_index: usize) -> Rope {
         let old_deletes_from_union = self.deletes_from_cur_union_for_index(rev_index);
@@ -469,6 +479,7 @@ mod tests {
         let mut engine = Engine::new(Rope::from(TEST_STR));
         engine.edit_rev(0, 0, 0, build_delta_1());
         assert_eq!("0123456789abcDEEFghijklmnopqr999stuvz", String::from(engine.get_head()));
+        engine.check_integrity();
     }
 
     #[test]
@@ -477,6 +488,7 @@ mod tests {
         engine.edit_rev(1, 0, 0, build_delta_1());
         engine.edit_rev(0, 1, 0, build_delta_2());
         assert_eq!("0!3456789abcDEEFGIjklmnopqr888999stuvHIz", String::from(engine.get_head()));
+        engine.check_integrity();
     }
 
     fn undo_test(before: bool, undos : BTreeSet<usize>, output: &str) {
@@ -490,6 +502,7 @@ mod tests {
             engine.undo(undos);
         }
         assert_eq!(output, String::from(engine.get_head()));
+        engine.check_integrity();
     }
 
     #[test]
@@ -561,6 +574,7 @@ mod tests {
         engine.edit_rev(1, 2, new_head, d3);
         engine.undo([0,2].iter().cloned().collect());
         assert_eq!("a0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", String::from(engine.get_head()));
+        engine.check_integrity();
     }
 
     #[test]
@@ -575,6 +589,7 @@ mod tests {
         assert_eq!(TEST_STR, String::from(engine.get_head()));
         engine.undo([].iter().cloned().collect());
         assert_eq!("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", String::from(engine.get_head()));
+        engine.check_integrity();
     }
 
     #[test]
@@ -592,6 +607,7 @@ mod tests {
         engine.edit_rev(1, 2, new_head, d3);
         engine.undo([2].iter().cloned().collect());
         assert_eq!("a0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", String::from(engine.get_head()));
+        engine.check_integrity();
     }
 
     /// This case is a regression test reproducing a panic I found while using the UI.
@@ -637,6 +653,7 @@ mod tests {
         }
         soln.push('f');
         assert_eq!(soln, String::from(engine.get_head()));
+        engine.check_integrity();
     }
 
     #[test]
@@ -662,5 +679,6 @@ mod tests {
         // shouldn't do anything since it was double-deleted and one was GC'd
         engine.undo([0,1].iter().cloned().collect());
         assert_eq!("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", String::from(engine.get_head()));
+        engine.check_integrity();
     }
 }

--- a/rust/rope/src/multiset.rs
+++ b/rust/rope/src/multiset.rs
@@ -185,7 +185,19 @@ impl Subset {
     pub fn subtract(&self, other: &Subset) -> Subset {
         let mut sb = SubsetBuilder::new();
         for zseg in self.zip(other) {
+            assert!(zseg.a_count >= zseg.b_count, "can't subtract {} from {}", zseg.a_count, zseg.b_count);
             sb.push_segment(zseg.len, zseg.a_count - zseg.b_count);
+        }
+        sb.build()
+    }
+
+    /// Compute the bitwise xor of two subsets, useful as a symmetric
+    /// difference. The count of an element in the result is the bitwise xor
+    /// of the counts of the inputs. Unchanged segments will be 0.
+    pub fn bitxor(&self, other: &Subset) -> Subset {
+        let mut sb = SubsetBuilder::new();
+        for zseg in self.zip(other) {
+            sb.push_segment(zseg.len, zseg.a_count ^ zseg.b_count);
         }
         sb.build()
     }

--- a/rust/rope/src/multiset.rs
+++ b/rust/rope/src/multiset.rs
@@ -180,6 +180,16 @@ impl Subset {
         sb.build()
     }
 
+    /// Compute the difference of two subsets. The count of an element in the
+    /// result is the subtraction of the counts of other from self.
+    pub fn subtract(&self, other: &Subset) -> Subset {
+        let mut sb = SubsetBuilder::new();
+        for zseg in self.zip(other) {
+            sb.push_segment(zseg.len, zseg.a_count - zseg.b_count);
+        }
+        sb.build()
+    }
+
     /// Map the contents of `self` into the 0-regions of `other`.
     /// Precondition: `self.count(CountMatcher::All) == other.count(CountMatcher::Zero)`
     fn transform(&self, other: &Subset, union: bool) -> Subset {

--- a/rust/rope/src/multiset.rs
+++ b/rust/rope/src/multiset.rs
@@ -191,9 +191,12 @@ impl Subset {
         sb.build()
     }
 
-    /// Compute the bitwise xor of two subsets, useful as a symmetric
+    /// Compute the bitwise xor of two subsets, useful as a reversible
     /// difference. The count of an element in the result is the bitwise xor
     /// of the counts of the inputs. Unchanged segments will be 0.
+    ///
+    /// This works like set symmetric difference when all counts are 0 or 1
+    /// but it extends nicely to the case of larger counts.
     pub fn bitxor(&self, other: &Subset) -> Subset {
         let mut sb = SubsetBuilder::new();
         for zseg in self.zip(other) {


### PR DESCRIPTION
This PR refactors `Engine` to store `deletes_from_union` only for the head revision in `Engine` rather than in every revision. It makes `Undo` reversible and then uses the reversibility of operations to compute the `deletes_from_union` for any revision by inverting changes from the head revision backwards.

I made `Undo` reversible by representing it as two symmetric differences / xors that can be applied in exactly the same way either direction and computed using the same operation. For undo groups this is `BTreeSet::symmetric_difference` and it conceptually represents the set of undo groups toggled between done and undone. 

Since `deletes_from_union` is a multiset with counts, it's slightly weirder but still simple. You could think of it like a set of toggled deletes if it was a normal set, but instead it is the bitwise xor of the counts for elements. This has the same algebraic xor properties that let it be used as a symmetric difference, and it has counts of `0` where there is no difference, but for elements that differ the counts don't have a nice human meaning.

I haven't yet re-written `compute_undo` to be more efficient, I'll do that in a different PR, but for now I preserved the correctness of `gc` so everything should still work.

In an intermediate step, I instrumented all the tests to check the old `deletes_from_union` stored on the `Revision` against the new computation, and it found no differences for any revision in any test, but I reverted that commit and then removed the old field. The commits are un-squashed so we can look in the git history if we ever want to check that or similar things again.