### PR TITLE
Implement CRDT merge for inserts only

### DIFF
--- a/rust/rope/src/delta.rs
+++ b/rust/rope/src/delta.rs
@@ -252,26 +252,26 @@ impl<N: NodeInfo> fmt::Debug for Delta<N> where Node<N>: fmt::Debug {
             for el in &self.els {
                 match *el {
                     DeltaElement::Copy(beg,end) => {
-                        try!(write!(f, "{}", "-".repeat(end-beg)));
+                        write!(f, "{}", "-".repeat(end-beg))?;
                     }
                     DeltaElement::Insert(ref node) => {
-                        try!(node.fmt(f));
+                        node.fmt(f)?;
                     }
                 }
             }
         } else {
-            try!(write!(f, "Delta("));
+            write!(f, "Delta(")?;
             for el in &self.els {
                 match *el {
                     DeltaElement::Copy(beg,end) => {
-                        try!(write!(f, "[{},{}) ", beg, end));
+                        write!(f, "[{},{}) ", beg, end)?;
                     }
                     DeltaElement::Insert(ref node) => {
-                        try!(write!(f, "<ins:{}> ", node.len()));
+                        write!(f, "<ins:{}> ", node.len())?;
                     }
                 }
             }
-            try!(write!(f, ")"));
+            write!(f, ")")?;
         }
         Ok(())
     }

--- a/rust/rope/src/delta.rs
+++ b/rust/rope/src/delta.rs
@@ -46,6 +46,7 @@ pub struct Delta<N: NodeInfo> {
 /// A struct marking that a Delta contains only insertions. That is, it copies
 /// all of the old document in the same order. It has a `Deref` impl so all
 /// normal `Delta` methods can also be used on it.
+#[derive(Clone)]
 pub struct InsertDelta<N: NodeInfo>(Delta<N>);
 
 impl<N: NodeInfo> Delta<N> {
@@ -245,21 +246,40 @@ impl<N: NodeInfo> Delta<N> {
     }
 }
 
-impl<N: NodeInfo> fmt::Debug for Delta<N> {
+impl<N: NodeInfo> fmt::Debug for Delta<N> where Node<N>: fmt::Debug {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "Delta("));
-        for el in &self.els {
-            match *el {
-                DeltaElement::Copy(beg,end) => {
-                    try!(write!(f, "[{},{}) ", beg, end));
-                }
-                DeltaElement::Insert(ref node) => {
-                    try!(write!(f, "<ins:{}> ", node.len()));
+        if f.alternate() {
+            for el in &self.els {
+                match *el {
+                    DeltaElement::Copy(beg,end) => {
+                        try!(write!(f, "{}", "-".repeat(end-beg)));
+                    }
+                    DeltaElement::Insert(ref node) => {
+                        try!(node.fmt(f));
+                    }
                 }
             }
+        } else {
+            try!(write!(f, "Delta("));
+            for el in &self.els {
+                match *el {
+                    DeltaElement::Copy(beg,end) => {
+                        try!(write!(f, "[{},{}) ", beg, end));
+                    }
+                    DeltaElement::Insert(ref node) => {
+                        try!(write!(f, "<ins:{}> ", node.len()));
+                    }
+                }
+            }
+            try!(write!(f, ")"));
         }
-        try!(write!(f, ")"));
         Ok(())
+    }
+}
+
+impl<N: NodeInfo> fmt::Debug for InsertDelta<N> where Node<N>: fmt::Debug {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 

--- a/rust/rope/src/multiset.rs
+++ b/rust/rope/src/multiset.rs
@@ -333,31 +333,12 @@ impl Subset {
             subset_amount_consumed: 0,
         }
     }
-
-
-    /// Print a debug representation where `#` for count 1, `-` for 0, and
-    /// digits otherwise. Mainly useful for testing with small lengths.
-    pub fn debug_print(&self) {
-        for s in &self.segments {
-            let chr = if s.count == 0 {
-                '-'
-            } else if s.count == 1 {
-                '#'
-            } else if s.count <= 9 {
-                ((s.count as u8) + ('0' as u8)) as char
-            } else {
-                '+'
-            };
-            for _ in 0..s.len {
-                print!("{}", chr);
-            }
-        }
-        println!("");
-    }
 }
 
 impl fmt::Debug for Subset {
     /// Use the alternate flag (`#`) to print a more compact representation
+    /// where each character represents the count of one element:
+    /// '-' is 0, '#' is 1, 2-9 are digits, `+` is >9
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if f.alternate() {
             for s in &self.segments {

--- a/rust/rope/src/multiset.rs
+++ b/rust/rope/src/multiset.rs
@@ -20,6 +20,7 @@ use std::cmp;
 use tree::{Node, NodeInfo, TreeBuilder};
 use interval::Interval;
 use std::slice;
+use std::fmt;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 struct Segment {
@@ -33,7 +34,7 @@ struct Segment {
 /// included in the set.
 ///
 /// Internally, this is stored as a list of "segments" with a length and a count.
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Subset {
     /// Invariant, maintained by `SubsetBuilder`: all `Segment`s have non-zero
     /// length, and no `Segment` has the same count as the one before it.
@@ -325,6 +326,33 @@ impl Subset {
             last_i: 0, // indices only need to be in non-decreasing order, not increasing
             cur_range: (0,0), // will immediately try to consume next range
             subset_amount_consumed: 0,
+        }
+    }
+}
+
+impl fmt::Debug for Subset {
+    /// Use the alternate flag (`#`) to print a more compact representation
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if f.alternate() {
+            for s in &self.segments {
+                let chr = if s.count == 0 {
+                    '-'
+                } else if s.count == 1 {
+                    '#'
+                } else if s.count <= 9 {
+                    ((s.count as u8) + ('0' as u8)) as char
+                } else {
+                    '+'
+                };
+                for _ in 0..s.len {
+                    try!(write!(f, "{}", chr));
+                }
+            }
+            Ok(())
+        } else {
+            f.debug_tuple("Subset")
+                .field(&self.segments)
+                .finish()
         }
     }
 }

--- a/rust/rope/src/multiset.rs
+++ b/rust/rope/src/multiset.rs
@@ -165,6 +165,11 @@ impl Subset {
         self.segments.iter().filter(|seg| matcher.matches(seg)).map(|seg| seg.len).sum()
     }
 
+    /// Convenience alias for `self.count(CountMatcher::All)`
+    pub fn len(&self) -> usize {
+        self.count(CountMatcher::All)
+    }
+
     /// Determine whether the subset is empty.
     /// In this case deleting it would do nothing.
     pub fn is_empty(&self) -> bool {
@@ -327,6 +332,27 @@ impl Subset {
             cur_range: (0,0), // will immediately try to consume next range
             subset_amount_consumed: 0,
         }
+    }
+
+
+    /// Print a debug representation where `#` for count 1, `-` for 0, and
+    /// digits otherwise. Mainly useful for testing with small lengths.
+    pub fn debug_print(&self) {
+        for s in &self.segments {
+            let chr = if s.count == 0 {
+                '-'
+            } else if s.count == 1 {
+                '#'
+            } else if s.count <= 9 {
+                ((s.count as u8) + ('0' as u8)) as char
+            } else {
+                '+'
+            };
+            for _ in 0..s.len {
+                print!("{}", chr);
+            }
+        }
+        println!("");
     }
 }
 

--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -437,7 +437,11 @@ impl<'a> From<&'a Rope> for String {
 
 impl fmt::Debug for Rope {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Rope({:?})", String::from(self))
+        if f.alternate() {
+            write!(f, "{}", String::from(self))
+        } else {
+            write!(f, "Rope({:?})", String::from(self))
+        }
     }
 }
 

--- a/rust/rope/src/test_helpers.rs
+++ b/rust/rope/src/test_helpers.rs
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 use multiset::{SubsetBuilder, Subset};
-use delta::Delta;
+use delta::{Delta, self};
 use rope::{Rope, RopeInfo};
+use interval::Interval;
 
 /// Creates a `Subset` of `s` by scanning through `substr` and finding which
 /// characters of `s` are missing from it in order. Returns a `Subset` which
@@ -69,4 +70,21 @@ pub fn debug_subsets(subsets: &[Subset]) {
     for s in subsets {
         println!("{:#?}", s);
     }
+}
+
+pub fn parse_insert(s: &str) -> Delta<RopeInfo> {
+    let base_len = s.chars().filter(|c| *c == '-').count();
+    let mut b = delta::Builder::new(base_len);
+
+    let mut i = 0;
+    for c in s.chars() {
+        if c == '-' {
+            i += 1;
+        } else {
+            let inserted = format!("{}", c);
+            b.replace(Interval::new_closed_open(i,i), Rope::from(inserted));
+        }
+    }
+
+    b.build()
 }

--- a/rust/rope/src/test_helpers.rs
+++ b/rust/rope/src/test_helpers.rs
@@ -44,3 +44,29 @@ impl PartialEq for Rope {
         String::from(self) == String::from(other)
     }
 }
+
+pub fn parse_subset(s: &str) -> Subset {
+    let mut sb = SubsetBuilder::new();
+
+    for c in s.chars() {
+        if c == '#' {
+            sb.push_segment(1,1);
+        } else if c == 'e' {
+            // do nothing, used for empty subsets
+        } else {
+            sb.push_segment(1,0);
+        }
+    }
+
+    sb.build()
+}
+
+pub fn parse_subset_list(s: &str) -> Vec<Subset> {
+    s.lines().map(|s| s.trim()).filter(|s| !s.is_empty()).map(parse_subset).collect()
+}
+
+pub fn debug_subsets(subsets: &[Subset]) {
+    for s in subsets {
+        println!("{:#?}", s);
+    }
+}


### PR DESCRIPTION
Based on converting Revisions on the right into Deltas and carrying them through the new commits on the left. Doesn't support undo or deletes yet.

Also adds a couple more tests and some `fmt::Debug` impls that use the alternative flag to display prettier but non-scalable representations.

In a follow-up PR I'm going to add a DSL for sequences of edits and merges that will allow me to test this much more thoroughly and eventually randomly generate test scripts. Then I'll move on to scaling this up to deletes and Undo, as well as making it faster.

cc @jimbeveridge