### PR TITLE
Make cursor dragging multi-select aware

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -163,6 +163,8 @@ version = "0.2.0"
 dependencies = [
  "bytecount 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -519,10 +519,6 @@ impl<W: Write + Send + 'static> Editor<W> {
         */
     }
 
-    fn modify_selection(&mut self) {
-        self.this_edit_type = EditType::Select;
-    }
-
     /// Apply a movement, also setting the scroll to the point requested by
     /// the movement.
     ///
@@ -700,6 +696,7 @@ impl<W: Write + Send + 'static> Editor<W> {
                     });
                     sel
                 };
+                self.view.start_drag(offset, offset, offset);
                 self.scroll_to = self.view.set_selection(&self.text, sel);
                 return;
             }
@@ -714,6 +711,7 @@ impl<W: Write + Send + 'static> Editor<W> {
                 horiz: None,
                 affinity: Affinity::default(),
             });
+            self.view.start_drag(offset, start, end);
             return;
         } else if click_count == 3 {
             let start = self.view.line_col_to_offset(&self.text, line as usize, 0);
@@ -724,15 +722,16 @@ impl<W: Write + Send + 'static> Editor<W> {
                 horiz: None,
                 affinity: Affinity::default(),
             });
+            self.view.start_drag(offset, start, end);
             return;
         }
+        self.view.start_drag(offset, offset, offset);
         self.set_cursor(offset, true);
     }
 
     fn do_drag(&mut self, line: u64, col: u64, _flags: u64) {
         let offset = self.view.line_col_to_offset(&self.text, line as usize, col as usize);
-        self.modify_selection();
-        self.set_cursor(offset, true);
+        self.scroll_to = self.view.do_drag(&self.text, offset, Affinity::default());
     }
 
     fn do_gesture(&mut self, line: u64, col: u64, ty: GestureType) {

--- a/rust/core-lib/src/selection.rs
+++ b/rust/core-lib/src/selection.rs
@@ -27,7 +27,7 @@ use xi_rope::rope::RopeInfo;
 pub type HorizPos = usize;
 
 /// A set of zero or more selection regions, representing a selection state.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct Selection {
     // an invariant: regions[i].max() <= regions[i+1].min()
     // and < if either is_caret()

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -158,6 +158,7 @@ impl View {
         if !self.selection.regions_in_range(offset, offset).is_empty() {
             self.selection.delete_range(offset, offset);
             if !self.selection.is_empty() {
+                self.drag_state = None;
                 return;
             }
         }


### PR DESCRIPTION
This patch makes the basic drag operation work on the new selection
data structure. It also enhances drags so that cursors added by
toggling can also be dragged into selection regions. Further, it
improves the behavior of drags started from double and triple click
gestures, by preserving the entire original selection. However, the
additional drag has grapheme granularity in all cases, and it would be
better to follow the granularity of the originating gesture.

Progress towards #188