### PR TITLE
Async plugin edits

### DIFF
--- a/python/xi_plugin/host.py
+++ b/python/xi_plugin/host.py
@@ -27,6 +27,9 @@ MAX_FETCH_SIZE = 1024*1024
 class PluginPeer(RpcPeer):
     """A proxy object which wraps RPC methods implemented in xi-core."""
 
+    def edit(self, view_id, edit):
+        self.send_rpc('edit', {'view_id': view_id, 'edit': edit.to_dict()})
+
     def update_spans(self, view_id, start, length, spans, rev):
         self.send_rpc('update_spans', {'view_id': view_id,
                                        'start': start,

--- a/python/xi_plugin/view.py
+++ b/python/xi_plugin/view.py
@@ -32,3 +32,6 @@ class View(object):
 
     def add_scopes(self, *args, **kwargs):
         self.lines.peer.add_scopes(self.view_id, *args, **kwargs)
+
+    def edit(self, *args, **kwargs):
+        self.lines.peer.edit(self.view_id, *args, **kwargs)

--- a/rust/core-lib/src/plugins/rpc_types.rs
+++ b/rust/core-lib/src/plugins/rpc_types.rs
@@ -81,7 +81,7 @@ pub enum UpdateResponse {
 
 
 /// An simple edit, received from a plugin.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PluginEdit {
     pub start: u64,
     pub end: u64,
@@ -110,6 +110,7 @@ pub enum PluginCommand {
     AddScopes { view_id: ViewIdentifier, scopes: Vec<Vec<String>> },
     UpdateSpans { view_id: ViewIdentifier, start: usize, len: usize, spans: Vec<ScopeSpan>, rev: u64 },
     GetData { view_id: ViewIdentifier, offset: usize, max_size: usize, rev: u64 },
+    Edit { view_id: ViewIdentifier, edit: PluginEdit },
     Alert { view_id: ViewIdentifier, msg: String },
     LineCount { view_id: ViewIdentifier },
 }


### PR DESCRIPTION
This patch gives plugins the ability to initiate edit events; previously plugin edits could only occur in response to buffer updates.

This (in combination with #366) will make useful command-based plugins (code formatting tools, removing trailing whitespace) possible.