### PR TITLE
Don't create empty inserts in delta::Builder

### DIFF
--- a/rust/rope/src/delta.rs
+++ b/rust/rope/src/delta.rs
@@ -485,7 +485,9 @@ impl<N: NodeInfo> Builder<N> {
     /// is not properly sorted.
     pub fn replace(&mut self, interval: Interval, rope: Node<N>) {
         self.delete(interval);
-        self.delta.els.push(DeltaElement::Insert(rope));
+        if rope.len() > 0 {
+            self.delta.els.push(DeltaElement::Insert(rope));
+        }
     }
 
     /// Determines if delta would be a no-op transformation if built.


### PR DESCRIPTION
The `multiset::SubsetBuilder` segments require that all segments pushed are non-
empty. This caused a crash when typing `ctrl+y` (yank) with nothing in the kill
ring would use `delta::Builder::replace` to insert an empty string, which would
end up constructing an empty segment. I fixed this by not allowing
`delta::Builder` to construct empty Insert nodes.