### PR TITLE
Fix build break, removal of W trait was incomplete

### DIFF
--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -538,7 +538,7 @@ impl Documents {
         }
     }
 
-    fn do_client_init(&self, rpc_peer: &MainPeer<W>) {
+    fn do_client_init(&self, rpc_peer: &MainPeer) {
         let params = {
             let style_map = self.style_map.lock().unwrap();
             json!({


### PR DESCRIPTION
Looks like one of the remaining <W> parameters didn't get removed
from #387. This should fix the build.