### PR TITLE
Synchronize Editor state to the Ledger on Fuchsia

### DIFF
--- a/rust/core-lib/BUILD.gn
+++ b/rust/core-lib/BUILD.gn
@@ -2,6 +2,11 @@ import("//build/rust/rust_library.gni")
 
 rust_library("xi_core_lib") {
     deps = [
+        "//apps/ledger/services/public:public_rust_library",
+        "//lib/fidl/rust/fidl",
+        "//rust/magenta-rs:magenta",
+        "//rust/magenta-rs/magenta-sys",
+        "//rust/mxruntime",
         "//third_party/xi-editor/rust/rpc:xi_rpc",
         "//third_party/xi-editor/rust/rope:xi_rope",
         "//third_party/xi-editor/rust/unicode:xi_unicode",

--- a/rust/core-lib/Cargo.toml
+++ b/rust/core-lib/Cargo.toml
@@ -22,7 +22,7 @@ default-features = false
 features = ["assets"]
 
 [target."cfg(target_os = \"fuchsia\")".dependencies]
-sha2 = "^0.5"
+sha2 = "0.5"
 
 [features]
 avx-accel = ["xi-rope/avx-accel"]

--- a/rust/core-lib/Cargo.toml
+++ b/rust/core-lib/Cargo.toml
@@ -21,6 +21,9 @@ version = "1.5"
 default-features = false
 features = ["assets"]
 
+[target."cfg(target_os = \"fuchsia\")".dependencies]
+sha2 = "^0.5"
+
 [features]
 avx-accel = ["xi-rope/avx-accel"]
 simd-accel = ["xi-rope/simd-accel"]

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -137,7 +137,7 @@ impl<W: Write + Send + 'static> Editor<W> {
             engine: engine,
             last_rev_id: last_rev_id,
             pristine_rev_id: last_rev_id,
-            undo_group_id: 0,
+            undo_group_id: 1,
             live_undos: Vec::new(),
             cur_undo: 0,
             undos: BTreeSet::new(),

--- a/rust/core-lib/src/fuchsia/ledger.rs
+++ b/rust/core-lib/src/fuchsia/ledger.rs
@@ -1,0 +1,66 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utility functions to make it easier to work with Ledger in Rust
+// TODO merge with equivalent module in fuchsia/rust_ledger_example into a library?
+
+use apps_ledger_services_public::*;
+use fuchsia::read_entire_vmo;
+use fidl::Error;
+use magenta::{Vmo, self};
+use sha2::{Sha256, Digest};
+
+pub fn ledger_crash_callback(res: Result<Status, Error>) {
+    let status = res.expect("ledger call failed to respond with a status");
+    assert_eq!(status, Status_Ok, "ledger call failed");
+}
+
+#[derive(Debug)]
+pub enum ValueError {
+    NeedsFetch,
+    LedgerFail(Status),
+    Vmo(magenta::Status),
+}
+
+/// Convert the low level result of getting a key from the ledger into a
+/// higher level Rust representation.
+pub fn value_result(res: (Status, Option<Vmo>)) -> Result<Option<Vec<u8>>, ValueError> {
+    // Rust emits a warning if matched-on constants aren't all-caps
+    const OK: Status = Status_Ok;
+    const KEY_NOT_FOUND: Status = Status_KeyNotFound;
+    const NEEDS_FETCH: Status = Status_NeedsFetch;
+    match res {
+        (OK, Some(vmo)) => {
+            let buffer = read_entire_vmo(&vmo).map_err(ValueError::Vmo)?;
+            Ok(Some(buffer))
+        },
+        (KEY_NOT_FOUND, _) => Ok(None),
+        (NEEDS_FETCH, _) => Err(ValueError::NeedsFetch),
+        (status, _) => Err(ValueError::LedgerFail(status)),
+    }
+}
+
+/// Ledger page ids are exactly 16 bytes, so we need a way of determining
+/// a unique 16 byte ID that won't collide based on some data we have
+pub fn gen_page_id(input_data: &[u8]) -> [u8; 16] {
+    let mut hasher = Sha256::default();
+    hasher.input(input_data);
+    let full_hash = hasher.result();
+    let full_slice = full_hash.as_slice();
+
+    // magic incantation to get the first 16 bytes of the hash
+    let mut arr: [u8; 16] = Default::default();
+    arr.as_mut().clone_from_slice(&full_slice[0..16]);
+    arr
+}

--- a/rust/core-lib/src/fuchsia/ledger.rs
+++ b/rust/core-lib/src/fuchsia/ledger.rs
@@ -21,6 +21,12 @@ use fidl::Error;
 use magenta::{Vmo, self};
 use sha2::{Sha256, Digest};
 
+// Rust emits a warning if matched-on constants aren't all-caps
+pub const OK: Status = Status_Ok;
+pub const KEY_NOT_FOUND: Status = Status_KeyNotFound;
+pub const NEEDS_FETCH: Status = Status_NeedsFetch;
+pub const RESULT_COMPLETED: ResultState = ResultState_Completed;
+
 pub fn ledger_crash_callback(res: Result<Status, Error>) {
     let status = res.expect("ledger call failed to respond with a status");
     assert_eq!(status, Status_Ok, "ledger call failed");
@@ -36,10 +42,6 @@ pub enum ValueError {
 /// Convert the low level result of getting a key from the ledger into a
 /// higher level Rust representation.
 pub fn value_result(res: (Status, Option<Vmo>)) -> Result<Option<Vec<u8>>, ValueError> {
-    // Rust emits a warning if matched-on constants aren't all-caps
-    const OK: Status = Status_Ok;
-    const KEY_NOT_FOUND: Status = Status_KeyNotFound;
-    const NEEDS_FETCH: Status = Status_NeedsFetch;
     match res {
         (OK, Some(vmo)) => {
             let buffer = read_entire_vmo(&vmo).map_err(ValueError::Vmo)?;

--- a/rust/core-lib/src/fuchsia/mod.rs
+++ b/rust/core-lib/src/fuchsia/mod.rs
@@ -1,0 +1,32 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod ledger;
+pub mod sync;
+
+use magenta::{Vmo, Status};
+
+// TODO: move this into magenta-rs?
+pub fn read_entire_vmo(vmo: &Vmo) -> Result<Vec<u8>, Status> {
+    let size = vmo.get_size()?;
+    // TODO: how fishy is this cast to usize?
+    let mut buffer: Vec<u8> = Vec::with_capacity(size as usize);
+    // TODO: consider using unsafe .set_len() to get uninitialized memory
+    for _ in 0..size {
+        buffer.push(0);
+    }
+    let bytes_read = vmo.read(buffer.as_mut_slice(), 0)?;
+    buffer.truncate(bytes_read);
+    Ok(buffer)
+}

--- a/rust/core-lib/src/fuchsia/sync.rs
+++ b/rust/core-lib/src/fuchsia/sync.rs
@@ -1,0 +1,186 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Architecture for synchronizing a CRDT with the ledger. Separated into a
+//! module so that it is easier to add other sync stores later.
+
+use magenta::{Channel, ChannelOpts};
+use fuchsia::read_entire_vmo;
+use super::ledger::{ledger_crash_callback, self};
+use apps_ledger_services_public::*;
+use std::sync::mpsc::{Sender, Receiver, RecvError};
+use std::io::Write;
+use fidl::{Promise, Future, self};
+use magenta::HandleBase;
+
+use tabs::{BufferIdentifier, BufferContainerRef};
+use xi_rope::engine::Engine;
+use serde_json;
+
+// TODO switch these to bincode
+fn state_to_buf(state: &Engine) -> Vec<u8> {
+    serde_json::to_vec(state).unwrap()
+}
+
+fn buf_to_state(buf: &[u8]) -> Option<Engine> {
+    serde_json::from_slice(buf).ok()
+}
+
+/// Stores state needed by the container to perform synchronization.
+pub struct SyncStore {
+    page: Page_Proxy,
+    key: Vec<u8>,
+    updates: Sender<SyncMsg>,
+    transaction_pending: bool,
+    buffer: BufferIdentifier,
+}
+
+impl SyncStore {
+    /// - `page` is a reference to the Ledger page to store data under.
+    /// - `key` is the key the `Syncable` managed by this `SyncStore` will be stored under.
+    ///    This example only supports storing things under a single key per page.
+    /// - `updates` is a channel to a `SyncUpdater` that will handle events.
+    ///
+    /// Returns a sync store and schedules the loading of initial
+    /// state and subscribes to state updates for this document.
+    pub fn new(mut page: Page_Proxy, key: Vec<u8>, updates: Sender<SyncMsg>,
+            buffer: BufferIdentifier) -> SyncStore {
+        let (s1, s2) = Channel::create(ChannelOpts::Normal).unwrap();
+        let watcher_client = PageWatcher_Client::from_handle(s1.into_handle());
+        let watcher_client_ptr = ::fidl::InterfacePtr {
+            inner: watcher_client,
+            version: PageWatcher_Metadata::VERSION,
+        };
+
+        let watcher = PageWatcherServer { updates: updates.clone(), buffer: buffer.clone() };
+        let _ = fidl::Server::new(watcher, s2).spawn();
+
+        let (mut snap, snap_request) = PageSnapshot_new_pair();
+        page.get_snapshot(snap_request, Some(key.clone()), Some(watcher_client_ptr)).with(ledger_crash_callback);
+
+        let initial_state_chan = updates.clone();
+        let initial_buffer = buffer.clone();
+        snap.get(key.clone()).with(move |raw_res| {
+            let res = raw_res.expect("fidl failed on initial state response");
+            let value_opt = ledger::value_result(res).expect("failed to read value for key");
+            if let Some(buf) = value_opt {
+                initial_state_chan.send(SyncMsg::NewState { buffer: initial_buffer, new_buf: buf, done: None }).unwrap();
+            }
+        });
+
+        SyncStore { page, key, updates, buffer, transaction_pending: false }
+    }
+
+    /// Called whenever this app changed its own state and would like to
+    /// persist the changes to the ledger. Changes can't be committed
+    /// immediately since we have to wait for PageWatcher changes that may not
+    /// have arrived yet.
+    pub fn state_changed(&mut self) {
+        if !self.transaction_pending {
+            self.transaction_pending = true;
+            let ready_future = self.page.start_transaction();
+            let done_chan = self.updates.clone();
+            let buffer = self.buffer.clone();
+            ready_future.with(move |res| {
+                assert_eq!(Status_Ok, res.unwrap(), "failed to start transaction");
+                done_chan.send(SyncMsg::TransactionReady { buffer }).unwrap();
+            });
+        }
+    }
+
+    /// Should be called in SyncContainer::transaction_ready to persist the current state.
+    pub fn commit_transaction(&mut self, state: &Engine) {
+        assert!(self.transaction_pending, "must call state_changed (and wait) before commit");
+        self.page.put(self.key.clone(), state_to_buf(state)).with(ledger_crash_callback);
+        self.page.commit().with(ledger_crash_callback);
+        self.transaction_pending = false;
+    }
+}
+
+/// All the different asynchronous events the updater thread needs to listen for and act on
+pub enum SyncMsg {
+    NewState { buffer: BufferIdentifier, new_buf: Vec<u8>, done: Option<Promise<Option<PageSnapshot_Server>, fidl::Error>> },
+    TransactionReady { buffer: BufferIdentifier },
+    /// Shut down the updater thread
+    Stop
+}
+
+/// We want to be able to register to recieve events from inside the
+/// `SyncStore`/`SyncContainer` but from there we don't have access to the
+/// Mutex that holds the container, so we give channel Senders to all the
+/// futures so that they can all trigger events in one place that does have
+/// the right reference.
+///
+/// Additionally, the individual `Editor`s aren't wrapped in a `Mutex` so we
+/// have to hold a `BufferContainerRef` and use `BufferIdentifier`s with one
+/// `SyncUpdater` for all buffers.
+pub struct SyncUpdater<W: Write> {
+    container_ref: BufferContainerRef<W>,
+    chan: Receiver<SyncMsg>,
+}
+
+impl<W: Write + Send + 'static> SyncUpdater<W> {
+    pub fn new(container_ref: BufferContainerRef<W>, chan: Receiver<SyncMsg>) -> SyncUpdater<W> {
+        SyncUpdater { container_ref, chan }
+    }
+
+    /// Run this in a thread, it will return when it encounters an error
+    /// reading the channel or when the `Stop` message is recieved.
+    pub fn work(&self) -> Result<(),RecvError> {
+        loop {
+            let msg = self.chan.recv()?;
+            match msg {
+                SyncMsg::Stop => return Ok(()),
+                SyncMsg::TransactionReady { buffer }=> {
+                    let mut container = self.container_ref.lock();
+                    let mut editor = container.editor_for_buffer_mut(&buffer).unwrap();
+                    editor.transaction_ready();
+                }
+                SyncMsg::NewState { new_buf, done, buffer } => {
+                    let new = buf_to_state(&new_buf).expect("ledger was set to invalid state");
+                    let mut container = self.container_ref.lock();
+                    let mut editor = container.editor_for_buffer_mut(&buffer).unwrap();
+                    editor.merge_new_state(new);
+                    if let Some(promise) = done {
+                        promise.set_ok(None);
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct PageWatcherServer {
+    updates: Sender<SyncMsg>,
+    buffer: BufferIdentifier,
+}
+
+impl PageWatcher for PageWatcherServer {
+    fn on_change(&mut self, page_change: PageChange, result_state: ResultState) -> Future<Option<PageSnapshot_Server>, fidl::Error> {
+        let (future, done) = Future::make_promise();
+
+        assert_eq!(ResultState_Completed, result_state, "example is for single-key pages");
+        assert_eq!(page_change.changes.len(), 1, "example is for single-key pages");
+        let value_vmo = page_change.changes[0].value.as_ref().expect("example is for single-key pages");
+        let new_buf = read_entire_vmo(value_vmo).expect("failed to read key Vmo");
+        self.updates.send(SyncMsg::NewState { buffer: self.buffer.clone(), new_buf, done: Some(done) }).unwrap();
+
+        future
+    }
+}
+
+impl PageWatcher_Stub for PageWatcherServer {
+    // Use default dispatching, but we could override it here.
+}
+impl_fidl_stub!(PageWatcherServer: PageWatcher_Stub);

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -22,6 +22,21 @@ extern crate serde_derive;
 extern crate time;
 extern crate syntect;
 
+#[cfg(target_os = "fuchsia")]
+extern crate magenta;
+#[cfg(target_os = "fuchsia")]
+extern crate magenta_sys;
+#[cfg(target_os = "fuchsia")]
+extern crate mxruntime;
+#[cfg(target_os = "fuchsia")]
+#[macro_use]
+extern crate fidl;
+#[cfg(target_os = "fuchsia")]
+extern crate apps_ledger_services_public;
+
+#[cfg(target_os = "fuchsia")]
+extern crate sha2;
+
 use std::io::Write;
 
 use serde_json::Value;
@@ -42,6 +57,8 @@ pub mod internal {
     pub mod view;
     pub mod linewrap;
     pub mod plugins;
+    #[cfg(target_os = "fuchsia")]
+    pub mod fuchsia;
     pub mod styles;
     pub mod word_boundaries;
     pub mod index_set;
@@ -63,9 +80,14 @@ use internal::selection;
 use internal::movement;
 use internal::syntax;
 use internal::layers;
+#[cfg(target_os = "fuchsia")]
+use internal::fuchsia;
 
 use tabs::Documents;
 use rpc::Request;
+
+#[cfg(target_os = "fuchsia")]
+use apps_ledger_services_public::Ledger_Proxy;
 
 extern crate xi_rope;
 extern crate xi_unicode;
@@ -84,6 +106,11 @@ impl<W: Write + Send + 'static> MainState<W> {
         MainState {
             tabs: Documents::new(),
         }
+    }
+
+    #[cfg(target_os = "fuchsia")]
+    pub fn set_ledger(&mut self, ledger: Ledger_Proxy) {
+        self.tabs.set_ledger(ledger);
     }
 }
 

--- a/rust/rope/src/engine.rs
+++ b/rust/rope/src/engine.rs
@@ -164,6 +164,11 @@ impl Engine {
         deletes_from_union
     }
 
+    /// Returns the largest undo group ID used so far
+    pub fn max_undo_group_id(&self) -> usize {
+        self.revs.last().unwrap().max_undo_so_far
+    }
+
     /// Get revision id of head revision.
     pub fn get_head_rev_id(&self) -> usize {
         self.revs.last().unwrap().rev_id


### PR DESCRIPTION
Adds the ability to synchronize the state of an Editor to and from the Ledger on Fuchsia. First a Ledger handle has to be given to MainState and then any buffer with a file name will be synchronized with any other buffer with the same file name.

I isolated as much of the Fuchsia-specific code as possible to the new `fuchsia` subdirectory/module, but I couldn't isolate some of the plumbing code since it needed access to private fields. Also some of the code on `Editor` isn't really Fuchsia/ledger specific but it is for now because we don't have any other sync backends and the Fuchsia build system doesn't support features so I can't scope it behind a feature instead of an OS.

A substantial amount of the code in the `fuchsia` folder is copy-pasted from [this fuchsia/rust_ledger_example CL](https://fuchsia-review.googlesource.com/#/c/33483/) but then modified. I couldn't preserve all the generic-ness because of the fact that the `SyncUpdater` needs to know about buffers because that is the level where the `Mutex` is, and that contaminates the rest of `sync.rs` to be Xi-specific.

Also includes a refactor of `Engine` to make its initial contents a `Revision`. In order for CRDT to eventually work even on documents that had initial contents loaded from a file, the two `Engine`'s being merged need a common ancestor, which they won't have if they have different initial Revisions. This mostly involved changing the tests to avoid assuming the initial state is revision 0, which is a refactor that would be necessary anyway when I change how revision IDs are generated in order to support merge.

**Edit:** forgot to note that this currently doesn't do a CRDT merge since that isn't implemented yet. It just does last-write-wins. This means that for now having the garbage collector enabled works but eventually the GC will have to be disabled in `Editor` once a real merge function is hooked up.

cc @jimbeveridge

**Not to be merged before #338**