### PR TITLE
Add get_selections plugin RPC

### DIFF
--- a/python/xi_plugin/host.py
+++ b/python/xi_plugin/host.py
@@ -43,6 +43,9 @@ class PluginPeer(RpcPeer):
                                                'max_size': max_size,
                                                'rev': rev})
 
+    def get_selections(self, view_id):
+        return self.send_rpc_sync('get_selections', {'view_id': view_id})
+
 
 class PluginHost(object):
     """Handles raw RPC calls, updating state and calling plugin methods

--- a/python/xi_plugin/view.py
+++ b/python/xi_plugin/view.py
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+from collections import namedtuple
+
+
+Selection = namedtuple('Selection', ['start', 'end', 'is_caret'])
+
 
 class View(object):
     """Represents a view into a buffer."""
@@ -26,6 +32,11 @@ class View(object):
     @property
     def syntax(self):
         return self.lines.syntax
+
+    def get_selections(self):
+        selections = self.lines.peer.get_selections(self.view_id)
+        selections = selections['selections']
+        return [Selection(s, e, (s == e)) for (s, e) in selections]
 
     def update_spans(self, *args, **kwargs):
         self.lines.peer.update_spans(self.view_id, *args, **kwargs)

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -1058,6 +1058,17 @@ impl<W: Write + Send + 'static> Editor<W> {
         Some(text.slice_to_string(offset, end_off))
     }
 
+    pub fn plugin_get_selections(&self, view_id: &ViewIdentifier) -> Value {
+        //TODO: multiview support
+        assert_eq!(view_id, &self.view.view_id);
+        let sels: Vec<(usize, usize)> = self.view.sel_regions()
+            .iter()
+            .map(|s| { (s.start, s.end) })
+            .collect();
+
+        json!({"selections": sels})
+    }
+
     // Note: currently we route up through Editor to DocumentCtx, but perhaps the plugin
     // should have its own reference.
     pub fn plugin_alert(&self, msg: &str) {

--- a/rust/core-lib/src/plugins/manager.rs
+++ b/rust/core-lib/src/plugins/manager.rs
@@ -72,6 +72,7 @@ impl <W: Write + Send + 'static>PluginManager<W> {
     pub fn handle_plugin_cmd(&self, cmd: PluginCommand, plugin_id: PluginPid) -> Option<Value> {
         use self::PluginCommand::*;
         match cmd {
+            //TODO: these should not be unwraps
             LineCount { view_id } => {
                 let n_lines = self.buffers.lock().editor_for_view(&view_id).unwrap()
                     .plugin_n_lines() as u64;
@@ -91,6 +92,10 @@ impl <W: Write + Send + 'static>PluginManager<W> {
                 self.buffers.lock().editor_for_view(&view_id).unwrap()
                 .plugin_get_data(offset, max_size, rev)
                 .map(|data| Value::String(data))
+            }
+            GetSelections { view_id } => {
+                Some(self.buffers.lock().editor_for_view(&view_id).unwrap()
+                     .plugin_get_selections(&view_id))
             }
             Alert { view_id, msg } => {
                 self.buffers.lock().editor_for_view(&view_id).unwrap()

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -90,10 +90,16 @@ impl<W: Write + Send + 'static> PluginRef<W> {
         };
 
         if let Some(plugin_manager) = plugin_manager {
-            let cmd = serde_json::from_value::<PluginCommand>(params.to_owned());
+            //FIXME: @cmyr: because rpcs arrive with the method already extracted,
+            //we can't currently rely on serde to deserialize. As a temporary
+            //solution we create a new json blob that conforms with serde's
+            //'Externally tagged' enum representation. This will be fixed by
+            //an upcoming PR introducing a typed RPC system.
+            let temp = json!({method: params});
+            let cmd = serde_json::from_value::<PluginCommand>(temp);
             if cmd.is_err() {
-                print_err!("failed to parse plugin rpc {}, params {:?}",
-                           method, params);
+                print_err!("failed to parse plugin rpc {:?}",
+                           &json!({method: params}));
                 return None
             }
             let pid = self.get_identifier();

--- a/rust/core-lib/src/plugins/rpc_types.rs
+++ b/rust/core-lib/src/plugins/rpc_types.rs
@@ -104,7 +104,7 @@ pub struct ScopeSpan {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
+#[serde(rename_all = "snake_case")]
 /// RPC commands sent from plugins.
 pub enum PluginCommand {
     AddScopes { view_id: ViewIdentifier, scopes: Vec<Vec<String>> },
@@ -112,6 +112,7 @@ pub enum PluginCommand {
     GetData { view_id: ViewIdentifier, offset: usize, max_size: usize, rev: u64 },
     Alert { view_id: ViewIdentifier, msg: String },
     LineCount { view_id: ViewIdentifier },
+    GetSelections { view_id: ViewIdentifier },
 }
 
 impl PluginBufferInfo {


### PR DESCRIPTION
Another small additional plugin capability: plugins can now query a view for the current selections. In conjunction with #367, this means that plugins can modify selected regions of a buffer.