### PR TITLE
Feature/runloop returns err

### DIFF
--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -232,7 +232,9 @@ pub fn start_plugin_process<C>(manager_ref: &PluginManagerRef,
                     Arc::new(Mutex::new(plugin)),
                     Arc::new(AtomicBool::new(false)));
                 completion(Ok(plugin_ref.clone()));
-                looper.mainloop(|| BufReader::new(child_stdout), &mut plugin_ref);
+                //TODO: we could be logging plugin exit results
+                let _ = looper.mainloop(|| BufReader::new(child_stdout),
+                                        &mut plugin_ref);
             }
             Err(err) => completion(Err(err)),
         }

--- a/rust/core-lib/tests/rpc.rs
+++ b/rust/core-lib/tests/rpc.rs
@@ -25,6 +25,7 @@ use xi_rpc::test_utils::{make_reader, test_channel};
 use xi_core_lib::MainState;
 
 #[test]
+/// Tests that the handler responds to a standard startup sequence as expected.
 fn test_startup() {
     let mut state = MainState::new();
     let (tx, mut rx) = test_channel();
@@ -42,6 +43,7 @@ fn test_startup() {
 
 
 #[test]
+/// Tests that the handler creates and destroys views and buffers
 fn test_state() {
     let mut state = MainState::new();
     let buffers = state._get_buffers();
@@ -71,6 +73,7 @@ fn test_state() {
 {"id":2,"method":"new_view","params":{}}
 {"id":3,"method":"new_view","params":{}}"#);
 
+
     assert!(rpc_looper.mainloop(|| json, &mut state).is_ok());
     {
         let buffers = buffers.lock();
@@ -79,6 +82,8 @@ fn test_state() {
 }
 
 #[test]
+/// Tests that the runloop exits with the correct error when receiving
+/// malformed json.
 fn test_malformed_json() {
     let mut state = MainState::new();
     let write = io::sink();
@@ -98,3 +103,116 @@ fn test_malformed_json() {
         assert_eq!(buffers.iter_editors().count(), 0);
     }
 }
+
+#[test]
+/// Sends all of the cursor movement-related commands, and verifies that
+/// they are handled.
+///
+///
+/// Note: this is a test of message parsing, not of editor behaviour.
+fn test_movement_cmds() {
+    let mut state = MainState::new();
+    let write = io::sink();
+    let mut rpc_looper = RpcLoop::new(write);
+    // init a new view
+    let json = make_reader(r#"{"method":"client_started","params":{}}
+{"method":"set_theme","params":{"theme_name":"InspiredGitHub"}}
+{"id":0,"method":"new_view","params":{}}"#);
+    assert!(rpc_looper.mainloop(|| json, &mut state).is_ok());
+    
+    let json = make_reader(MOVEMENT_RPCS);
+    assert!(rpc_looper.mainloop(|| json, &mut state).is_ok());
+}
+
+#[test]
+/// Sends all the commands which modify the buffer, and verifies that they
+/// are handled.
+fn test_text_commands() {
+    let mut state = MainState::new();
+    let write = io::sink();
+    let mut rpc_looper = RpcLoop::new(write);
+    // init a new view
+    let json = make_reader(r#"{"method":"client_started","params":{}}
+{"method":"set_theme","params":{"theme_name":"InspiredGitHub"}}
+{"id":0,"method":"new_view","params":{}}"#);
+    assert!(rpc_looper.mainloop(|| json, &mut state).is_ok());
+    
+    let json = make_reader(TEXT_EDIT_RPCS);
+    assert!(rpc_looper.mainloop(|| json, &mut state).is_ok());
+}
+
+#[test]
+fn test_other_edit_commands() {
+    let mut state = MainState::new();
+    let write = io::sink();
+    let mut rpc_looper = RpcLoop::new(write);
+    // init a new view
+    let json = make_reader(r#"{"method":"client_started","params":{}}
+{"method":"set_theme","params":{"theme_name":"InspiredGitHub"}}
+{"id":0,"method":"new_view","params":{}}"#);
+    assert!(rpc_looper.mainloop(|| json, &mut state).is_ok());
+    
+    let json = make_reader(OTHER_EDIT_RPCS);
+    assert!(rpc_looper.mainloop(|| json, &mut state).is_ok());
+}
+
+//TODO: test saving rpc
+//TODO: test plugin rpc
+
+const MOVEMENT_RPCS: &str = r#"{"method":"edit","params":{"view_id":"view-id-1","method":"move_up","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_down","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_up_and_modify_selection","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_down_and_modify_selection","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_left","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_backward","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_right","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_forward","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_left_and_modify_selection","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_right_and_modify_selection","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_word_left","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_word_right","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_word_left_and_modify_selection","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_word_right_and_modify_selection","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_to_beginning_of_paragraph","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_to_end_of_paragraph","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_to_left_end_of_line","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_to_left_end_of_line_and_modify_selection","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_to_right_end_of_line","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_to_right_end_of_line_and_modify_selection","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_to_beginning_of_document","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_to_beginning_of_document_and_modify_selection","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_to_end_of_document","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"move_to_end_of_document_and_modify_selection","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"scroll_page_up","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"scroll_page_down","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"page_up_and_modify_selection","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"page_down_and_modify_selection","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"select_all","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"add_selection_above","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"add_selection_below","params":[]}}"#;
+
+const TEXT_EDIT_RPCS: &str = r#"{"method":"edit","params":{"view_id":"view-id-1","method":"insert","params":{"chars":"a"}}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"delete_backward","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"delete_forward","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"delete_word_forward","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"delete_word_backward","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"delete_to_end_of_paragraph","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"insert_newline","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"insert_tab","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"yank","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"undo","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"redo","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"transpose","params":[]}}
+{"id":2,"method":"edit","params":{"view_id":"view-id-1","method":"cut","params":[]}}"#;
+
+const OTHER_EDIT_RPCS: &str = r#"{"method":"edit","params":{"view_id":"view-id-1","method":"scroll","params":[0,1]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"goto_line","params":{"line":1}}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"request_lines","params":[0,1]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"click","params":[6,0,0,1]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"drag","params":[17,15,0]}}
+{"id":4,"method":"edit","params":{"view_id":"view-id-1","method":"find","params":{"case_sensitive":false,"chars":"m"}}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"find_next","params":{"wrap_around":true}}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"find_previous","params":{"wrap_around":true}}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"debug_rewrap","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"debug_print_spans","params":[]}}
+{"id":3,"method":"edit","params":{"view_id":"view-id-1","method":"copy","params":[]}}"#;

--- a/rust/rpc/src/error.rs
+++ b/rust/rpc/src/error.rs
@@ -41,6 +41,8 @@ pub enum ReadError {
     Json(JsonError),
     /// The message was not a JSON object.
     NotObject,
+    /// The the method and params were not recognized by the handler.
+    UnknownRequest(JsonError),
     /// The peer closed the connection.
     Disconnect,
 }
@@ -142,6 +144,7 @@ impl fmt::Display for ReadError {
             ReadError::Io(ref err) => write!(f, "I/O Error: {:?}", err),
             ReadError::Json(ref err) => write!(f, "JSON Error: {:?}", err),
             ReadError::NotObject => write!(f, "JSON message was not an object."),
+            ReadError::UnknownRequest(ref err) => write!(f, "Unknown request: {:?}", err),
             ReadError::Disconnect => write!(f, "Peer closed the connection."),
         }
     }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -29,5 +29,8 @@ fn main() {
     let stdout = io::stdout();
     let mut rpc_looper = RpcLoop::new(stdout);
 
-    rpc_looper.mainloop(|| stdin.lock(), &mut state);
+    match rpc_looper.mainloop(|| stdin.lock(), &mut state) {
+        Ok(_) => (),
+        Err(err) => print_err!("xi-core exited with error:\n{:?}", err),
+    }
 }


### PR DESCRIPTION
This is primarily to facilitate the writing of certain types of tests,
specifically those where we want to start a run loop with a specific
handler, and then verify that JSON is handled as expected.

This also has the benefit of providing more error information to the
call site, where more specific decisions can be made about error
handling and/or logging.