### PR TITLE
Correct deletes and max_undo_so_far for merge

### DIFF
--- a/rust/rope/src/delta.rs
+++ b/rust/rope/src/delta.rs
@@ -493,6 +493,7 @@ impl<N: NodeInfo> Builder<N> {
 
     /// Deletes the given interval. Panics if interval is not properly sorted.
     pub fn delete(&mut self, interval: Interval) {
+        // TODO: doesn't handle interval types other than closed_open
         let (start, end) = interval.start_end();
         assert!(start >= self.last_offset, "Delta builder: intervals not properly sorted");
         if start > self.last_offset {

--- a/rust/rope/src/test_helpers.rs
+++ b/rust/rope/src/test_helpers.rs
@@ -72,13 +72,16 @@ pub fn debug_subsets(subsets: &[Subset]) {
     }
 }
 
-pub fn parse_insert(s: &str) -> Delta<RopeInfo> {
-    let base_len = s.chars().filter(|c| *c == '-').count();
+pub fn parse_delta(s: &str) -> Delta<RopeInfo> {
+    let base_len = s.chars().filter(|c| *c == '-' || *c == '!').count();
     let mut b = delta::Builder::new(base_len);
 
     let mut i = 0;
     for c in s.chars() {
         if c == '-' {
+            i += 1;
+        } else if c == '!' {
+            b.delete(Interval::new_closed_open(i,i+1));
             i += 1;
         } else {
             let inserted = format!("{}", c);


### PR DESCRIPTION
This PR adds support for deletes and `max_undo_so_far`. Previous support for deletes was incomplete and in places I just threw in something without thinking too much about it to stop the insert-only cases from crashing.

Merge is now to the best of my knowledge correct for all cases that don't involve undo. That doesn't mean there's no bugs, just that there's none I know of and I think there's a good chance of no bugs.

cc @jimbeveridge

**Not to be merged before #349**