### PR TITLE
Small fixes

### DIFF
--- a/rust/rope/src/engine.rs
+++ b/rust/rope/src/engine.rs
@@ -157,8 +157,8 @@ impl RevId {
     /// should be as unlikely to collide as two random u64s.
     pub fn token(&self) -> RevToken {
         use std::hash::{Hash, Hasher};
-        /// Rust is unlikely to break the property that this hash is strongly collision-resistant
-        /// and it only needs to be consistent over one execution.
+        // Rust is unlikely to break the property that this hash is strongly collision-resistant
+        // and it only needs to be consistent over one execution.
         let mut hasher = DefaultHasher::new();
         self.hash(&mut hasher);
         hasher.finish()

--- a/rust/rpc/src/lib.rs
+++ b/rust/rpc/src/lib.rs
@@ -22,7 +22,6 @@
 //! Because these changes make the protocol not fully compliant with the spec,
 //! the `"jsonrpc"` member is omitted from request and response objects.
 
-extern crate serde;
 #[macro_use]
 extern crate serde_json;
 extern crate crossbeam;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -11,10 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-extern crate serde;
-extern crate serde_json;
-
 use std::io;
 
 #[macro_use]


### PR DESCRIPTION
Two small fixes that cargo clean && cargo build on 1.21.0-beta.2 detected. I rebuild with 1.18.0 to ensure the fixes work.