### PR TITLE
Tweaks to be able to build Xi inside the Fuchsia tree.

### DIFF
--- a/rust/core-lib/BUILD.gn
+++ b/rust/core-lib/BUILD.gn
@@ -1,0 +1,9 @@
+import("//build/rust/rust_library.gni")
+
+rust_library("xi_core_lib") {
+    deps = [
+        "//rust/xi-editor/rust/rpc:xi_rpc",
+        "//rust/xi-editor/rust/rope:xi_rope",
+        "//rust/xi-editor/rust/unicode:xi_unicode",
+    ]
+}

--- a/rust/core-lib/BUILD.gn
+++ b/rust/core-lib/BUILD.gn
@@ -2,8 +2,8 @@ import("//build/rust/rust_library.gni")
 
 rust_library("xi_core_lib") {
     deps = [
-        "//rust/xi-editor/rust/rpc:xi_rpc",
-        "//rust/xi-editor/rust/rope:xi_rope",
-        "//rust/xi-editor/rust/unicode:xi_unicode",
+        "//third_party/xi-editor/rust/rpc:xi_rpc",
+        "//third_party/xi-editor/rust/rope:xi_rope",
+        "//third_party/xi-editor/rust/unicode:xi_unicode",
     ]
 }

--- a/rust/core-lib/src/plugins/manifest.rs
+++ b/rust/core-lib/src/plugins/manifest.rs
@@ -23,6 +23,7 @@ use syntax::SyntaxDefinition;
 static PLUGIN_DIR: &'static str = "XI_PLUGIN_DIR";
 
 // example plugins. Eventually these should be loaded from disk.
+#[cfg(not(target_os = "fuchsia"))]
 pub fn debug_plugins() -> Vec<PluginDescription> {
     use self::PluginActivation::*;
     use self::PluginScope::*;
@@ -58,6 +59,11 @@ pub fn debug_plugins() -> Vec<PluginDescription> {
         })
         .map(|desc| desc.to_owned())
         .collect::<Vec<_>>()
+}
+
+#[cfg(target_os = "fuchsia")]
+pub fn debug_plugins() -> Vec<PluginDescription> {
+    Vec::new()
 }
 
 /// Describes attributes and capabilities of a plugin.

--- a/rust/core-lib/src/plugins/manifest.rs
+++ b/rust/core-lib/src/plugins/manifest.rs
@@ -14,17 +14,18 @@
 
 //! Structured representation of a plugin's features and capabilities.
 
-use std::env;
 use std::path::PathBuf;
 
 use syntax::SyntaxDefinition;
 
 // optional environment variable for debug plugin executables
+#[cfg(not(target_os = "fuchsia"))]
 static PLUGIN_DIR: &'static str = "XI_PLUGIN_DIR";
 
 // example plugins. Eventually these should be loaded from disk.
 #[cfg(not(target_os = "fuchsia"))]
 pub fn debug_plugins() -> Vec<PluginDescription> {
+    use std::env;
     use self::PluginActivation::*;
     use self::PluginScope::*;
     let plugin_dir = match env::var(PLUGIN_DIR).map(PathBuf::from) {
@@ -49,7 +50,7 @@ pub fn debug_plugins() -> Vec<PluginDescription> {
         PluginDescription::new("shouty", "0.0", BufferLocal, make_path("shouty.py"),
         Vec::new()),
     ].iter()
-        .filter(|desc|{ 
+        .filter(|desc|{
             if !desc.exec_path.exists() {
                 print_err!("missing plugin {} at {:?}", desc.name, desc.exec_path);
                 false
@@ -106,6 +107,7 @@ pub enum PluginScope {
     SingleInvocation,
 }
 
+#[cfg(not(target_os = "fuchsia"))]
 impl PluginDescription {
     fn new<S, P>(name: S, version: S, scope: PluginScope, exec_path: P,
                  activations: Vec<PluginActivation>) -> Self

--- a/rust/rope/BUILD.gn
+++ b/rust/rope/BUILD.gn
@@ -1,0 +1,5 @@
+import("//build/rust/rust_library.gni")
+
+rust_library("xi_rope") {
+
+}

--- a/rust/rpc/BUILD.gn
+++ b/rust/rpc/BUILD.gn
@@ -1,0 +1,5 @@
+import("//build/rust/rust_library.gni")
+
+rust_library("xi_rpc") {
+
+}

--- a/rust/unicode/BUILD.gn
+++ b/rust/unicode/BUILD.gn
@@ -1,0 +1,5 @@
+import("//build/rust/rust_library.gni")
+
+rust_library("xi_unicode") {
+
+}


### PR DESCRIPTION
The debug plugins are disabled (with #cfg) on Fuchsia. Also, add
BUILD.gn build rules, so the core can be built using GN rather than
pulled in as a third-party dependency.

- [x] Should Xi be in `third_party/` instead of `rust/`?