### PR TITLE
Fix build on Fuchsia

### DIFF
--- a/rust/core-lib/src/plugins/manifest.rs
+++ b/rust/core-lib/src/plugins/manifest.rs
@@ -107,8 +107,8 @@ pub enum PluginScope {
     SingleInvocation,
 }
 
-#[cfg(not(target_os = "fuchsia"))]
 impl PluginDescription {
+    #[cfg(not(target_os = "fuchsia"))]
     fn new<S, P>(name: S, version: S, scope: PluginScope, exec_path: P,
                  activations: Vec<PluginActivation>) -> Self
         where S: Into<String>, P: Into<PathBuf>


### PR DESCRIPTION
Turns out the is_global method is required to build on Fuchsia,
but if the new method is present, it will warn it isn't being used.