### PR TITLE
plugin commands

### DIFF
--- a/doc/frontend.md
+++ b/doc/frontend.md
@@ -287,29 +287,36 @@ this writing, the following is valid json for a `Command` object:
 
 ```json
     {
-    "title": "Test Command",
-    "description": "Passes the current test",
-    "rpc_cmd": {
-        "type": "notification",
-        "method": "test.cmd",
-        "params": {
-            "this_works": "some value",
-            "a_choice": "some value"
-        }
-    },
-    "args": [
-        {"title": "This Works", "description": "Indicates something", "key": "this_works", "arg_type": "Bool"},
-        {
-            "title": "Favourite Number",
-            "description": "A number used in a test.",
-            "key": "a_choice",
-            "arg_type": "Choice",
-            "options": [
-                {"title": "Five", "value": 5},
-                {"title": "Ten", "value": 10}
-            ]
-        }
-    ]
+        "title": "Test Command",
+        "description": "Passes the current test",
+        "rpc_cmd": {
+            "rpc_type": "notification",
+            "method": "test.cmd",
+            "params": {
+                "view": "",
+                "non_arg": "plugin supplied value",
+                "arg_one": "",
+                "arg_two": ""
+            }
+        },
+        "args": [
+            {
+                "title": "First argument",
+                "description": "Indicates something",
+                "key": "arg_one",
+                "arg_type": "Bool"
+            },
+            {
+                "title": "Favourite Number",
+                "description": "A number used in a test.",
+                "key": "arg_two",
+                "arg_type": "Choice",
+                "options": [
+                    {"title": "Five", "value": 5},
+                    {"title": "Ten", "value": 10}
+                ]
+            }
+        ]
     }
 ```
 

--- a/doc/frontend.md
+++ b/doc/frontend.md
@@ -99,6 +99,19 @@ Starts the named given for the given view.
 
 Stops the named plugin for the given view.
 
+#### plugin_rpc
+
+```
+plugin_rpc {"view_id": "view-id-1", "receiver": "syntect",
+            "notification": {
+                "method": "custom_method",
+                "params": {"foo": "bar"},
+            }}
+ ```
+
+Sends a custom rpc command to the named receiver. This may be a notification
+or a request.
+
 ### edit
 `edit {"method": "insert", "params": {"chars": "A"}, "view_id":
 "view-id-4"}`
@@ -231,9 +244,8 @@ follow the existing pattern.
 `theme_changed {"name": "InspiredGitHub", "theme": Theme}`
 
 Notifies the client that the theme has been changed. The client should
-use the new theme to set colors as appropriate.
-The `Theme` object is directly serialized from a 
-[`syntect::highlighting::ThemeSettings`](https://github.com/trishume/syntect/blob/master/src/highlighting/theme.rs#L27) 
+use the new theme to set colors as appropriate. The `Theme` object is
+directly serialized from a [`syntect::highlighting::ThemeSettings`](https://github.com/trishume/syntect/blob/master/src/highlighting/theme.rs#L27)
 instance.
 
 ### plugins

--- a/doc/frontend.md
+++ b/doc/frontend.md
@@ -86,12 +86,6 @@ Dispatches the inner method to the plugin manager.
 
 ### Plugin methods
 
-#### initial_plugins
-
-`initial_plugins {"view_id": "view-id-1"}` -> `[plugin_name]`
-
-Returns an initial list of plugins available for this view.
-
 #### start
 
 `start {"view_id": "view-id-1", "plugin_name": "syntect"}`
@@ -241,6 +235,71 @@ use the new theme to set colors as appropriate.
 The `Theme` object is directly serialized from a 
 [`syntect::highlighting::ThemeSettings`](https://github.com/trishume/syntect/blob/master/src/highlighting/theme.rs#L27) 
 instance.
+
+### plugins
+
+#### available_plugins
+
+`available_plugins {"view_id": "view-id-1", "plugins": [{"name": "syntect",
+"running": true]}`
+
+Notifies the client of the plugins available to the given view.
+
+#### plugin_started
+
+`plugin_started {"view_id": "view-id-1", "plugin": "syntect"}`
+
+Notifies the client that the named plugin is running.
+
+#### plugin_stopped
+
+`plugin_stopped {"view_id": "view-id-1", "plugin": "syntect", "code" 101}`
+
+Notifies the client that the named plugin has stopped. The `code` field is an
+integer exit code; currently 0 indicates a user-initiated exit and 1 indicates
+an abnormal exit, i.e. a plugin crash.
+
+#### update_cmds
+
+`update_cmds {"view_id": "view-id-1", "plugin", "syntect", "cmds": [Command]}`
+
+Notifies the client of a change in the available commands for a given plugin.
+The `cmds` field is a list of all commands currently available to this plugin.
+Clients should store commands on a per-plugin basis; when the `cmds` argument is
+an empty list it means that this plugin is providing no commands; any previously
+available commands should be disabled.
+
+The format for describing a `Command` is in flux. The best place to look for
+a working example is in the tests in core-lib/src/plugins/manifest.rs. As of
+this writing, the following is valid json for a `Command` object:
+
+```json
+    {
+    "title": "Test Command",
+    "description": "Passes the current test",
+    "rpc_cmd": {
+        "type": "notification",
+        "method": "test.cmd",
+        "params": {
+            "this_works": "some value",
+            "a_choice": "some value"
+        }
+    },
+    "args": [
+        {"title": "This Works", "description": "Indicates something", "key": "this_works", "arg_type": "Bool"},
+        {
+            "title": "Favourite Number",
+            "description": "A number used in a test.",
+            "key": "a_choice",
+            "arg_type": "Choice",
+            "options": [
+                {"title": "Five", "value": 5},
+                {"title": "Ten", "value": 10}
+            ]
+        }
+    ]
+    }
+```
 
 ### RPCs from front-end to back-end
 

--- a/python/xi_plugin/host.py
+++ b/python/xi_plugin/host.py
@@ -64,7 +64,6 @@ class PluginHost(object):
 
         else:
             assert len(buffer_info) == 1
-            print(buffer_info, file=sys.stderr)
             first_view = buffer_info[0]["views"][0]
             self.plugin.initialize(self.views[first_view])
 
@@ -101,6 +100,17 @@ class PluginHost(object):
     def shutdown(self, peer, **params):
         peer.done = True
         self.plugin.shutdown()
+
+    def other_cmd(self, peer, method, params):
+        '''Unknown RPC, presumably a custom command provided by the plugin.'''
+        view_id = params.pop("view_id")
+        if view_id:
+            view = self.views.get(view_id)
+            if view is None:
+                print("plugin {} missing view for id {}",
+                      self.plugin.identifier, view_id)
+            params["view"] = view
+        return getattr(self.plugin, method)(**params)
 
     def _initialize_buffers(self, peer, buffer_info):
         for buf in buffer_info:

--- a/python/xi_plugin/host.py
+++ b/python/xi_plugin/host.py
@@ -101,15 +101,11 @@ class PluginHost(object):
         peer.done = True
         self.plugin.shutdown()
 
-    def other_cmd(self, peer, method, params):
-        '''Unknown RPC, presumably a custom command provided by the plugin.'''
-        view_id = params.pop("view_id")
-        if view_id:
-            view = self.views.get(view_id)
-            if view is None:
-                print("plugin {} missing view for id {}",
-                      self.plugin.identifier, view_id)
-            params["view"] = view
+    def custom_command(self, peer, method, params):
+        '''Custom command provided by the plugin.'''
+        if params.get('view'):
+            view = self.views.get(params['view'])
+            params['view'] = view
         return getattr(self.plugin, method)(**params)
 
     def _initialize_buffers(self, peer, buffer_info):

--- a/python/xi_plugin/rpc.py
+++ b/python/xi_plugin/rpc.py
@@ -75,10 +75,12 @@ class RpcPeer(object):
         method = data['method']
         params = data['params'] or {}
         f = getattr(self.handler, method, None)
-        if f is not None:
-            result = f(self, **params)
-        else:
-            result = self.handler.other_cmd(self, method, params)
+        if f is None:
+            print("python plugin handler has no method for {}".format(method),
+                  file=sys.stderr)
+            return
+
+        result = f(self, **params)
 
         if result is not None:
             if req_id is None:

--- a/python/xi_plugin/rpc.py
+++ b/python/xi_plugin/rpc.py
@@ -74,7 +74,11 @@ class RpcPeer(object):
         req_id = data.get('id', None)
         method = data['method']
         params = data['params'] or {}
-        result = getattr(self.handler, method)(self, **params)
+        f = getattr(self.handler, method, None)
+        if f is not None:
+            result = f(self, **params)
+        else:
+            result = self.handler.other_cmd(self, method, params)
 
         if result is not None:
             if req_id is None:

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -34,7 +34,8 @@ use selection::{Affinity, Selection, SelRegion};
 use tabs::{BufferIdentifier, ViewIdentifier, DocumentCtx};
 use rpc::{EditCommand, GestureType};
 use syntax::SyntaxDefinition;
-use plugins::rpc_types::{PluginUpdate, PluginEdit, ScopeSpan, PluginBufferInfo};
+use plugins::rpc_types::{PluginUpdate, PluginEdit, ScopeSpan, PluginBufferInfo,
+ClientPluginInfo};
 use plugins::{PluginPid, Command};
 use layers::Scopes;
 
@@ -1073,6 +1074,12 @@ impl<W: Write + Send + 'static> Editor<W> {
     // should have its own reference.
     pub fn plugin_alert(&self, msg: &str) {
         self.doc_ctx.alert(msg);
+    }
+
+    /// Notifies the client of the currently available plugins.
+    pub fn available_plugins(&self, view_id: &ViewIdentifier,
+                             plugins: &[ClientPluginInfo]) {
+        self.doc_ctx.available_plugins(view_id, plugins);
     }
 
     /// Notifies the client that the named plugin has started.

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -35,7 +35,7 @@ use tabs::{BufferIdentifier, ViewIdentifier, DocumentCtx};
 use rpc::{EditCommand, GestureType};
 use syntax::SyntaxDefinition;
 use plugins::rpc_types::{PluginUpdate, PluginEdit, ScopeSpan, PluginBufferInfo};
-use plugins::PluginPid;
+use plugins::{PluginPid, Command};
 use layers::Scopes;
 
 
@@ -1081,10 +1081,12 @@ impl<W: Write + Send + 'static> Editor<W> {
     /// for a particular view; plugins are active at the editor/buffer level.
     /// Some `view_id` is needed, however, to route to the correct client view.
     //TODO: revisit this after implementing multiview
-    pub fn plugin_started<'a, T>(&'a self, view_id: T, plugin: &str)
+    pub fn plugin_started<'a, T>(&'a self, view_id: T, plugin: &str,
+                                 cmds: &[Command])
         where T: Into<Option<&'a ViewIdentifier>> {
         let view_id = view_id.into().unwrap_or(&self.view.view_id);
         self.doc_ctx.plugin_started(view_id, plugin);
+        self.doc_ctx.update_cmds(view_id, plugin, cmds);
     }
 
     /// Notifies client that the named plugin has stopped.
@@ -1100,6 +1102,7 @@ impl<W: Write + Send + 'static> Editor<W> {
         }
         let view_id = view_id.into().unwrap_or(&self.view.view_id);
         self.doc_ctx.plugin_stopped(view_id, plugin, code);
+        self.doc_ctx.update_cmds(view_id, plugin, &Vec::new());
     }
 }
 

--- a/rust/core-lib/src/plugins/manager.rs
+++ b/rust/core-lib/src/plugins/manager.rs
@@ -396,9 +396,7 @@ impl <W: Write>WeakPluginManagerRef<W> {
     /// Returns `None` if the inner value has been deallocated.
     pub fn upgrade(&self) -> Option<PluginManagerRef<W>> {
         match self.0.upgrade() {
-            Some(inner) => {
-                Some(PluginManagerRef(inner))
-            }
+            Some(inner) => Some(PluginManagerRef(inner)),
             None => None
         }
     }
@@ -406,17 +404,16 @@ impl <W: Write>WeakPluginManagerRef<W> {
 
 impl<W: Write + Send + 'static> PluginManagerRef<W> {
     pub fn new(buffers: BufferContainerRef<W>) -> Self {
-        PluginManagerRef(
-            Arc::new(Mutex::new(
-                PluginManager {
-                    // TODO: actually parse these from manifest files
-                    catalog: PluginCatalog::debug(),
-                    buffer_plugins: BTreeMap::new(),
-                    global_plugins: PluginGroup::new(),
-                    buffers: buffers,
-                    next_id: 0,
-                })),
-        )
+        PluginManagerRef(Arc::new(Mutex::new(
+            PluginManager {
+                // TODO: actually parse these from manifest files
+                catalog: PluginCatalog::debug(),
+                buffer_plugins: BTreeMap::new(),
+                global_plugins: PluginGroup::new(),
+                buffers: buffers,
+                next_id: 0,
+            }
+        )))
     }
 
     pub fn lock(&self) -> MutexGuard<PluginManager<W>> {
@@ -425,9 +422,7 @@ impl<W: Write + Send + 'static> PluginManagerRef<W> {
 
     /// Creates a new `WeakPluginManagerRef<W>`.
     pub fn to_weak(&self) -> WeakPluginManagerRef<W> {
-        WeakPluginManagerRef(
-            Arc::downgrade(&self.0),
-        )
+        WeakPluginManagerRef(Arc::downgrade(&self.0))
     }
 
 

--- a/rust/core-lib/src/plugins/manifest.rs
+++ b/rust/core-lib/src/plugins/manifest.rs
@@ -52,10 +52,6 @@ pub fn debug_plugins() -> Vec<PluginDescription> {
         Vec::new(), Vec::new()),
         PluginDescription::new("shouty", "0.0", BufferLocal, make_path("shouty.py"),
         Vec::new(), Vec::new()),
-        PluginDescription::new("cmd_test", "0.0", BufferLocal, make_path("cmd_test.py"),
-        Vec::new(), vec![Command::new(
-            "Count Lines", "Print the number of lines in the active buffer",
-            PlaceholderRpc::new("cmd_test.count_lines", None), None)]),
     ].iter()
         .filter(|desc|{
             if !desc.exec_path.exists() {
@@ -116,19 +112,26 @@ pub enum PluginScope {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// Represents a custom command provided by a plugin.
 pub struct Command {
+    /// Human readable title, for display in (for example) a menu.
     pub title: String,
+    /// A short description of the command.
     pub description: String,
+    /// Template of the command RPC as it should be sent to the plugin.
     pub rpc_cmd: PlaceholderRpc,
+    /// A list of `CommandArgument`s, which the client should use to build the RPC.
     pub args: Vec<CommandArgument>,
 }
 
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// A user provided argument to a plugin command.
 pub struct CommandArgument {
     pub tag: String,
     pub arg_type: ArgumentType,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// If `arg_type` is `Choice`, `options` must contain a list of options.
     pub options: Option<Vec<ArgumentOption>>,
 }
 
@@ -138,12 +141,14 @@ pub enum ArgumentType {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// Represents a user-selectable an option for a user-selectable argument.
 pub struct ArgumentOption {
     pub title: String,
     pub value: Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// A placeholder type which can represent a generic RPC.
 pub struct PlaceholderRpc {
     pub method: String,
     pub params: Value,

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -135,6 +135,10 @@ impl<W: Write + Send + 'static> PluginRef<W> {
         }
     }
 
+    pub fn command(&self, method: &str, params: &Value) {
+        self.0.lock().unwrap().peer.send_rpc_notification(method, params);
+    }
+
     /// Termination message sent to the plugin.
     ///
     /// The plugin is expected to clean up and close the pipe.

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -149,10 +149,6 @@ impl<W: Write + Send + 'static> PluginRef<W> {
         }
     }
 
-    pub fn command(&self, method: &str, params: &Value) {
-        self.0.lock().unwrap().peer.send_rpc_notification(method, params);
-    }
-
     /// Termination message sent to the plugin.
     ///
     /// The plugin is expected to clean up and close the pipe.

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -22,7 +22,7 @@ mod catalog;
 use std::sync::{Arc, Mutex, mpsc};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
-use std::process::{ChildStdin, Child, Command, Stdio};
+use std::process::{ChildStdin, Child, Command as ProcCommand, Stdio};
 use std::io::{self, BufReader, Write};
 
 use serde_json::{self, Value};
@@ -31,10 +31,9 @@ use xi_rpc::{self, RpcPeer, RpcCtx, RpcLoop, Handler};
 use tabs::ViewIdentifier;
 
 pub use self::manager::{PluginManagerRef, WeakPluginManagerRef};
-pub use self::manifest::PlaceholderRpc;
+pub use self::manifest::{PluginDescription, Command, PlaceholderRpc};
 
 use self::rpc_types::{PluginUpdate, PluginCommand, PluginBufferInfo};
-use self::manifest::PluginDescription;
 use self::manager::PluginName;
 use self::catalog::PluginCatalog;
 
@@ -237,7 +236,7 @@ pub fn start_plugin_process<W, C>(manager_ref: &PluginManagerRef<W>,
 
     thread::spawn(move || {
         print_err!("starting plugin at path {:?}", &plugin_desc.exec_path);
-        let child = Command::new(&plugin_desc.exec_path)
+        let child = ProcCommand::new(&plugin_desc.exec_path)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .spawn();

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -114,20 +114,6 @@ impl<W: Write + Send + 'static> PluginRef<W> {
         self.0.lock().unwrap().peer.send_rpc_notification(method, params);
     }
 
-    /// Send an arbitrary RPC request to the plugin.
-    pub fn rpc_request(&self, method: &str, params: &Value) -> Value {
-        //TODO: the core RPC handler isn't set up to send RPC errors,
-        //so this will be sent as a 'result'; when we add error support
-        //this function will return a Result<Value>.
-        self.0.lock().unwrap().peer.send_rpc_request(method, params)
-            .unwrap_or_else(|err| {
-                json!({"error": {
-                    "code": 520,
-                    "message": format!("{:?}", err)
-                }})
-            })
-    }
-
     /// Initialize the plugin.
     pub fn initialize(&self, init: &[PluginBufferInfo]) {
         self.0.lock().unwrap().peer

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -135,7 +135,6 @@ pub enum EditCommand<'a> {
 #[serde(tag = "command")]
 #[serde(rename_all = "snake_case")]
 pub enum PluginCommand {
-    InitialPlugins { view_id: ViewIdentifier },
     Start { view_id: ViewIdentifier, plugin_name: String },
     Stop { view_id: ViewIdentifier, plugin_name: String },
     PluginRpc { view_id: ViewIdentifier, receiver: String, rpc: PlaceholderRpc },

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -41,7 +41,7 @@ pub enum Request<'a> {
 }
 
 /// An enum representing a core command, parsed from JSON.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq)]
 pub enum CoreCommand<'a> {
     Edit { view_id: ViewIdentifier, edit_command: EditCommand<'a> },
     /// A command from the client to a plugin.
@@ -130,15 +130,14 @@ pub enum EditCommand<'a> {
 
 
 //TODO: just prototyping, these should be borrows
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(tag = "command")]
+#[serde(rename_all = "snake_case")]
 pub enum PluginCommand {
-    #[serde(rename = "initial_plugins")]
     InitialPlugins { view_id: ViewIdentifier },
-    #[serde(rename = "start")]
     Start { view_id: ViewIdentifier, plugin_name: String },
-    #[serde(rename = "stop")]
     Stop { view_id: ViewIdentifier, plugin_name: String },
+    Other { view_id: ViewIdentifier, receiver: String, method: String, params: Value },
 }
 
 impl<'a> CoreCommand<'a> {

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -19,6 +19,7 @@ use std::fmt;
 use serde_json::{self, Value};
 use xi_rpc::{dict_get_u64, dict_get_string, dict_get_bool, arr_get_u64, arr_get_i64};
 use tabs::ViewIdentifier;
+use plugins::PlaceholderRpc;
 
 // =============================================================================
 //  Request handling
@@ -137,7 +138,7 @@ pub enum PluginCommand {
     InitialPlugins { view_id: ViewIdentifier },
     Start { view_id: ViewIdentifier, plugin_name: String },
     Stop { view_id: ViewIdentifier, plugin_name: String },
-    Other { view_id: ViewIdentifier, receiver: String, method: String, params: Value },
+    PluginRpc { view_id: ViewIdentifier, receiver: String, rpc: PlaceholderRpc },
 }
 
 impl<'a> CoreCommand<'a> {

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -491,6 +491,11 @@ impl<W: Write + Send + 'static> Documents<W> {
                 self.plugins.stop_plugin(&view_id, &plugin_name);
                 None
             }
+            Other { view_id, receiver, method, params } => {
+                //TODO: this only currently works with notifications.
+                self.plugins.dispatch_command(&view_id, &receiver, &method, &params);
+                None
+            }
         }
     }
 

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -30,7 +30,7 @@ use styles::{Style, ThemeStyleMap};
 use MainPeer;
 
 use syntax::SyntaxDefinition;
-use plugins::{self, PluginManagerRef};
+use plugins::{self, PluginManagerRef, Command};
 use plugins::rpc_types::PluginUpdate;
 use plugins::PlaceholderRpc;
 
@@ -601,6 +601,16 @@ impl<W: Write> DocumentCtx<W> {
                                                 "view_id": view_id,
                                                 "plugin": plugin,
                                                 "code": code,
+                                            }));
+    }
+
+    pub fn update_cmds(&self, view_id: &ViewIdentifier,
+                       plugin: &str, cmds: &[Command]) {
+        self.rpc_peer.send_rpc_notification("update_cmds",
+                                            &json!({
+                                                "view_id": view_id,
+                                                "plugin": plugin,
+                                                "cmds": cmds,
                                             }));
     }
 


### PR DESCRIPTION
With this PR, plugins can declare custom commands.

This isn't super useful right now because plugins can't do a whole lot in _response_ to commands, but that will be up next.

There's an accompanying xi-mac PR coming (https://github.com/google/xi-mac/pull/55).

progress towards #253 