### PR TITLE
Implement serde traits for Engine, Subset, Rope, Revision

### DIFF
--- a/rust/rope/Cargo.toml
+++ b/rust/rope/Cargo.toml
@@ -9,6 +9,11 @@ version = "0.2.0"
 [dependencies]
 bytecount = "0.1.2"
 memchr = "1.0"
+serde = "1.0"
+serde_derive = "1.0"
+
+[dev-dependencies]
+serde_test = "^1.0"
 
 [features]
 avx-accel = ["bytecount/avx-accel"]

--- a/rust/rope/src/engine.rs
+++ b/rust/rope/src/engine.rs
@@ -25,7 +25,7 @@ use rope::{Rope, RopeInfo};
 use multiset::{Subset, CountMatcher};
 use delta::Delta;
 
-#[derive(Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Engine {
     rev_id_counter: usize,
     text: Rope,
@@ -36,7 +36,7 @@ pub struct Engine {
     revs: Vec<Revision>,
 }
 
-#[derive(Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 struct Revision {
     rev_id: usize,
     edit: Contents,
@@ -44,7 +44,7 @@ struct Revision {
 
 use self::Contents::*;
 
-#[derive(Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 enum Contents {
     Edit {
         priority: usize,

--- a/rust/rope/src/lib.rs
+++ b/rust/rope/src/lib.rs
@@ -16,6 +16,9 @@
 
 extern crate bytecount;
 extern crate memchr;
+extern crate serde;
+#[macro_use] extern crate serde_derive;
+#[cfg(test)] extern crate serde_test;
 
 pub mod tree;
 pub mod breaks;

--- a/rust/rope/src/multiset.rs
+++ b/rust/rope/src/multiset.rs
@@ -21,7 +21,7 @@ use tree::{Node, NodeInfo, TreeBuilder};
 use interval::Interval;
 use std::slice;
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 struct Segment {
     len: usize,
     count: usize,
@@ -33,7 +33,7 @@ struct Segment {
 /// included in the set.
 ///
 /// Internally, this is stored as a list of "segments" with a length and a count.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct Subset {
     /// Invariant, maintained by `SubsetBuilder`: all `Segment`s have non-zero
     /// length, and no `Segment` has the same count as the one before it.

--- a/rust/rope/src/test_helpers.rs
+++ b/rust/rope/src/test_helpers.rs
@@ -38,3 +38,9 @@ impl Delta<RopeInfo> {
         String::from(self.apply(&Rope::from(s)))
     }
 }
+
+impl PartialEq for Rope {
+    fn eq(&self, other: &Rope) -> bool {
+        String::from(self) == String::from(other)
+    }
+}


### PR DESCRIPTION
Adds the serde and serde_derive crates to xi_rope and uses them to implement the traits for `Engine` and its transitive dependencies. This will be useful when synchronizing `Engine` with ledger as part of #250.

Includes a custom tested Serialize and Deserialize implementation for Rope which just converts it to and from a String. Also tests that this works with serde's many string types, I got this wrong the first time and it only worked in zero-copy mode.