### PR TITLE
CRDT Merge test scripts

### DIFF
--- a/rust/rope/src/engine.rs
+++ b/rust/rope/src/engine.rs
@@ -1217,7 +1217,7 @@ mod tests {
         MergeTestState::new(3).run_script(&script[..]);
     }
 
-    /// Tests that merging again when there is no new revisions does nothing
+    /// Tests that merging again when there are no new revisions does nothing
     #[test]
     fn merge_idempotent() {
         use self::MergeTestOp::*;


### PR DESCRIPTION
Adds some test helpers for running "merge scripts" that make it easier to test sequences of edits and merges between multiple engines. Ports the two existing tests in #348 to use them and adds two more tests.

These also open the door to randomized or even fuzz testing of merge later by generating these merge scripts and adding tests at the end for properties like eventual consistency.

**Not to be merged before #348**

cc @jimbeveridge