### PR TITLE
Typed RPC handling

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -370,6 +370,7 @@ version = "0.2.0"
 dependencies = [
  "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -91,7 +91,7 @@ extern crate xi_rope;
 extern crate xi_unicode;
 extern crate xi_rpc;
 
-use xi_rpc::{RpcPeer, RpcCtx, Handler};
+use xi_rpc::{RpcPeer, RpcCtx, RpcCall, MethodHandler};
 
 pub type MainPeer = RpcPeer;
 
@@ -112,27 +112,29 @@ impl MainState {
     }
 }
 
-impl Handler for MainState {
-    fn handle_notification(&mut self, mut ctx: RpcCtx, method: &str, params: &Value) {
-        match Request::from_json(method, params) {
+impl MethodHandler for MainState {
+    type Notification = RpcCall;
+    type Request = RpcCall;
+    fn handle_notification(&mut self, mut ctx: RpcCtx, rpc: Self::Notification) {
+        match Request::from_json(&rpc.method, &rpc.params) {
             Ok(req) => {
                 if let Some(_) = self.handle_req(req, &mut ctx) {
-                    print_err!("Unexpected return value for notification {}", method)
+                    print_err!("Unexpected return value for notification {}", &rpc.method)
                 }
             }
-            Err(e) => print_err!("Error {} decoding RPC request {}", e, method)
+            Err(e) => print_err!("Error {} decoding RPC request {}", e, &rpc.method)
         }
     }
 
-    fn handle_request(&mut self, mut ctx: RpcCtx, method: &str, params: &Value) ->
+    fn handle_request(&mut self, mut ctx: RpcCtx, rpc: Self::Request) ->
         Result<Value, Value> {
-        match Request::from_json(method, params) {
+        match Request::from_json(&rpc.method, &rpc.params) {
             Ok(req) => {
                 let result = self.handle_req(req, &mut ctx);
                 result.ok_or_else(|| json!("return value missing"))
             }
             Err(e) => {
-                print_err!("Error {} decoding RPC request {}", e, method);
+                print_err!("Error {} decoding RPC request {}", e, &rpc.method);
                 Err(json!("error decoding request"))
             }
         }

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -91,7 +91,7 @@ extern crate xi_rope;
 extern crate xi_unicode;
 extern crate xi_rpc;
 
-use xi_rpc::{RpcPeer, RpcCtx, RpcCall, MethodHandler};
+use xi_rpc::{RpcPeer, RpcCtx, RpcCall, Handler, RemoteError};
 
 pub type MainPeer = RpcPeer;
 
@@ -112,7 +112,7 @@ impl MainState {
     }
 }
 
-impl MethodHandler for MainState {
+impl Handler for MainState {
     type Notification = RpcCall;
     type Request = RpcCall;
     fn handle_notification(&mut self, mut ctx: RpcCtx, rpc: Self::Notification) {
@@ -127,15 +127,15 @@ impl MethodHandler for MainState {
     }
 
     fn handle_request(&mut self, mut ctx: RpcCtx, rpc: Self::Request) ->
-        Result<Value, Value> {
+       Result<Value, RemoteError> {
         match Request::from_json(&rpc.method, &rpc.params) {
             Ok(req) => {
                 let result = self.handle_req(req, &mut ctx);
-                result.ok_or_else(|| json!("return value missing"))
+                Ok(result.expect("missing return value"))
             }
             Err(e) => {
                 print_err!("Error {} decoding RPC request {}", e, &rpc.method);
-                Err(json!("error decoding request"))
+                Err(RemoteError::Parse(Some(json!(e.to_string()))))
             }
         }
     }

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -135,7 +135,7 @@ impl Handler for MainState {
             }
             Err(e) => {
                 print_err!("Error {} decoding RPC request {}", e, &rpc.method);
-                Err(RemoteError::Parse(Some(json!(e.to_string()))))
+                Err(RemoteError::InvalidRequest(Some(json!(e.to_string()))))
             }
         }
     }

--- a/rust/core-lib/src/plugins/manager.rs
+++ b/rust/core-lib/src/plugins/manager.rs
@@ -94,7 +94,7 @@ impl PluginManager {
     }
 
     /// Handle a request from a plugin.
-    pub fn handle_plugin_request(&self, cmd: PluginRequest, plugin_id: PluginPid) -> Value {
+    pub fn handle_plugin_request(&self, cmd: PluginRequest, _: PluginPid) -> Value {
         use self::PluginRequest::*;
         match cmd {
             //TODO: these should not be unwraps

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -27,13 +27,15 @@ use std::io::{self, BufReader};
 
 use serde_json::{self, Value};
 
-use xi_rpc::{self, RpcPeer, RpcCtx, RpcLoop, Handler};
+use xi_rpc::{self, RpcPeer, RpcCtx, RpcLoop, MethodHandler};
 use tabs::ViewIdentifier;
 
 pub use self::manager::{PluginManagerRef, WeakPluginManagerRef};
 pub use self::manifest::{PluginDescription, Command, PlaceholderRpc};
 
-use self::rpc_types::{PluginUpdate, PluginCommand, PluginBufferInfo};
+use self::rpc_types::{PluginUpdate, PluginNotification, PluginRequest,
+PluginBufferInfo};
+
 use self::manager::PluginName;
 use self::catalog::PluginCatalog;
 
@@ -69,46 +71,35 @@ impl Clone for PluginRef {
     }
 }
 
-impl Handler for PluginRef {
-    fn handle_notification(&mut self, _ctx: RpcCtx, method: &str, params: &Value) {
-        if let Some(_) = self.rpc_handler(method, params) {
-            print_err!("Unexpected return value for notification {}", method)
-        }
-    }
-
-    fn handle_request(&mut self, _ctx: RpcCtx, method: &str, params: &Value) ->
-        Result<Value, Value> {
-        let result = self.rpc_handler(method, params);
-        result.ok_or_else(|| Value::String("missing return value".to_string()))
-    }
-}
-
-impl PluginRef {
-    fn rpc_handler(&self, method: &str, params: &Value) -> Option<Value> {
+impl MethodHandler for PluginRef {
+    type Notification = PluginNotification;
+    type Request = PluginRequest;
+    fn handle_notification(&mut self, _ctx: RpcCtx, rpc: Self::Notification) {
         let plugin_manager = {
             self.0.lock().unwrap().manager.upgrade()
         };
-
         if let Some(plugin_manager) = plugin_manager {
-            //FIXME: @cmyr: because rpcs arrive with the method already extracted,
-            //we can't currently rely on serde to deserialize. As a temporary
-            //solution we create a new json blob that conforms with serde's
-            //'Externally tagged' enum representation. This will be fixed by
-            //an upcoming PR introducing a typed RPC system.
-            let temp = json!({method: params});
-            let cmd = serde_json::from_value::<PluginCommand>(temp);
-            if cmd.is_err() {
-                print_err!("failed to parse plugin rpc {:?}",
-                           &json!({method: params}));
-                return None
-            }
             let pid = self.get_identifier();
-            plugin_manager.lock().handle_plugin_cmd(cmd.unwrap(), pid)
-        } else {
-            None
+            plugin_manager.lock().handle_plugin_notification(rpc, pid)
         }
     }
 
+    fn handle_request(&mut self, _ctx: RpcCtx, rpc: Self::Request) ->
+        Result<Value, Value> {
+        let plugin_manager = {
+            self.0.lock().unwrap().manager.upgrade()
+        };
+        if let Some(plugin_manager) = plugin_manager {
+            let pid = self.get_identifier();
+            Ok(plugin_manager.lock().handle_plugin_request(rpc, pid))
+        } else {
+            Err(json!({"code": 88, "description": "plugin manager missing"}))
+        }
+    }
+}
+
+
+impl PluginRef {
     /// Send an arbitrary RPC notification to the plugin.
     pub fn rpc_notification(&self, method: &str, params: &Value) {
         self.0.lock().unwrap().peer.send_rpc_notification(method, params);

--- a/rust/core-lib/src/plugins/rpc_types.rs
+++ b/rust/core-lib/src/plugins/rpc_types.rs
@@ -81,6 +81,7 @@ pub enum UpdateResponse {
 
 
 /// An simple edit, received from a plugin.
+//TODO: use a real delta here
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PluginEdit {
     pub start: u64,
@@ -105,15 +106,23 @@ pub struct ScopeSpan {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
-/// RPC commands sent from plugins.
-pub enum PluginCommand {
-    AddScopes { view_id: ViewIdentifier, scopes: Vec<Vec<String>> },
-    UpdateSpans { view_id: ViewIdentifier, start: usize, len: usize, spans: Vec<ScopeSpan>, rev: u64 },
+#[serde(tag = "method", content = "params")]
+/// RPC requests sent from plugins.
+pub enum PluginRequest {
     GetData { view_id: ViewIdentifier, offset: usize, max_size: usize, rev: u64 },
-    Edit { view_id: ViewIdentifier, edit: PluginEdit },
-    Alert { view_id: ViewIdentifier, msg: String },
     LineCount { view_id: ViewIdentifier },
     GetSelections { view_id: ViewIdentifier },
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
+#[serde(tag = "method", content = "params")]
+/// RPC commands sent from plugins.
+pub enum PluginNotification {
+    AddScopes { view_id: ViewIdentifier, scopes: Vec<Vec<String>> },
+    UpdateSpans { view_id: ViewIdentifier, start: usize, len: usize, spans: Vec<ScopeSpan>, rev: u64 },
+    Edit { view_id: ViewIdentifier, edit: PluginEdit },
+    Alert { view_id: ViewIdentifier, msg: String },
 }
 
 impl PluginBufferInfo {

--- a/rust/plugin-lib/src/plugin_base.rs
+++ b/rust/plugin-lib/src/plugin_base.rs
@@ -272,7 +272,7 @@ impl<'a, H: Handler> xi_rpc::Handler for MyHandler<'a, H> {
             }
             Err(err) => {
                 print_err!("Error {} decoding RPC request {}", err, &rpc.method);
-                Err(RemoteError::Parse(Some(Value::String(err.to_string()))))
+                Err(RemoteError::InvalidRequest(Some(Value::String(err.to_string()))))
             }
         }
     }

--- a/rust/plugin-lib/src/plugin_base.rs
+++ b/rust/plugin-lib/src/plugin_base.rs
@@ -21,7 +21,7 @@ use std::path::PathBuf;
 use serde_json::{self, Value};
 
 use xi_rpc;
-use xi_rpc::{RpcLoop, RpcCtx, dict_get_u64, dict_get_string};
+use xi_rpc::{RpcLoop, RpcCtx, RpcCall, dict_get_u64, dict_get_string};
 
 // TODO: avoid duplicating this in every crate
 macro_rules! print_err {
@@ -249,27 +249,29 @@ fn parse_plugin_request<'a>(method: &str, params: &'a Value) ->
 
 struct MyHandler<'a, H: 'a>(&'a mut H);
 
-impl<'a, H: Handler> xi_rpc::Handler for MyHandler<'a, H> {
-    fn handle_notification(&mut self, ctx: RpcCtx, method: &str, params: &Value) {
-        match parse_plugin_request(method, params) {
+impl<'a, H: Handler> xi_rpc::MethodHandler for MyHandler<'a, H> {
+    type Notification = RpcCall;
+    type Request = RpcCall;
+    fn handle_notification(&mut self, ctx: RpcCtx, rpc: Self::Notification) {
+        match parse_plugin_request(&rpc.method, &rpc.params) {
             Ok(req) => {
                 if let Some(_) = self.0.call(&req, PluginCtx(ctx)) {
-                    print_err!("Unexpected return value for notification {}", method)
+                    print_err!("Unexpected return value for notification {}", &rpc.method)
                 }
             }
             Err(err) => print_err!("error: {}", err)
         }
     }
 
-    fn handle_request(&mut self, ctx: RpcCtx, method: &str, params: &Value) ->
+    fn handle_request(&mut self, mut ctx: RpcCtx, rpc: Self::Request) ->
         Result<Value, Value> {
-        match parse_plugin_request(method, params) {
+        match parse_plugin_request(&rpc.method, &rpc.params) {
             Ok(req) => {
                 let result = self.0.call(&req, PluginCtx(ctx));
                 result.ok_or_else(|| Value::String("return value missing".to_string()))
             }
             Err(err) => {
-                print_err!("Error {} decoding RPC request {}", err, method);
+                print_err!("Error {} decoding RPC request {}", err, &rpc.method);
                 Err(Value::String("error decoding request".to_string()))
             }
         }

--- a/rust/rpc/Cargo.toml
+++ b/rust/rpc/Cargo.toml
@@ -9,4 +9,5 @@ description = "Utilities for building peers (both client and server side) for xi
 [dependencies]
 serde = "1.0"
 serde_json = "1.0"
+serde_derive = "1.0"
 crossbeam = "0.2.9"

--- a/rust/rpc/src/error.rs
+++ b/rust/rpc/src/error.rs
@@ -51,7 +51,7 @@ impl fmt::Display for ReadError {
             ReadError::Io(ref err) => write!(f, "I/O Error: {:?}", err),
             ReadError::Json(ref err) => write!(f, "JSON Error: {:?}", err),
             ReadError::NotObject => write!(f, "JSON message was not an object."),
-            ReadError::Disconnect => write!(f, "Peer closd the connection."),
+            ReadError::Disconnect => write!(f, "Peer closed the connection."),
         }
     }
 }
@@ -145,7 +145,11 @@ impl<'de> Deserialize<'de> for RemoteError
             -32600 => RemoteError::InvalidRequest(resp.data),
             -32601 => RemoteError::MethodNotFound(resp.data),
             -32602 => RemoteError::InvalidParams(resp.data),
-            _ => RemoteError::Custom { code: resp.code, message: resp.message, data: resp.data },
+            _ => RemoteError::Custom {
+                code: resp.code,
+                message: resp.message,
+                data: resp.data
+            },
         })
     }
 }
@@ -163,7 +167,7 @@ impl Serialize for RemoteError
              RemoteError::Custom { code, ref message, ref data } => {
                  (code, message.as_ref(), data)
              }
-             RemoteError::Unknown(_) => panic!("The 'Unknown' error variant is\
+             RemoteError::Unknown(_) => panic!("The 'Unknown' error variant is \
                                                not intended for client use."),
         };
         let message = message.to_owned();

--- a/rust/rpc/src/error.rs
+++ b/rust/rpc/src/error.rs
@@ -1,0 +1,125 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io;
+
+use serde_json::{Value, Error as JsonError};
+use serde::de::{self, Deserializer, Deserialize};
+use serde::ser::{Serializer, Serialize};
+
+/// Errors that can occur when sending an RPC.
+#[derive(Debug)]
+pub enum Error {
+    /// An IO error occurred on the underlying communication channel.
+    IoError(io::Error),
+    /// The peer returned an error.
+    RemoteError(RemoteError),
+    /// The peer closed its connection.
+    PeerDisconnect,
+    /// The peer sent a response containing the id, but was malformed according
+    /// to the json-rpc spec.
+    InvalidResponse,
+}
+
+/// Errors that can occur in the process of receiving an RPC.
+///
+/// These errors are based off the errors defined in the JSON-RPC spec,
+/// and are intended to go over the wire. Serialized, they are an
+/// object with three fields: 'code', 'message', and optionally 'data'.
+///
+/// The first four members represent message parsing errors.
+/// The last member represents application logic errors.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RemoteError {
+    /// The JSON was valid, but was not a correctly formed request.
+    InvalidRequest(Option<Value>),
+    /// The called method is not handled.
+    MethodNotFound(Option<Value>),
+    /// The params were not valid for the method.
+    InvalidParams(Option<Value>),
+    /// The message could not be parsed.
+    ///
+    /// This is a catch-all. Where possible, use a more specific error.
+    Parse(Option<Value>),
+    /// A custom error.
+    Custom { code: i64, message: String, data: Option<Value> },
+}
+
+impl RemoteError {
+    /// Creates a new custom error.
+    pub fn custom<S, V>(code: i64, message: S, data: V) -> Self
+        where S: AsRef<str>,
+              V: Into<Option<Value>>,
+    {
+        let message = message.as_ref().into();
+        let data = data.into();
+        RemoteError::Custom { code, message, data }
+    }
+}
+
+impl From<JsonError> for RemoteError {
+    fn from(err: JsonError) -> RemoteError {
+        RemoteError::Parse(Some(json!(err.to_string())))
+    }
+}
+
+impl From<RemoteError> for Error {
+    fn from(err: RemoteError) -> Error {
+        Error::RemoteError(err)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+struct ErrorHelper {
+    code: i64,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<Value>,
+}
+
+impl<'de> Deserialize<'de> for RemoteError
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>
+    {
+        let resp = ErrorHelper::deserialize(deserializer).map_err(de::Error::custom)?;
+        Ok(match resp.code {
+            -32700 => RemoteError::Parse(resp.data),
+            -32600 => RemoteError::InvalidRequest(resp.data),
+            -32601 => RemoteError::MethodNotFound(resp.data),
+            -32602 => RemoteError::InvalidParams(resp.data),
+            _ => RemoteError::Custom { code: resp.code, message: resp.message, data: resp.data },
+        })
+    }
+}
+
+impl Serialize for RemoteError
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        let (code, message, data) = match *self {
+             RemoteError::Parse(ref d) => (-32700, "Parse error", d),
+             RemoteError::InvalidRequest(ref d) => (-32600, "Invalid request", d),
+             RemoteError::MethodNotFound(ref d) => (-32601, "Method not found", d),
+             RemoteError::InvalidParams(ref d) => (-32602, "Invalid params", d),
+             RemoteError::Custom { code, ref message, ref data } => (code, message.as_ref(), data),
+        };
+        let message = message.to_owned();
+        let data = data.to_owned();
+        let err = ErrorHelper { code, message, data };
+        err.serialize(serializer)
+    }
+}
+

--- a/rust/rpc/src/lib.rs
+++ b/rust/rpc/src/lib.rs
@@ -31,29 +31,20 @@ extern crate crossbeam;
 
 #[macro_use]
 mod macros;
+mod parse;
+mod error;
 
 use std::collections::{BTreeMap, VecDeque};
-use std::io;
-use std::io::{BufRead, Write};
+use std::io::{self, BufRead, Write};
 use std::sync::{Arc, Mutex, Condvar};
 use std::sync::mpsc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use serde_json::{Value, Error as JsonError};
+use serde_json::Value;
 use serde::de::DeserializeOwned;
 
-#[derive(Debug)]
-pub enum Error {
-    /// An IO error occurred on the underlying communication channel.
-    IoError(io::Error),
-    /// The peer closed its connection.
-    PeerDisconnect,
-    /// The remote method returned an error.
-    RemoteError(Value),
-    /// The peer sent a response containing the id, but was malformed according
-    /// to the json-rpc spec.
-    MalformedResponse,
-}
+use parse::{ParseResult, Response};
+pub use error::{Error, RemoteError};
 
 /// An interface to access the other side of the RPC channel. The main purpose
 /// is to send RPC requests and notifications to the peer.
@@ -72,19 +63,20 @@ pub trait Peer: Send + 'static {
     /// For an explanation on this approach, see this thread:
     /// https://users.rust-lang.org/t/solved-is-it-possible-to-clone-a-boxed-trait-object/1714/6
     fn box_clone(&self) -> Box<Peer>;
-    /// Sends a notification (asynchronous rpc) to the peer.
+    /// Sends a notification (asynchronous RPC) to the peer.
     fn send_rpc_notification(&self, method: &str, params: &Value);
-    /// Sends a request asynchronously, and the supplied callback will be called when
-    /// the response arrives.
+    /// Sends a request asynchronously, and the supplied callback will
+    /// be called when the response arrives.
     ///
-    /// `Callback` is an alias for FnOnce(Result<Value, Error>); it must be boxed
-    /// because trait objects cannot use generic paramaters.
+    /// `Callback` is an alias for FnOnce(Result<Value, Error>); it must
+    /// be boxed because trait objects cannot use generic paramaters.
     fn send_rpc_request_async(&self, method: &str, params: &Value,
                                  f: Box<Callback>);
-    /// Sends a request (synchronous rpc) to the peer, and waits for the result.
+    /// Sends a request (synchronous RPC) to the peer, and waits for the result.
     fn send_rpc_request(&self, method: &str, params: &Value) -> Result<Value, Error>;
-    /// Determines whether an incoming request (or notification) is pending. This
-    /// is intended to reduce latency for bulk operations done in the background.
+    /// Determines whether an incoming request (or notification) is
+    /// pending. This is intended to reduce latency for bulk operations
+    /// done in the background.
     fn request_is_pending(&self) -> bool;
 }
 
@@ -97,7 +89,7 @@ pub struct RpcCtx<'a> {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-/// An Rpc command.
+/// An RPC command.
 ///
 /// This type is used as a placeholder in various places, and can be
 /// used by clients as a catchall type for implementing `MethodHandler`.
@@ -106,72 +98,20 @@ pub struct RpcCall {
     pub params: Value,
 }
 
-/// A trait for types which can handle Rpcs.
+/// A trait for types which can handle RPCs.
 ///
 /// Types which implement `MethodHandler` are also responsible for implementing
 /// `Parser`; `Parser` is provided when Self::Notification and Self::Request
 /// can be used with serde::DeserializeOwned.
-pub trait MethodHandler {
-    type Notification;
-    type Request;
+pub trait Handler {
+    type Notification: DeserializeOwned;
+    type Request: DeserializeOwned;
     fn handle_notification(&mut self, ctx: RpcCtx, rpc: Self::Notification);
     fn handle_request(&mut self, ctx: RpcCtx, rpc: Self::Request) ->
-        Result<Value, Value>;
+        Result<Value, RemoteError>;
     #[allow(unused_variables)]
     fn idle(&mut self, ctx: RpcCtx, token: usize) {}
 }
-
-/// A unique identifier attached to request Rpcs.
-pub type RequestId = Value;
-
-/// Represents a successfully parsed Rpc.
-pub enum ParseResult<N, R> {
-    /// An id and an Rpc Request
-    Request(RequestId, R),
-    /// An Rpc Notification
-    Notification(N),
-    /// An id was found, but the request was malformed.
-    /// The peer will receive an error response.
-    MalformedRequest(RequestId, JsonError),
-}
-
-/// Responsible for parsing a `Value` into a given Rpc type.
-///
-/// Note:
-///
-/// This trait exists so that Handler::Notification and Handler::Request
-/// don't have to be `Deserialize`. This may be overkill?
-///
-/// If we went that route, we could implement all the parsing in
-/// RpcLoop::parse_json (generic over N and R) and we could expand
-/// `ParseResult` to include Responses and the general error case.
-pub trait Parser: MethodHandler {
-    fn parse_json(&self, json: Value) -> Result<ParseResult<Self::Notification, Self::Request>, JsonError>;
-}
-
-pub trait Handler: MethodHandler + Parser {}
-
-impl<H: MethodHandler + Parser> Handler for H {}
-
-impl<N, R, H> Parser for H
-where N: DeserializeOwned,
-      R: DeserializeOwned,
-      H: MethodHandler<Notification = N, Request = R>,
-{
-    fn parse_json(&self, mut json: Value) -> Result<ParseResult<Self::Notification, Self::Request>, JsonError> {
-        let id = json.as_object_mut()
-            .and_then(|obj| obj.remove("id"));
-        if let Some(id) = id {
-            match serde_json::from_value::<R>(json) {
-                Ok(val) => Ok(ParseResult::Request(id, val)),
-                Err(err) => Ok(ParseResult::MalformedRequest(id, err)),
-            }
-        } else {
-            Ok(ParseResult::Notification(serde_json::from_value::<N>(json)?))
-        }
-    }
-}
-
 
 pub trait Callback: Send {
     fn call(self: Box<Self>, result: Result<Value, Error>);
@@ -210,7 +150,7 @@ impl ResponseHandler {
 }
 
 struct RpcState<W: Write> {
-    rx_queue: Mutex<VecDeque<Value>>,
+    rx_queue: Mutex<VecDeque<Result<String, ()>>>,
     rx_cvar: Condvar,
     writer: Mutex<W>,
     id: AtomicUsize,
@@ -245,30 +185,26 @@ impl<W: Write + Send> RpcLoop<W> {
         self.peer.clone()
     }
 
-    // Reads raw json from the input stream.
-    fn read_json<R: BufRead>(&mut self, reader: &mut R)
-            -> Option<serde_json::error::Result<Value>> {
+    /// Reads raw json from the input stream.
+    fn read_json<R: BufRead>(&mut self, reader: &mut R) -> Option<String> {
         self.buf.clear();
-        if reader.read_line(&mut self.buf).is_ok() {
-            if self.buf.is_empty() {
-                return None;
-            }
-            return Some(serde_json::from_str::<Value>(&self.buf));
+        let result = reader.read_line(&mut self.buf).is_ok();
+        match result {
+            true if !self.buf.is_empty() => Some(self.buf.clone()),
+            _ => None
         }
-        None
     }
 
-    /// Starts a main loop. The reader is supplied via a closure, as basically
-    /// a workaround so that the reader doesn't have to be `Send`. Internally, the
-    /// main loop starts a separate thread for I/O, and at startup that thread calls
-    /// the given closure.
+    /// Starts a main loop. The reader is supplied via a closure, as
+    /// basically a workaround so that the reader doesn't have to be
+    /// `Send`. Internally, the main loop starts a separate thread for
+    /// I/O, and at startup that thread calls the given closure.
     ///
-    /// Calls to the handler (the second closure) happen on the caller's thread, so
-    /// that closure need not be `Send`.
+    /// Calls to the handler happen on the caller's thread.
     ///
-    /// Calls to the handler are guaranteed to preserve the order as they appear on
-    /// on the channel. At the moment, there is no way for there to be more than one
-    /// incoming request to be outstanding.
+    /// Calls to the handler are guaranteed to preserve the order as
+    /// they appear on on the channel. At the moment, there is no way
+    /// for there to be more than one incoming request to be outstanding.
     ///
     /// This method returns when the input channel is closed.
     pub fn mainloop<'a, R, RF, H>(&mut self, rf: RF, handler: &mut H)
@@ -281,25 +217,15 @@ impl<W: Write + Send> RpcLoop<W> {
             let peer = self.get_raw_peer();
             scope.spawn(move|| {
                 let mut reader = rf();
-                while let Some(json_result) = self.read_json(&mut reader) {
-                    match json_result {
-                        Ok(json) => {
-                            let is_method = json.as_object().map_or(false, |dict|
-                                dict.contains_key("method"));
-                            if is_method {
-                                self.peer.put_rx(json);
-                            } else {
-                                self.peer.handle_response(json);
-                            }
-                        }
-                        Err(err) => print_err!("Error decoding json: {:?}", err)
-                    }
+                while let Some(json) = self.read_json(&mut reader) {
+                    self.peer.put_rx(Ok(json));
                 }
-                self.peer.put_rx(Value::Null);
-                // TODO: send disconnect error to all pending
+                self.peer.put_rx(Err(()));
             });
+
             let mut idle = VecDeque::<usize>::new();
             loop {
+                // only do idle work if no pending messages
                 let json = if !idle.is_empty() {
                     if let Some(json) = peer.try_get_rx() {
                         json
@@ -315,37 +241,44 @@ impl<W: Write + Send> RpcLoop<W> {
                 } else {
                     peer.get_rx()
                 };
-                if json == Value::Null {
-                    break;
-                }
-                //print_err!("to core: {:?}", json);
+
+                let json = match json {
+                    Ok(j) => j,
+                    Err(_) => break, // disconnect
+                };
                 let ctx = RpcCtx {
                     peer: Box::new(peer.clone()),
                     idle: &mut idle,
                 };
 
-                match handler.parse_json(json) {
-                    Ok(ParseResult::Request(id, req)) => {
-                        let result = handler.handle_request(ctx, req);
-                        peer.respond(result, &id);
+                use ParseResult::*;
+
+                let parsed: ParseResult<H::Notification, H::Request> = serde_json::from_str(&json)
+                    .expect("ParseResult should handle errors internally");
+
+                match parsed {
+                    Request(id, cmd) => {
+                        let result = handler.handle_request(ctx, cmd);
+                        peer.respond(result, Some(id));
                     }
-                    Ok(ParseResult::Notification(notif)) => {
-                        handler.handle_notification(ctx, notif);
+                    Notification(cmd) => handler.handle_notification(ctx, cmd),
+                    Response(id, resp) => {
+                        peer.handle_response(id, resp.map_err(Error::from));
                     }
-                    Ok(ParseResult::MalformedRequest(id, err)) => {
-                        // code / message borrowed from jsonrpc spec
-                        let response = json!({
-                            "code": -32600,
-                            "message": "Invalid Request",
-                            "data": {
-                                "error": format!("{:?}", err)
-                            }
-                        });
-                        peer.respond(Err(response), &id);
+                    InvalidRequest(id, msg) => {
+                        let response = RemoteError::InvalidRequest(
+                            Some(json!(msg)));
+                        peer.respond(Err(response), id);
                     }
-                    Err(err) => eprintln!("Error parsing json: {:?}", err),
+                    InvalidResponse(id) => {
+                        peer.handle_response(id, Err(Error::InvalidResponse))
+                    }
+                    OtherError(msg) => { 
+                        print_err!("error parsing json: {}\n{}", msg, &json)
+                    }
                 }
             }
+            peer.disconnect();
         });
     }
 }
@@ -397,15 +330,15 @@ impl<W:Write> RawPeer<W> {
     fn send(&self, v: &Value) -> Result<(), io::Error> {
         let mut s = serde_json::to_string(v).unwrap();
         s.push('\n');
-        //print_err!("from core: {}", s);
         self.0.writer.lock().unwrap().write_all(s.as_bytes())
         // Technically, maybe we should flush here, but doesn't seem to be required.
     }
 
-    fn respond(&self, result: Result<Value, Value>, id: &Value) {
+    fn respond(&self, result: Response, id: Option<u64>) {
+        let id = id.map(Value::from).unwrap_or(Value::Null);
         let mut response = json!({"id": id});
         match result {
-            Ok(result) => response["result"] = json!(result),
+            Ok(result) => response["result"] = result,
             Err(error) => response["error"] = json!(error),
         };
         if let Err(e) = self.send(&response) {
@@ -431,39 +364,26 @@ impl<W:Write> RawPeer<W> {
         }
     }
 
-    fn handle_response(&self, mut response: Value) {
-        let mut dict = response.as_object_mut().unwrap();
-        let id = dict.get("id").and_then(Value::as_u64);
-        if id.is_none() {
-            print_err!("id missing from response, or is not u64");
-            return;
-        }
-        let id = id.unwrap() as usize;
-        let result = dict.remove("result");
-        let error = dict.remove("error");
-        let result = match (result, error) {
-            (Some(result), None) => Ok(result),
-            (None, Some(err)) => Err(Error::RemoteError(err)),
-            _ => Err(Error::MalformedResponse)
-        };
+    fn handle_response(&self, id: u64, resp: Result<Value, Error>) {
+        let id = id as usize;
         let handler = {
             let mut pending = self.0.pending.lock().unwrap();
             pending.remove(&id)
         };
         match handler {
-            Some(responsehandler) => responsehandler.invoke(result),
+            Some(responsehandler) => responsehandler.invoke(resp),
             None => print_err!("id {} not found in pending", id)
         }
     }
 
     // Get a message from the receive queue if available.
-    fn try_get_rx(&self) -> Option<Value> {
+    fn try_get_rx(&self) -> Option<Result<String, ()>> {
         let mut queue = self.0.rx_queue.lock().unwrap();
         queue.pop_front()
     }
 
     // Get a message from the receive queue, blocking until available.
-    fn get_rx(&self) -> Value {
+    fn get_rx(&self) -> Result<String, ()> {
         let mut queue = self.0.rx_queue.lock().unwrap();
         while queue.is_empty() {
             queue = self.0.rx_cvar.wait(queue).unwrap();
@@ -471,10 +391,20 @@ impl<W:Write> RawPeer<W> {
         queue.pop_front().unwrap()
     }
 
-    fn put_rx(&self, json: Value) {
+    fn put_rx(&self, json: Result<String, ()>) {
         let mut queue = self.0.rx_queue.lock().unwrap();
         queue.push_back(json);
         self.0.rx_cvar.notify_one();
+    }
+
+    /// send disconnect error to pending requests.
+    fn disconnect(&self) {
+        let mut pending = self.0.pending.lock().unwrap();
+        let ids = pending.keys().map(|id| *id).collect::<Vec<_>>();
+        for id in ids.iter() {
+            let callback = pending.remove(id).unwrap();
+            callback.invoke(Err(Error::PeerDisconnect));
+        }
     }
 }
 
@@ -495,6 +425,7 @@ impl<W: Write> Clone for RawPeer<W> {
 //  Helper functions for value manipulation
 // =============================================================================
 
+//TODO: delete after finishing migration
 pub fn dict_get_u64(dict: &serde_json::Map<String, Value>, key: &str) -> Option<u64> {
     dict.get(key).and_then(Value::as_u64)
 }

--- a/rust/rpc/src/lib.rs
+++ b/rust/rpc/src/lib.rs
@@ -249,7 +249,8 @@ impl<W: Write + Send> RpcLoop<W> {
                             }
                             Err(msg) => {
                                 print_err!("failed to parse response: {}", msg);
-                                break
+                                self.peer.handle_response(
+                                    id, Err(Error::InvalidResponse));
                             }
                         }
                     } else {
@@ -386,7 +387,7 @@ impl<W:Write> RawPeer<W> {
         })) {
             let mut pending = self.0.pending.lock().unwrap();
             if let Some(rh) = pending.remove(&id) {
-                rh.invoke(Err(Error::IoError(e)));
+                rh.invoke(Err(Error::Io(e)));
             }
         }
     }

--- a/rust/rpc/src/parse.rs
+++ b/rust/rpc/src/parse.rs
@@ -1,0 +1,197 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Parsing of raw JSON messages into RPC objects.
+
+use serde_json::Value;
+use serde::de::{Deserializer, Deserialize};
+
+use error::RemoteError;
+
+
+/// A unique identifier attached to request RPCs.
+type RequestId = u64;
+
+#[derive(Debug, Clone, PartialEq)]
+/// An internal type, used to represent the various possible outcomes
+/// of attempting to parse a new message.
+///
+/// Because of the generality of the failure messages we get from serde,
+/// we handle various failure cases on our own.
+pub enum ParseResult<N, R> {
+    /// An id and an RPC Request
+    Request(RequestId, R),
+    /// An RPC Notification
+    Notification(N),
+    /// A response from the peer
+    Response(RequestId, Response),
+    /// The JSON was not a correctly formed request. The peer will
+    /// receive an error response, with the id if present.
+    InvalidRequest(Option<RequestId>, RemoteError),
+    /// The JSON contained an ID but was not a valid Response.
+    InvalidResponse(RequestId),
+    /// The message could not be parsed for some other reason.
+    OtherError(String),
+}
+
+pub type Response = Result<Value, RemoteError>;
+
+//TODO: revisit this if https://github.com/arcnmx/serde-value/issues/15 happens
+impl<'de, N, R> Deserialize<'de> for ParseResult<N, R>
+    where N: Deserialize<'de>,
+          R: Deserialize<'de>
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>
+    {
+        #[derive(Deserialize)]
+        struct Helper {
+            id: Option<u64>,
+            method: Option<String>,
+        }
+
+        #[derive(Deserialize)]
+        struct ResponseHelper {
+            result: Option<Value>,
+            error: Option<RemoteError>,
+        }
+
+        let v = match Value::deserialize(deserializer) {
+            Ok(v) => v,
+            Err(err) => return Ok(ParseResult::OtherError(err.to_string())),
+        };
+
+        let helper =  match Helper::deserialize(&v) {
+            Ok(h) => h,
+            Err(e) => return Ok(ParseResult::OtherError(e.to_string())),
+        };
+
+        let is_method = helper.method.is_some();
+        match (is_method, helper.id) {
+            (true, Some(id)) => {
+                match R::deserialize(v) {
+                    Ok(r) => Ok(ParseResult::Request(id, r)),
+                    Err(e) => {
+                        //TODO: if serde-json error messages improve, we should send
+                        // 'method not found' or 'invalid params' where appropriate
+                        let err = RemoteError::InvalidRequest(Some(json!(e.to_string())));
+                        Ok(ParseResult::InvalidRequest(Some(id), err))
+                    }
+                }
+            }
+            (true, None) => {
+                match N::deserialize(v) {
+                    Ok(n) => Ok(ParseResult::Notification(n)),
+                    Err(e) => Ok(ParseResult::OtherError(e.to_string())),
+                }
+            }
+            (false, Some(id)) => {
+                match ResponseHelper::deserialize(v) {
+                    Ok(resp) => {
+                        assert!(resp.result.is_some() != resp.error.is_some());
+                        if let Some(r) = resp.result {
+                            Ok(ParseResult::Response(id, Ok(r)))
+                        } else {
+                            Ok(ParseResult::Response(id, Err(resp.error.unwrap())))
+                        }
+                    }
+                    Err(_) => Ok(ParseResult::InvalidResponse(id)),
+                }
+            }
+            // if 'id' and 'method' fields are missing, msg is malformed
+            _ => Ok(ParseResult::OtherError("RPC is missing 'id' or 'method' field".into())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use serde_json;
+    use super::*;
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[serde(rename_all = "snake_case")]
+    #[serde(tag = "method", content = "params")]
+    enum TestR {
+        NewView { file_path: Option<String> },
+        OldView { file_path: usize },
+    }
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[serde(rename_all = "snake_case")]
+    #[serde(tag = "method", content = "params")]
+    enum TestN {
+        CloseView { view_id: String },
+        Save { view_id: String, file_path: String },
+    }
+
+    type RpcType = ParseResult<TestN, TestR>;
+
+    #[test]
+    fn request_success() {
+        let json = r#"{"id":0,"method":"new_view","params":{}}"#;
+        let p = serde_json::from_str::<RpcType>(json).unwrap();
+        assert_eq!(p, ParseResult::Request(0, TestR::NewView { file_path: None }));
+    }
+
+    #[test]
+    fn request_failure() {
+        // method does not exist
+        let json = r#"{"id":0,"method":"new_truth","params":{}}"#;
+        let p = serde_json::from_str::<RpcType>(json).unwrap();
+        let is_ok = match p {
+            ParseResult::InvalidRequest(Some(0), _) => true,
+            _ => false,
+        };
+        if !is_ok {
+            panic!("{:?}", p);
+        }
+    }
+
+    #[test]
+    fn notif_with_id() {
+        // method is a notification, should not have ID
+        let json = r#"{"id":0,"method":"close_view","params":{"view_id": "view-id-1"}}"#;
+        let p = serde_json::from_str::<RpcType>(json).unwrap();
+        let is_ok = match p {
+            ParseResult::InvalidRequest(Some(0), _) => true,
+            _ => false,
+        };
+        if !is_ok {
+            panic!("{:?}", p);
+        }
+    }
+
+    #[test]
+    fn test_resp_err() {
+        let json = r#"{"id":5,"error":{"code":420, "message":"chill out"}}"#;
+        let p = serde_json::from_str::<RpcType>(json).unwrap();
+        assert_eq!(p, ParseResult::Response(5, Err(RemoteError::custom(420, "chill out", None))));
+    }
+
+    #[test]
+    fn test_resp_result() {
+        let json = r#"{"id":5,"result":"success!"}"#;
+        let p = serde_json::from_str::<RpcType>(json).unwrap();
+        assert_eq!(p, ParseResult::Response(5, Ok(json!("success!"))));
+    }
+
+    #[test]
+    fn test_err() {
+        let json = r#"{"code": -32600, "message": "Invalid Request"}"#;
+        let e = serde_json::from_str::<RemoteError>(json).unwrap();
+        assert_eq!(e, RemoteError::InvalidRequest(None));
+    }
+}

--- a/rust/rpc/src/parse.rs
+++ b/rust/rpc/src/parse.rs
@@ -14,8 +14,8 @@
 
 //! Parsing of raw JSON messages into RPC objects.
 
-use serde_json::Value;
-use serde::de::{Deserializer, Deserialize};
+use serde_json::{self, Value, Error as JsonError};
+use serde::de::DeserializeOwned;
 
 use error::RemoteError;
 
@@ -23,97 +23,110 @@ use error::RemoteError;
 /// A unique identifier attached to request RPCs.
 type RequestId = u64;
 
-#[derive(Debug, Clone, PartialEq)]
-/// An internal type, used to represent the various possible outcomes
-/// of attempting to parse a new message.
+/// An RPC response, received from the peer.
+pub type Response = Result<Value, RemoteError>;
+
+/// An internal type used during initial JSON parsing.
 ///
-/// Because of the generality of the failure messages we get from serde,
-/// we handle various failure cases on our own.
-pub enum ParseResult<N, R> {
+/// Wraps an arbitrary JSON object, which may be any valid or invalid
+/// RPC message. This allows initial parsing and response handling to
+/// occur on the read thread. If the message looks like a request, it
+/// is passed to the main thread for handling.
+pub struct RpcObject(Value);
+
+#[derive(Debug, Clone, PartialEq)]
+/// An RPC call, which may be either a notification or a request.
+pub enum Call<N, R> {
     /// An id and an RPC Request
     Request(RequestId, R),
     /// An RPC Notification
     Notification(N),
-    /// A response from the peer
-    Response(RequestId, Response),
-    /// The JSON was not a correctly formed request. The peer will
-    /// receive an error response, with the id if present.
-    InvalidRequest(Option<RequestId>, RemoteError),
-    /// The JSON contained an ID but was not a valid Response.
-    InvalidResponse(RequestId),
-    /// The message could not be parsed for some other reason.
-    OtherError(String),
+    /// A malformed request: the request contained an id, but could
+    /// not be parsed. The client will receive an error.
+    InvalidRequest(RequestId, RemoteError),
 }
 
-pub type Response = Result<Value, RemoteError>;
+impl RpcObject {
+    /// Returns the 'id' of the underlying object, if present.
+    pub fn get_id(&self) -> Option<RequestId> {
+        self.0.get("id").and_then(Value::as_u64)
+    }
 
-//TODO: revisit this if https://github.com/arcnmx/serde-value/issues/15 happens
-impl<'de, N, R> Deserialize<'de> for ParseResult<N, R>
-    where N: Deserialize<'de>,
-          R: Deserialize<'de>
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer<'de>
+    /// Returns `true` if this object looks like an RPC response;
+    /// that is, if it has an 'id' field and does _not_ have a 'method'
+    /// field.
+    pub fn is_response(&self) -> bool {
+        self.0.get("id").is_some() && self.0.get("method").is_none()
+    }
+
+    /// Attempts to convert the underlying `Value` into an RPC response
+    /// object, and returns the result.
+    ///
+    /// The caller is expected to verify that the object is a response
+    /// before calling this method.
+    ///
+    /// # Errors
+    ///
+    /// If the `Value` is not a well formed response object, this will
+    /// return a `String` containing an error message. The caller should
+    /// print this message and exit.
+    pub fn into_response(mut self) -> Result<Response, String> {
+        let _ = self.get_id()
+            .ok_or("Response requires 'id' field.".to_string())?;
+
+        if self.0.get("result").is_some() == self.0.get("error").is_some() {
+            return Err("RPC response must contain exactly one of\
+                       'error' or 'result' fields.".into());
+        }
+        let result = self.0.as_object_mut()
+            .and_then(|obj| obj.remove("result"));
+        //let id = id.map(Value::from).unwrap_or(Value::Null);
+        match result {
+            Some(r) => Ok(Ok(r)),
+            None => {
+                let error = self.0.as_object_mut()
+                    .and_then(|obj| obj.remove("error")).unwrap();
+                match serde_json::from_value::<RemoteError>(error) {
+                    Ok(e) => Ok(Err(e)),
+                    Err(e) => Err(format!("Error handling response: {:?}", e)),
+                }
+            }
+        }
+    }
+
+    /// Attempts to convert the underlying `Value` into either an RPC
+    /// notification or request.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `serde_json::Error` if the `Value` cannot be converted
+    /// to one of the expected types.
+    pub fn into_rpc<N, R>(self) -> Result<Call<N, R>, JsonError>
+    where N: DeserializeOwned,
+          R: DeserializeOwned,
     {
-        #[derive(Deserialize)]
-        struct Helper {
-            id: Option<u64>,
-            method: Option<String>,
-        }
-
-        #[derive(Deserialize)]
-        struct ResponseHelper {
-            result: Option<Value>,
-            error: Option<RemoteError>,
-        }
-
-        let v = match Value::deserialize(deserializer) {
-            Ok(v) => v,
-            Err(err) => return Ok(ParseResult::OtherError(err.to_string())),
-        };
-
-        let helper =  match Helper::deserialize(&v) {
-            Ok(h) => h,
-            Err(e) => return Ok(ParseResult::OtherError(e.to_string())),
-        };
-
-        let is_method = helper.method.is_some();
-        match (is_method, helper.id) {
-            (true, Some(id)) => {
-                match R::deserialize(v) {
-                    Ok(r) => Ok(ParseResult::Request(id, r)),
-                    Err(e) => {
-                        //TODO: if serde-json error messages improve, we should send
-                        // 'method not found' or 'invalid params' where appropriate
-                        let err = RemoteError::InvalidRequest(Some(json!(e.to_string())));
-                        Ok(ParseResult::InvalidRequest(Some(id), err))
-                    }
+        let id = self.get_id();
+        match id {
+            Some(id) => {
+                match serde_json::from_value::<R>(self.0) {
+                    Ok(resp) => Ok(Call::Request(id, resp)),
+                    Err(err) => Ok(Call::InvalidRequest(id, err.into())),
                 }
             }
-            (true, None) => {
-                match N::deserialize(v) {
-                    Ok(n) => Ok(ParseResult::Notification(n)),
-                    Err(e) => Ok(ParseResult::OtherError(e.to_string())),
-                }
+            None => {
+                let result = serde_json::from_value::<N>(self.0)?;
+                Ok(Call::Notification(result))
             }
-            (false, Some(id)) => {
-                match ResponseHelper::deserialize(v) {
-                    Ok(resp) => {
-                        assert!(resp.result.is_some() != resp.error.is_some());
-                        if let Some(r) = resp.result {
-                            Ok(ParseResult::Response(id, Ok(r)))
-                        } else {
-                            Ok(ParseResult::Response(id, Err(resp.error.unwrap())))
-                        }
-                    }
-                    Err(_) => Ok(ParseResult::InvalidResponse(id)),
-                }
-            }
-            // if 'id' and 'method' fields are missing, msg is malformed
-            _ => Ok(ParseResult::OtherError("RPC is missing 'id' or 'method' field".into())),
         }
     }
 }
+
+impl From<Value> for RpcObject {
+    fn from(v: Value) -> RpcObject {
+        RpcObject(v)
+    }
+}
+
 
 #[cfg(test)]
 mod tests {
@@ -137,26 +150,27 @@ mod tests {
         Save { view_id: String, file_path: String },
     }
 
-    type RpcType = ParseResult<TestN, TestR>;
-
     #[test]
     fn request_success() {
         let json = r#"{"id":0,"method":"new_view","params":{}}"#;
-        let p = serde_json::from_str::<RpcType>(json).unwrap();
-        assert_eq!(p, ParseResult::Request(0, TestR::NewView { file_path: None }));
+        let p: RpcObject = serde_json::from_str::<Value>(json).unwrap().into();
+        assert!(!p.is_response());
+        let req = p.into_rpc::<TestN, TestR>().unwrap();
+        assert_eq!(req, Call::Request(0, TestR::NewView { file_path: None }));
     }
 
     #[test]
     fn request_failure() {
         // method does not exist
         let json = r#"{"id":0,"method":"new_truth","params":{}}"#;
-        let p = serde_json::from_str::<RpcType>(json).unwrap();
-        let is_ok = match p {
-            ParseResult::InvalidRequest(Some(0), _) => true,
+        let p: RpcObject = serde_json::from_str::<Value>(json).unwrap().into();
+        let req = p.into_rpc::<TestN, TestR>().unwrap();
+        let is_ok = match req {
+            Call::InvalidRequest(0, _) => true,
             _ => false,
         };
         if !is_ok {
-            panic!("{:?}", p);
+            panic!("{:?}", req);
         }
     }
 
@@ -164,28 +178,33 @@ mod tests {
     fn notif_with_id() {
         // method is a notification, should not have ID
         let json = r#"{"id":0,"method":"close_view","params":{"view_id": "view-id-1"}}"#;
-        let p = serde_json::from_str::<RpcType>(json).unwrap();
-        let is_ok = match p {
-            ParseResult::InvalidRequest(Some(0), _) => true,
+        let p: RpcObject = serde_json::from_str::<Value>(json).unwrap().into();
+        let req = p.into_rpc::<TestN, TestR>().unwrap();
+        let is_ok = match req {
+            Call::InvalidRequest(0, _) => true,
             _ => false,
         };
         if !is_ok {
-            panic!("{:?}", p);
+            panic!("{:?}", req);
         }
     }
 
     #[test]
     fn test_resp_err() {
         let json = r#"{"id":5,"error":{"code":420, "message":"chill out"}}"#;
-        let p = serde_json::from_str::<RpcType>(json).unwrap();
-        assert_eq!(p, ParseResult::Response(5, Err(RemoteError::custom(420, "chill out", None))));
+        let p: RpcObject = serde_json::from_str::<Value>(json).unwrap().into();
+        assert!(p.is_response());
+        let resp  = p.into_response().unwrap();
+        assert_eq!(resp, Err(RemoteError::custom(420, "chill out", None)));
     }
 
     #[test]
     fn test_resp_result() {
         let json = r#"{"id":5,"result":"success!"}"#;
-        let p = serde_json::from_str::<RpcType>(json).unwrap();
-        assert_eq!(p, ParseResult::Response(5, Ok(json!("success!"))));
+        let p: RpcObject = serde_json::from_str::<Value>(json).unwrap().into();
+        assert!(p.is_response());
+        let resp  = p.into_response().unwrap();
+        assert_eq!(resp, Ok(json!("success!")));
     }
 
     #[test]

--- a/rust/syntect-plugin/Cargo.lock
+++ b/rust/syntect-plugin/Cargo.lock
@@ -340,6 +340,7 @@ version = "0.2.0"
 dependencies = [
  "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 


### PR DESCRIPTION
## Typed `Handler`s

This PR updates `xi-rpc`, chiefly to add associated types to the `Handler` trait.

Types that implement `Handler` now specify the types of RPCs they handle. This is chiefly intended to be used with serde; the general idea is that the set of accepted RPCs can be represented as a pair of enums, which can be automatically parsed using serde's `derive` macros.

This PR doesn't include the large refactors required to take advantage of this change, although I have them largely done in other working branches.

### Rationale

The major advantage of this change is that it means adding a new RPC call is as simple as adding a new member to an enum, and lets `xi-rpc` do more input validation and error handling.

### Questions

#### `Parser` trait?

The `Parser` trait: I wanted to avoid requiring the associated types from having a `: Deserialize` trait bound; the approach I took was to split `Handler` into two traits, `Parser` and `MethodHandler`. We provide an implementation of `Parser` for types which _do_ implement `Deserialize`. (Technically `DeserializeOwned`, right now, although this may change if something like https://github.com/arcnmx/serde-value/issues/15 is resolved). However, it may not be unreasonable to just require the associated types to be `Deserialize`; another option would be to create a new trait, like `RpcCall`, and use that as a constraint on the associated types, and provide a free implementation for types that are `Deserialize`. Which of these approaches makes the most sense?

#### Performance
Performance: The current hand-rolled parsing is quite efficient, because after the initial parsing to a `Value` everything else is a borrow. The new system currently involves first parsing to a `Value`, and then parsing _again_ to one of the associated types. In some small benchmarks, the new approach is about 25% slower (the 1st and 3rd items here):

```
test borrow       ... bench:      14,427 ns/iter (+/- 48) // current impl in master
test own          ... bench:      18,127 ns/iter (+/- 409) // shim impl in this PR
test serde        ... bench:      19,348 ns/iter (+/- 499) // impl after refactor
test future_serde ... bench:       9,776 ns/iter (+/- 153) // (optimistic) future impl with serde borrowing
```

(the benchmark code is available here: https://github.com/cmyr/xi_der_bench)

There are some big potential future gains, however, because we do not currently take advantage of serde's borrowing functionality; the last benchmark suggests we should be able to at least equal current performance as work continues on serde.

However: if we had to live with this slowdown indefinitely, would that be an acceptable tradeoff?

### Conclusion

If this approach seems sound, I will prepare some follow-on PRs:
1. Improve the error handling story in `xi-rpc`, to formalize an error system based on the [json-rpc spec](http://www.jsonrpc.org/specification#error_object);
1. Refactor `xi-core` to use this for the core protocol
1. Ditto the rust plugin-lib

And then look into a few other possible changes in `xi-rpc`:

1. Investigate a similar change for the _peer_ side of the RPC channel
1. Investigate some changes to support more flexible idle scheduling

If this approach _doesn't_ seem sound, I will stop talking about this and move on to something more concretely useful. 🤷‍♂️ 
