### PR TITLE
Use new pure Rust syntect config

### DIFF
--- a/rust/core-lib/Cargo.toml
+++ b/rust/core-lib/Cargo.toml
@@ -17,9 +17,9 @@ xi-unicode = { path = "../unicode", version = "0.1.0" }
 xi-rpc = { path = "../rpc", version = "0.2.0" }
 
 [dependencies.syntect]
-version = "1.6"
+version = "1.7"
 default-features = false
-features = ["assets"]
+features = ["assets","dump-load-rs"]
 
 [target."cfg(target_os = \"fuchsia\")".dependencies]
 sha2 = "0.5"


### PR DESCRIPTION
Bumps the syntect version so that we can use the new dump-load-rs feature,
avoiding an indirect dependency on miniz-sys, so that we can build on Fuchsia
without any transitive dependencies on C.

See https://github.com/trishume/syntect/pull/84