### PR TITLE
implement add_selection_above and add_selection_below

### DIFF
--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -431,13 +431,7 @@ impl<W: Write + Send + 'static> Editor<W> {
         let mut deletions = Selection::new();
         for r in self.view.sel_regions() {
             if r.is_caret() {
-                let (offset, horiz) = region_movement(movement, r, &self.view, &self.text, true);
-                let new_region = SelRegion {
-                    start: r.start,
-                    end: offset,
-                    horiz: horiz,
-                    affinity: Affinity::default(),
-                };
+                let new_region = region_movement(movement, r, &self.view, &self.text, true);
                 deletions.add_region(new_region);
             } else {
                 deletions.add_region(r.clone());

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -587,6 +587,16 @@ impl<W: Write + Send + 'static> Editor<W> {
         self.view.select_all(self.text.len());
     }
 
+    fn add_selection_by_movement(&mut self, movement: Movement) {
+        let mut sel = Selection::new();
+        for region in self.view.sel_regions() {
+            sel.add_region(region.clone());
+            let new_region = region_movement(movement, region, &self.view, &self.text, false);
+            sel.add_region(new_region);
+        }
+        self.scroll_to = self.view.set_selection(&self.text, sel);
+    }
+
     fn do_key(&mut self, chars: &str, flags: u64) {
         match chars {
             "\r" => self.insert_newline(),
@@ -875,6 +885,8 @@ impl<W: Write + Send + 'static> Editor<W> {
                 async(self.scroll_page_down(FLAG_SELECT))
             }
             SelectAll => async(self.select_all()),
+            AddSelectionAbove => async(self.add_selection_by_movement(Movement::Up)),
+            AddSelectionBelow => async(self.add_selection_by_movement(Movement::Down)),
             Scroll { first, last } => async(self.do_scroll(first, last)),
             GotoLine { line } => async(self.do_goto_line(line)),
             RequestLines { first, last } => async(self.do_request_lines(first, last)),

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -105,6 +105,8 @@ pub enum EditCommand<'a> {
     ScrollPageDown,
     PageDownAndModifySelection,
     SelectAll,
+    AddSelectionAbove,
+    AddSelectionBelow,
     Scroll { first: i64, last: i64 },
     GotoLine { line: u64 },
     RequestLines { first: i64, last: i64 },
@@ -228,6 +230,8 @@ impl<'a> EditCommand<'a> {
             "page_down" => Ok(ScrollPageDown),
             "page_down_and_modify_selection" => Ok(PageDownAndModifySelection),
             "select_all" => Ok(SelectAll),
+            "add_selection_above" => Ok(AddSelectionAbove),
+            "add_selection_below" => Ok(AddSelectionBelow),
 
             "scroll" => params.as_array().and_then(|arr| {
                 if let (Some(first), Some(last)) =


### PR DESCRIPTION
The behaviour approximately matches the behaviour of Sublime Text (with the exception that it adds a cursor at the beginning of the document if you call `add_selection_above` when there is a cursor on the first line). I decided for this approach because it was simple to implement, but generally I'd prefer Atom's behaviour (if you have a selection that is not a caret and call `add_selection_below`, Atom will duplicate that selection and Sublime Text will only add a caret on the line below).