### PR TITLE
Clarify minimal supported rust version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ below.
 
 ### Building the core
 
-If you want to experiment, you can build just the core like so:
+Building the xi editor requires Rust 1.18 or later. If you want to experiment,
+you can build just the core like so:
 
 ```
 > cd rust


### PR DESCRIPTION
Another simple PR to clarify we are relying on Rust 1.18 or later.