### PR TITLE
Style progress (plus basic themes)

### DIFF
--- a/doc/frontend.md
+++ b/doc/frontend.md
@@ -70,6 +70,12 @@ Closes the view associated with this `view_id`.
 Saves the buffer associated with `view_id` to `file_path`. See the
 note for `new_view`. Errors are not currently reported.
 
+### set_theme
+
+`set_theme {"theme_name": "InspiredGitHub"}`
+
+Requests that core change the theme. If the change succeeds the client
+will receive a `theme_changed` notification.
 
 ### plugin
 **Note:** plugin commands are in flux, and may change.
@@ -95,7 +101,6 @@ Starts the named given for the given view.
 
 #### stop
 
-**Not Implemented**
 `stop {"view_id": "view-id-1", "plugin_name": "syntect"}`
 
 Stops the named plugin for the given view.
@@ -226,6 +231,16 @@ contents may have been invalidated and need to be redrawn. The
 evolution of this method will probably include finer grained
 invalidation (including motion of just the cursor), but will broadly
 follow the existing pattern.
+
+#### theme_changed
+
+`theme_changed {"name": "InspiredGitHub", "theme": Theme}`
+
+Notifies the client that the theme has been changed. The client should
+use the new theme to set colors as appropriate.
+The `Theme` object is directly serialized from a 
+[`syntect::highlighting::ThemeSettings`](https://github.com/trishume/syntect/blob/master/src/highlighting/theme.rs#L27) 
+instance.
 
 ### RPCs from front-end to back-end
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -238,7 +238,7 @@ dependencies = [
 
 [[package]]
 name = "syntect"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -295,7 +295,7 @@ dependencies = [
  "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntect 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntect 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "xi-rope 0.2.0",
  "xi-rpc 0.2.0",
@@ -365,7 +365,7 @@ dependencies = [
 "checksum serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "48b04779552e92037212c3615370f6bd57a40ebba7f20e554ff9f55e41a69a7b"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-"checksum syntect 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fed7a5661c5c42fe998c561efb12137381a4486702f41c95a1d7269f3cc8ca6a"
+"checksum syntect 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f75613d1df82e2f8020e86c260a46bdef180d16ac8d2febe43194037d6fe76"
 "checksum time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "ffd7ccbf969a892bf83f1e441126968a07a3941c24ff522a26af9f9f4585d1a3"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bb08f9e670fab86099470b97cd2b252d6527f0b3cc1401acdb595ffc9dd288ff"

--- a/rust/core-lib/Cargo.toml
+++ b/rust/core-lib/Cargo.toml
@@ -17,7 +17,7 @@ xi-unicode = { path = "../unicode", version = "0.1.0" }
 xi-rpc = { path = "../rpc", version = "0.2.0" }
 
 [dependencies.syntect]
-version = "1.5"
+version = "1.6"
 default-features = false
 features = ["assets"]
 

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -904,6 +904,13 @@ impl<W: Write + Send + 'static> Editor<W> {
         result
     }
 
+    pub fn theme_changed(&mut self) {
+        self.styles.theme_changed(&self.doc_ctx);
+        self.view.set_dirty();
+        self.render();
+        self.doc_ctx.theme_changed(&self.view.view_id);
+    }
+
     // Note: the following are placeholders for prototyping, and are not intended to
     // deal with asynchrony or be efficient.
 

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -908,7 +908,6 @@ impl<W: Write + Send + 'static> Editor<W> {
         self.styles.theme_changed(&self.doc_ctx);
         self.view.set_dirty();
         self.render();
-        self.doc_ctx.theme_changed(&self.view.view_id);
     }
 
     // Note: the following are placeholders for prototyping, and are not intended to

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -26,7 +26,7 @@ use xi_rope::interval::Interval;
 use xi_rope::delta::{self, Delta, Transformer};
 use xi_rope::engine::Engine;
 use xi_rope::spans::{Spans, SpansBuilder};
-use view::{Style, View};
+use view::View;
 use word_boundaries::WordCursor;
 use movement::{Movement, region_movement};
 use selection::{Affinity, Selection, SelRegion};
@@ -37,6 +37,7 @@ use syntax::SyntaxDefinition;
 use plugins::rpc_types::{PluginUpdate, PluginEdit, ScopeSpan, PluginBufferInfo};
 use plugins::PluginPid;
 use layers::Scopes;
+use styles::Style;
 
 const FLAG_SELECT: u64 = 2;
 
@@ -949,7 +950,7 @@ impl<W: Write + Send + 'static> Editor<W> {
         }
         let iv = Interval::new_closed_closed(start, end_offset);
         self.style_scopes.update_layer(plugin, iv, spans);
-        let updated_styles = self.style_scopes.resolve_styles(iv);
+        let updated_styles = self.style_scopes.resolve_styles(iv, &self.doc_ctx);
         self.style_spans.edit(iv, updated_styles);
         self.view.set_dirty();
         self.render();

--- a/rust/core-lib/src/layers.rs
+++ b/rust/core-lib/src/layers.rs
@@ -107,7 +107,6 @@ impl Scopes {
     /// Resolves styles from all layers for the given interval, updating
     /// the master style spans.
     fn resolve_styles(&mut self, iv: Interval) {
-        print_err!("resolving styles");
         if self.layers.is_empty() {
             return
         }

--- a/rust/core-lib/src/layers.rs
+++ b/rust/core-lib/src/layers.rs
@@ -24,7 +24,7 @@
 use std::collections::BTreeMap;
 use std::io::Write;
 use syntect::parsing::Scope;
-use syntect::highlighting::{Highlighter, StyleModifier};
+use syntect::highlighting::Highlighter;
 
 use xi_rope::interval::Interval;
 use xi_rope::spans::{Spans, SpansBuilder};
@@ -165,18 +165,10 @@ impl ScopeLayer {
 
         let mut new_styles = Vec::new();
         for stack in &stacks {
-            let style = highlighter.style_for_stack(stack);
-            //FIXME: temporarily create stylemod from a style while we wait for upstream
-            let style = StyleModifier {
-                foreground: Some(style.foreground),
-                background: Some(style.background),
-                font_style: Some(style.font_style),
-            };
-
+            let style = highlighter.style_mod_for_stack(stack);
             let style = Style::from_syntect_style_mod(&style);
             new_styles.push(style);
         }
-        //print_err!("added styles: {:?}", &new_styles);
         self.stack_lookup.append(&mut stacks);
         self.style_lookup.append(&mut new_styles);
     }

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -50,6 +50,7 @@ pub enum CoreCommand<'a> {
     NewView { file_path: Option<&'a str> },
     CloseView { view_id: ViewIdentifier },
     Save { view_id: ViewIdentifier, file_path: &'a str },
+    SetTheme { theme_name: &'a str }
 }
 
 /// An enum representing touch and mouse gestures applied to the text.
@@ -136,7 +137,6 @@ pub enum PluginCommand {
     Start { view_id: ViewIdentifier, plugin_name: String },
     #[serde(rename = "stop")]
     Stop { view_id: ViewIdentifier, plugin_name: String },
-    //Other { view_id: String, params: Value },
 }
 
 impl<'a> CoreCommand<'a> {
@@ -152,6 +152,10 @@ impl<'a> CoreCommand<'a> {
             "new_view" => params.as_object()
                 .map(|dict| NewView { file_path: dict_get_string(dict, "file_path") }) // optional
                 .ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
+
+            "set_theme" => params.as_object().and_then(|dict| {
+                dict_get_string(dict, "theme_name").map(|theme_name| SetTheme { theme_name: theme_name })
+            }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
 
             "save" => params.as_object().and_then(|dict| {
                 dict_get_string(dict, "view_id").and_then(|view_id| {

--- a/rust/core-lib/src/styles.rs
+++ b/rust/core-lib/src/styles.rs
@@ -113,8 +113,7 @@ impl Style {
         Style::new(
             p1.priority,
             p1.fg_color.or(p2.fg_color),
-            //FIXME: use bg_color once we've switched to syntect StyleModifiers
-            None,
+            p1.bg_color.or(p2.bg_color),
             p1.weight.or(p2.weight),
             p1.underline.or(p2.underline),
             p1.italic.or(p2.italic),

--- a/rust/core-lib/src/styles.rs
+++ b/rust/core-lib/src/styles.rs
@@ -176,7 +176,7 @@ impl ThemeStyleMap {
         Highlighter::new(&self.theme)
     }
 
-    pub fn get_theme_name<'a>(&'a self) -> &String {
+    pub fn get_theme_name(&self) -> &str {
         &self.theme_name
     }
 
@@ -185,6 +185,9 @@ impl ThemeStyleMap {
     }
 
     pub fn set_theme(&mut self, theme_name: &str) -> Result<(), &'static str> {
+        if theme_name == self.theme_name {
+            return Ok(())
+        }
         if let Some(new_theme) = self.themes.themes.get(theme_name) {
             self.theme = new_theme.to_owned();
             self.theme_name = theme_name.to_owned();

--- a/rust/core-lib/src/styles.rs
+++ b/rust/core-lib/src/styles.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 
 use serde_json::{self, Value};
 use syntect::highlighting::StyleModifier as SynStyleModifier;
-use syntect::highlighting::{Color, Theme, ThemeSet, Highlighter, BLACK};
+use syntect::highlighting::{Color, Theme, ThemeSet, ThemeSettings, Highlighter, BLACK};
 
 const N_RESERVED_STYLES: usize = 2;
 const SYNTAX_PRIORITY_DEFAULT: u16 = 200;
@@ -171,9 +171,30 @@ impl ThemeStyleMap {
     pub fn get_default_style(&self) -> &Style {
         &self.default_style
     }
-    
+
     pub fn get_highlighter<'a>(&'a self) -> Highlighter<'a> {
         Highlighter::new(&self.theme)
+    }
+
+    pub fn get_theme_name<'a>(&'a self) -> &String {
+        &self.theme_name
+    }
+
+    pub fn get_theme_settings<'a>(&'a self) -> &ThemeSettings {
+        &self.theme.settings
+    }
+
+    pub fn set_theme(&mut self, theme_name: &str) -> Result<(), &'static str> {
+        if let Some(new_theme) = self.themes.themes.get(theme_name) {
+            self.theme = new_theme.to_owned();
+            self.theme_name = theme_name.to_owned();
+            self.default_style = Style::default_for_theme(&self.theme);
+            self.map = HashMap::new();
+            self.styles = Vec::new();
+            Ok(())
+        } else {
+        Err("unknown theme")
+        }
     }
 
     pub fn merge_with_default(&self, style: &Style) -> Style {

--- a/rust/core-lib/src/styles.rs
+++ b/rust/core-lib/src/styles.rs
@@ -16,40 +16,123 @@
 
 use std::collections::HashMap;
 
-use serde_json::value::Value;
+use serde_json::{self, Value};
+use syntect::highlighting::StyleModifier as SynStyleModifier;
+use syntect::highlighting::{Color, Theme, BLACK};
 
 const N_RESERVED_STYLES: usize = 2;
+const SYNTAX_PRIORITY_DEFAULT: u16 = 200;
+const SYNTAX_PRIORITY_LOWEST: u16 = 0;
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Default, Hash, Debug, Serialize, Deserialize)]
+/// A mergeable style. All values except priority are optional.
+///
+/// Note: A `None` value represents the absense of preference; in the case of
+/// boolean options, `Some(false)` means that this style will override a lower
+/// priority value in the same field.
 pub struct Style {
-    pub fg: u32,  // ARGB format
-    pub bg: u32,  // ARGB format
-    pub weight: u16,  // 100-900, same interpretation as CSS
-    pub underline: bool,
-    pub italic: bool,
+    /// The priority of this style, in the range (0, 1000). Used to resolve
+    /// conflicting fields when merging styles. The higher priority wins.
+    #[serde(skip_serializing)]
+    pub priority: u16,
+    /// The foreground text color, in ARGB.
+    pub fg_color: Option<u32>,
+    /// The background text color, in ARGB.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bg_color: Option<u32>,
+    /// The font-weight, in the range 100-900, interpreted like the CSS
+    /// font-weight property.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub weight: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub underline: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub italic: Option<bool>,
 }
 
 impl Style {
-    // construct the params for a def_style request
-    pub fn to_json(&self, id: usize) -> Value {
-        let mut json = json!({
-            "id": id,
-            "fg_color": self.fg,
-        });
 
-        if (self.bg >> 24) > 0 {
-            json["bg_color"] = json!(self.bg);
+    /// Creates a new `Style` by converting from a `Syntect::StyleModifier`.
+    pub fn from_syntect_style_mod(style: &SynStyleModifier) -> Self {
+        let font_style = style.font_style.map(|s|s.bits()).unwrap_or_default();
+        let weight = if (font_style & 1) != 0 { Some(700) } else { None };
+        let underline = if (font_style & 2) != 0 { Some(true) } else { None };
+        let italic = if (font_style & 4) != 0 { Some(true) } else { None };
+
+        Self::new(
+            SYNTAX_PRIORITY_DEFAULT,
+            style.foreground.map(|c| Self::rgba_from_syntect_color(&c)),
+            style.background.map(|c| Self::rgba_from_syntect_color(&c)),
+            weight,
+            underline,
+            italic,
+            )
+    }
+
+    pub fn new<O32, O16, OB>(priority: u16, fg_color: O32, bg_color: O32,
+                             weight: O16, underline: OB, italic: OB) -> Self
+        where O32: Into<Option<u32>>,
+              O16: Into<Option<u16>>,
+              OB: Into<Option<bool>>
+    {
+        assert!(priority <= 1000);
+        Style {
+            priority: priority,
+            fg_color: fg_color.into(),
+            bg_color: bg_color.into(),
+            weight: weight.into(),
+            underline: underline.into(),
+            italic: italic.into(),
         }
-        if self.weight != 400 {
-            json["weight"] = json!(self.weight);
-        }
-        if self.underline {
-            json["underline"] = json!(self.underline);
-        }
-        if self.italic {
-            json["italic"] = json!(self.italic);
-        }
-        json 
+    }
+
+    /// Returns the default style for the given `Theme`.
+    pub fn default_for_theme(theme: &Theme) -> Self {
+        let fg = theme.settings.foreground.unwrap_or(BLACK);
+        Style::new(
+            SYNTAX_PRIORITY_LOWEST,
+            Some(Self::rgba_from_syntect_color(&fg)),
+            None,
+            None,
+            None,
+            None)
+    }
+
+    /// Creates a new style by combining attributes of `self` and `other`.
+    /// If both styles define an attribute, the highest priority wins; `other`
+    /// wins in the case of a tie.
+    ///
+    /// Note: when merging multiple styles, apply them in increasing priority.
+    pub fn merge(&self, other: &Style) -> Style {
+        let (p1, p2) = if self.priority > other.priority {
+            (self, other)
+        } else {
+            (other, self)
+        };
+
+        Style::new(
+            p1.priority,
+            p1.fg_color.or(p2.fg_color),
+            //FIXME: use bg_color once we've switched to syntect StyleModifiers
+            None,
+            p1.weight.or(p2.weight),
+            p1.underline.or(p2.underline),
+            p1.italic.or(p2.italic),
+            )
+    }
+
+    /// Encode this `Style`, setting the `id` property.
+    ///
+    /// Note: this should only be used when sending the `def_style` RPC.
+    pub fn to_json(&self, id: usize) -> Value {
+        let mut as_val = serde_json::to_value(self).expect("failed to encode style");
+        as_val["id"] = serde_json::to_value(id).unwrap();
+        as_val
+    }
+
+    fn rgba_from_syntect_color(color: &Color) -> u32 {
+        let &Color { r, g, b, a } = color;
+        ((a as u32) << 24) | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
     }
 }
 

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -320,7 +320,7 @@ impl<W: Write + Send + 'static> Documents<W> {
             Save { view_id, file_path } => self.do_save(&view_id, file_path),
             Edit { view_id, edit_command } => self.do_edit(&view_id, edit_command),
             Plugin { plugin_command } => self.do_plugin_cmd(plugin_command),
-            SetTheme { theme_name, .. } => {
+            SetTheme { theme_name } => {
                 self.do_set_theme(rpc_peer, theme_name);
                 None
             }

--- a/rust/rope/src/spans.rs
+++ b/rust/rope/src/spans.rs
@@ -18,6 +18,7 @@
 
 use std::marker::PhantomData;
 use std::mem;
+use std::fmt;
 
 use tree::{Leaf, Node, NodeInfo, TreeBuilder, Cursor};
 use delta::Transformer;
@@ -289,6 +290,16 @@ impl<T: Clone + Default> Spans<T> {
             cursor: Cursor::new(self, 0),
             ix: 0,
         }
+    }
+}
+
+impl<T: Clone + Default + fmt::Debug> fmt::Debug for Spans<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let strs = self.iter().map(|(iv, val)| {
+            format!("{}: {:?}", iv, val)
+        })
+        .collect::<Vec<String>>();
+        write!(f, "len: {}\nspans:\n\t{}", self.len(), &strs.join("\n\t"))
     }
 }
 


### PR DESCRIPTION
This is the last little bit of work towards #319 and #284, with the exception of clarifying custom style _declaration_; that will be revisited at some point down the line.

A consequence of this work is that the theme now lives in `xi-core`. It seemed like a shame not to expose that to the user. Some of the implementation details around setting themes will change, but it works well enough for now.

Theme selection is testable from the xi-mac branch PR'd here: https://github.com/google/xi-mac/pull/51