### PR TITLE
Incremental syntax highlighting

### DIFF
--- a/rust/plugin-lib/Cargo.toml
+++ b/rust/plugin-lib/Cargo.toml
@@ -10,6 +10,7 @@ description = "The library base for implementing xi-editor plugins."
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
+bytecount = "0.1.2"
 
 [dependencies.xi-rpc]
 path = "../rpc"

--- a/rust/plugin-lib/Cargo.toml
+++ b/rust/plugin-lib/Cargo.toml
@@ -11,6 +11,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 bytecount = "0.1.2"
+rand = "0.3"
 
 [dependencies.xi-rpc]
 path = "../rpc"

--- a/rust/plugin-lib/src/lib.rs
+++ b/rust/plugin-lib/src/lib.rs
@@ -25,3 +25,4 @@ mod macros;
 
 pub mod plugin_base;
 pub mod caching_plugin;
+pub mod state_cache;

--- a/rust/plugin-lib/src/lib.rs
+++ b/rust/plugin-lib/src/lib.rs
@@ -20,6 +20,7 @@ extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;
 extern crate bytecount;
+extern crate rand;
 
 #[macro_use]
 mod macros;

--- a/rust/plugin-lib/src/lib.rs
+++ b/rust/plugin-lib/src/lib.rs
@@ -19,6 +19,7 @@ extern crate xi_rpc;
 extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;
+extern crate bytecount;
 
 #[macro_use]
 mod macros;

--- a/rust/plugin-lib/src/state_cache.rs
+++ b/rust/plugin-lib/src/state_cache.rs
@@ -1,0 +1,332 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A more sophisticated cache that manages user state.
+
+use std::path::PathBuf;
+use serde_json::Value;
+
+use plugin_base;
+use plugin_base::PluginRequest;
+
+pub use plugin_base::{Error, ScopeSpan};
+
+const CHUNK_SIZE: usize = 1024 * 1024;
+
+/// A handler that the plugin needs to instantiate.
+pub trait Handler {
+    type State: Default + Clone;
+
+    fn initialize(&mut self, ctx: PluginCtx<Self::State>, buf_size: usize);
+    fn update(&mut self, ctx: PluginCtx<Self::State>);
+    fn did_save(&mut self, ctx: PluginCtx<Self::State>);
+    #[allow(unused_variables)]
+    fn idle(&mut self, ctx: PluginCtx<Self::State>, token: usize) {}
+}
+
+struct CacheEntry<S> {
+    line_num: usize,
+    offset: usize,
+    user_state: Option<S>,
+}
+
+/// The caching state
+#[derive(Default)]
+struct MyState<S> {
+    /// The length of the document in bytes.
+    buf_size: usize,
+    view_id: String,
+    rev: u64,
+    cache: Option<String>,
+    cache_offset: usize,
+
+    // line iteration state
+    line_num: usize,
+    offset_of_line: usize,
+
+    /// A chunk of the document.
+    chunk: String,
+    /// Starting offset of the chunk.
+    chunk_offset: usize,
+
+    // cache of per-line state
+    // Note: this doesn't store the 0 state, that's assumed
+    state_cache: Vec<CacheEntry<S>>,
+
+    syntax: String,
+    path: Option<PathBuf>,
+}
+
+pub struct PluginCtx<'a, S: 'a> {
+    state: &'a mut MyState<S>,
+    peer: plugin_base::PluginCtx<'a>,
+}
+
+struct MyHandler<'a, H: Handler + 'a> {
+    handler: &'a mut H,
+    state: MyState<H::State>,
+}
+
+impl<'a, H: Handler> plugin_base::Handler for MyHandler<'a, H> {
+    fn call(&mut self, req: &PluginRequest, peer: plugin_base::PluginCtx) -> Option<Value> {
+        let ctx = PluginCtx {
+            state: &mut self.state,
+            peer: peer,
+        };
+        match *req {
+            PluginRequest::Ping => {
+                print_err!("got ping");
+                None
+            }
+            PluginRequest::Initialize(ref init_info) => {
+                ctx.state.buf_size = init_info.buf_size;
+                assert_eq!(init_info.views.len(), 1);
+                ctx.state.view_id = init_info.views[0].clone();
+                ctx.state.rev = init_info.rev;
+                ctx.state.syntax = init_info.syntax.clone();
+                ctx.state.path = init_info.path.clone().map(|p| PathBuf::from(p));
+                self.handler.initialize(ctx, init_info.buf_size);
+                None
+            }
+            PluginRequest::Update { start, end, new_len, rev, text, .. } => {
+                //print_err!("got update notification {:?}", edit_type);
+                ctx.state.buf_size = ctx.state.buf_size - (end - start) + new_len;
+                ctx.state.rev = rev;
+                if let (Some(text), Some(mut cache)) = (text, ctx.state.cache.take()) {
+                    let off = ctx.state.cache_offset;
+                    if start >= off && start <= off + cache.len() {
+                        let tail = if end < off + cache.len() {
+                            Some(cache[end - off ..].to_string())
+                        } else {
+                            None
+                        };
+                        cache.truncate(start - off);
+                        cache.push_str(text);
+                        if let Some(tail) = tail {
+                            cache.push_str(&tail);
+                        }
+                        ctx.state.cache = Some(cache);
+                    }
+                }
+                ctx.state.line_num = 0;
+                ctx.state.offset_of_line = 0;
+                self.handler.update(ctx);
+                Some(Value::from(0i32))
+            }
+            PluginRequest::DidSave { ref path } => {
+                let new_path = Some(path.to_owned());
+                if ctx.state.path != new_path {
+                    ctx.state.line_num = 0;
+                    ctx.state.offset_of_line = 0;
+                }
+                ctx.state.path = Some(path.to_owned());
+                self.handler.did_save(ctx);
+                None
+            }
+        }
+    }
+
+    fn idle(&mut self, peer: plugin_base::PluginCtx, token: usize) {
+        let ctx = PluginCtx {
+            state: &mut self.state,
+            peer: peer,
+        };
+        self.handler.idle(ctx, token);
+    }
+}
+
+pub fn mainloop<H: Handler>(handler: &mut H) {
+    let mut my_handler = MyHandler {
+        handler: handler,
+        state: MyState::default(),
+    };
+    plugin_base::mainloop(&mut my_handler);
+}
+
+impl<'a, S: Default + Clone> PluginCtx<'a, S> {
+
+    pub fn get_path(&self) -> Option<&PathBuf> {
+        match self.state.path {
+            Some(ref p) => Some(p),
+            None => None,
+        }
+    }
+
+    pub fn add_scopes(&self, scopes: &Vec<Vec<String>>) {
+        self.peer.add_scopes(&self.state.view_id, scopes)
+    }
+
+    pub fn update_spans(&self, start: usize, len: usize, spans: &[ScopeSpan]) {
+        self.peer.update_spans(&self.state.view_id, start, len, self.state.rev, spans)
+    }
+
+    /// Determines whether an incoming request (or notification) is pending. This
+    /// is intended to reduce latency for bulk operations done in the background.
+    pub fn request_is_pending(&self) -> bool {
+        self.peer.request_is_pending()
+    }
+
+    /// Schedule the idle handler to be run when there are no requests pending.
+    pub fn schedule_idle(&mut self, token: usize) {
+        self.peer.schedule_idle(token);
+    }
+
+    /// Find an entry in the cache by line num. On return `Ok(i)` means entry
+    /// at index `i` is an exact match, while `Err(i)` means the entry would be
+    /// inserted at `i`.
+    fn find_line(&self, line_num: usize) -> Result<usize, usize> {
+        self.state.state_cache.binary_search_by(|probe| probe.line_num.cmp(&line_num))
+    }
+
+    /// Get state at or before given line number.
+    pub fn get_prev(&self, line_num: usize) -> (usize, usize, S) {
+        if line_num > 0 {
+            let mut ix = match self.find_line(line_num) {
+                Ok(ix) => ix,
+                Err(0) => return (0, 0, S::default()),
+                Err(ix) => ix - 1,
+            };
+            loop {
+                let item = &self.state.state_cache[ix];
+                if let Some(ref s) = item.user_state {
+                    return (item.line_num, item.offset, s.clone());
+                }
+                if ix == 0 { break; }
+                ix -= 1;
+            }
+        }
+        (0, 0, S::default())
+    }
+
+    /// Set the state at the given line number.
+    pub fn set(&mut self, line_num: usize, s: S) {
+        self.get_entry(line_num).user_state = Some(s);
+    }
+
+    /// Get the cache entry at the given line number, creating it if necessary.
+    fn get_entry(&mut self, line_num: usize) -> &mut CacheEntry<S> {
+        match self.find_line(line_num) {
+            Ok(ix) => &mut self.state.state_cache[ix],
+            Err(ix) => unimplemented!(),
+        }
+    }
+
+    /// Insert a new entry into the cache, returning its index.
+    fn insert_entry(&mut self, line_num: usize, offset: usize, user_state: Option<S>) -> usize {
+        match self.find_line(line_num) {
+            // TODO: evict if full
+            Ok(ix) => panic!("entry already exists"),
+            Err(ix) => {
+                self.state.state_cache.insert(ix, CacheEntry {
+                    line_num, offset, user_state
+                });
+                ix
+            }
+        }
+    }
+
+    fn fetch_chunk(&mut self, start: usize) -> Result<String, Error> {
+        self.peer.get_data(&self.state.view_id, start, CHUNK_SIZE, self.state.rev)
+    }
+
+    /// Get a slice of the document, containing at least the given interval
+    /// plus at least one more codepoint (unless at EOF).
+    fn get_chunk(&mut self, start: usize, end: usize) -> Result<&str, Error> {
+        loop {
+            let chunk_start = self.state.chunk_offset;
+            let chunk_end = chunk_start + self.state.chunk.len();
+            if start >= chunk_start && start < chunk_end {
+                // At least the first codepoint at start is in the chunk
+                if end < chunk_end || end == self.state.buf_size {
+                    return Ok(&self.state.chunk[start - chunk_start ..]);
+                }
+                let new_chunk = self.fetch_chunk(chunk_end)?;
+                if start == chunk_start {
+                    self.state.chunk.push_str(&new_chunk);
+                } else {
+                    self.state.chunk_offset = start;
+                    self.state.chunk = [&self.state.chunk[start - chunk_start ..],
+                        &new_chunk].concat();
+                }
+            } else {
+                // TODO: if chunk_start < start + CHUNK_SIZE, could fetch smaller
+                // chunk and concat; probably not a major savings in practice.
+                self.state.chunk = self.fetch_chunk(start)?;
+                self.state.chunk_offset = start;
+            }
+        }
+    }
+
+    fn get_offset_ix_of_line(&mut self, line_num: usize) -> Result<(usize, usize), Error> {
+        if line_num == 0 {
+            return Ok((0, 0));
+        }
+        match self.find_line(line_num) {
+            Ok(ix) => Ok((self.state.state_cache[ix].offset, ix)),
+            Err(ix) => {
+                let (mut l, mut offset) = if ix == 0 { (0, 0) } else {
+                    let item = &self.state.state_cache[ix - 1];
+                    (item.line_num, item.offset)
+                };
+                let mut end = offset;
+                loop {
+                    let chunk = self.get_chunk(offset, end)?;
+                    if let Some(pos) = memchr(b'\n', chunk.as_bytes()) {
+                        offset += pos + 1;
+                        l += 1;
+                        if l == line_num {
+                            return Ok((offset, ix));
+                        }
+                    } else {
+                        end = offset + chunk.len();
+                    }
+                }
+                unimplemented!()
+            }
+        }
+    }
+
+    fn get_line_len(&mut self, start: usize) -> Result<usize, Error> {
+        let mut end = start;
+        loop {
+            let buf_size = self.state.buf_size;
+            let chunk = self.get_chunk(start, end)?;
+            match memchr(b'\n', chunk.as_bytes()) {
+                Some(pos) => return Ok(pos + 1),
+                None => {
+                    end = start + chunk.len();
+                    if end == buf_size {
+                        return Ok(chunk.len());
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn get_line(&mut self, line_num: usize) -> Result<&str, Error> {
+        let (start, _ix) = self.get_offset_ix_of_line(line_num)?;
+        // TODO: if cache entry at ix + 1 has line_num + 1, then we know line len
+        let len = self.get_line_len(start)?;
+        // TODO: this will pull in the first codepoint of the next line, which
+        // is not necessary.
+        let chunk = self.get_chunk(start, start + len)?;
+        Ok(&chunk[start .. start + len])
+    }
+
+}
+
+// TODO: use burntsushi memchr, or import this from xi_rope
+fn memchr(needle: u8, haystack: &[u8]) -> Option<usize> {
+    haystack.iter().position(|&b| b == needle)
+}

--- a/rust/syntect-plugin/Cargo.lock
+++ b/rust/syntect-plugin/Cargo.lock
@@ -65,8 +65,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "conv"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "custom_derive"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -116,6 +129,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "libc"
 version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "magenta"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "magenta-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "miniz-sys"
@@ -200,6 +230,15 @@ dependencies = [
 name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -334,6 +373,7 @@ name = "xi-plugin-lib"
 version = "0.1.0"
 dependencies = [
  "bytecount 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -371,7 +411,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
 "checksum chrono 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d9123be86fd2a8f627836c235ecdf331fdd067ecf7ac05aa1a68fbcf2429f056"
 "checksum cmake 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ebbb35d3dc9cd09497168f33de1acb79b265d350ab0ac34133b98f8509af1f"
+"checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 "checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
+"checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
 "checksum flate2 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)" = "36df0166e856739905cd3d7e0b210fe818592211a008862599845e012d8d304c"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
@@ -380,6 +422,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
 "checksum libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)" = "38f5c2b18a287cf78b4097db62e20f43cace381dc76ae5c0a3073067f78b7ddc"
+"checksum magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf0336886480e671965f794bc9b6fce88503563013d1bfb7a502c81fe3ac527"
+"checksum magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40d014c7011ac470ae28e2f76a02bfea4a8480f73e701353b49ad7a8d75f4699"
 "checksum miniz-sys 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "28eaee17666671fa872e567547e8428e83308ebe5808cdf6a0e28397dbe2c726"
 "checksum num 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "2c3a3dc9f30bf824141521b30c908a859ab190b76e20435fcd89f35eb6583887"
 "checksum num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "ef1a4bf6f9174aa5783a9b4cc892cacd11aebad6c69ad027a0b65c6ca5f8aa37"
@@ -390,6 +434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum plist 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1e2f7e9574aabcf57bc5e9f602caabdffffa8179b0c130a039f7895fea3dbdb5"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+"checksum rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb250fd207a4729c976794d03db689c9be1d634ab5a1c9da9492a13d8fecbcdf"
 "checksum redox_syscall 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "3041aeb6000db123d2c9c751433f526e1f404b23213bd733167ab770c3989b4d"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum same-file 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d931a44fdaa43b8637009e7632a02adc4f2b2e0733c08caa4cf00e8da4a117a7"

--- a/rust/syntect-plugin/Cargo.lock
+++ b/rust/syntect-plugin/Cargo.lock
@@ -5,7 +5,7 @@ dependencies = [
  "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntect 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntect 1.7.2 (git+https://github.com/raphlinus/syntect)",
  "xi-plugin-lib 0.1.0",
 ]
 
@@ -35,6 +35,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "bitflags"
 version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bytecount"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -270,8 +275,8 @@ dependencies = [
 
 [[package]]
 name = "syntect"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "1.7.2"
+source = "git+https://github.com/raphlinus/syntect#489683054a0df02302615ef350d9edc10d1cfced"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -328,6 +333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "xi-plugin-lib"
 version = "0.1.0"
 dependencies = [
+ "bytecount 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -361,6 +367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e103c8b299b28a9c6990458b7013dc4a8356a9b854c51b9883241f5866fac36e"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
+"checksum bytecount 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "4bbeb7c30341fce29f6078b4bdf876ea4779600866e98f5b2d203a534f195050"
 "checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
 "checksum chrono 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d9123be86fd2a8f627836c235ecdf331fdd067ecf7ac05aa1a68fbcf2429f056"
 "checksum cmake 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ebbb35d3dc9cd09497168f33de1acb79b265d350ab0ac34133b98f8509af1f"
@@ -392,7 +399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "48b04779552e92037212c3615370f6bd57a40ebba7f20e554ff9f55e41a69a7b"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-"checksum syntect 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fed7a5661c5c42fe998c561efb12137381a4486702f41c95a1d7269f3cc8ca6a"
+"checksum syntect 1.7.2 (git+https://github.com/raphlinus/syntect)" = "<none>"
 "checksum time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "ffd7ccbf969a892bf83f1e441126968a07a3941c24ff522a26af9f9f4585d1a3"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bb08f9e670fab86099470b97cd2b252d6527f0b3cc1401acdb595ffc9dd288ff"

--- a/rust/syntect-plugin/Cargo.lock
+++ b/rust/syntect-plugin/Cargo.lock
@@ -5,7 +5,7 @@ dependencies = [
  "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntect 1.7.2 (git+https://github.com/raphlinus/syntect)",
+ "syntect 1.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "xi-plugin-lib 0.1.0",
 ]
 
@@ -314,8 +314,8 @@ dependencies = [
 
 [[package]]
 name = "syntect"
-version = "1.7.2"
-source = "git+https://github.com/raphlinus/syntect#489683054a0df02302615ef350d9edc10d1cfced"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -445,7 +445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "48b04779552e92037212c3615370f6bd57a40ebba7f20e554ff9f55e41a69a7b"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-"checksum syntect 1.7.2 (git+https://github.com/raphlinus/syntect)" = "<none>"
+"checksum syntect 1.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "882d5f0b5f1562edab9deabf6c194e68292f64e8fe99f9dc4ac0f74620ae07d6"
 "checksum time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "ffd7ccbf969a892bf83f1e441126968a07a3941c24ff522a26af9f9f4585d1a3"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bb08f9e670fab86099470b97cd2b252d6527f0b3cc1401acdb595ffc9dd288ff"

--- a/rust/syntect-plugin/Cargo.toml
+++ b/rust/syntect-plugin/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/google/xi-editor"
 description = "A syntax highlighting plugin based on syntect."
 
 [dependencies]
-syntect = { git = "https://github.com/raphlinus/syntect" }
+syntect = "1.7.3"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/rust/syntect-plugin/Cargo.toml
+++ b/rust/syntect-plugin/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/google/xi-editor"
 description = "A syntax highlighting plugin based on syntect."
 
 [dependencies]
-syntect = "1.5"
+syntect = { git = "https://github.com/raphlinus/syntect" }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/rust/syntect-plugin/src/main.rs
+++ b/rust/syntect-plugin/src/main.rs
@@ -91,7 +91,7 @@ impl<'a> PluginState<'a> {
     // Return true if there's any more work to be done.
     fn highlight_one_line(&mut self, ctx: &mut PluginCtx<State>) -> bool {
         if let Some(line_num) = ctx.get_frontier() {
-            print_err!("highlighting {}", line_num);
+            //print_err!("highlighting {}", line_num);
             let (line_num, offset, state) = ctx.get_prev(line_num);
             if offset != self.offset {
                 self.flush_spans(ctx);

--- a/rust/syntect-plugin/src/main.rs
+++ b/rust/syntect-plugin/src/main.rs
@@ -25,7 +25,7 @@ use xi_plugin_lib::plugin_base::ScopeSpan;
 use syntect::parsing::{ParseState, ScopeStack, SyntaxSet, SCOPE_REPO};
 use stackmap::{StackMap, LookupResult};
 
-
+/// The state for syntax highlighting of one file.
 struct PluginState<'a> {
     syntax_set: &'a SyntaxSet,
     stack_idents: StackMap,
@@ -37,6 +37,15 @@ struct PluginState<'a> {
     new_scopes: Vec<Vec<String>>,
     syntax_name: String,
 }
+
+const LINES_PER_RPC: usize = 50;
+
+/// The syntax highlighting state corresponding to the beginning of a line
+/// (as stored in the state cache).
+// Note: this needs to be option because the caching layer relies on Default.
+// We can't implement that because the actual initial state depends on the
+// syntax. There are other ways to handle this, but this will do for now.
+type State = Option<(ParseState, ScopeStack)>;
 
 
 impl<'a> PluginState<'a> {
@@ -164,14 +173,7 @@ impl<'a> PluginState<'a> {
     }
 }
 
-const LINES_PER_RPC: usize = 50;
-
-// TODO: this needs to be option because the caching layer relies on Default.
-// We can't implement that because the actual initial state depends on the
-// syntax. There are other ways to handle this, but this will do for now.
-type State = Option<(ParseState, ScopeStack)>;
-
-impl<'a> state_cache::Handler for PluginState<'a> {
+impl<'a> state_cache::Plugin for PluginState<'a> {
     type State = State;
 
     fn initialize(&mut self, ctx: PluginCtx<State>, _buf_size: usize) {

--- a/rust/syntect-plugin/src/stackmap.rs
+++ b/rust/syntect-plugin/src/stackmap.rs
@@ -62,7 +62,7 @@ impl Node {
             // if key exists, value still might not be assigned:
             let needs_value = self.children.get(first).unwrap().value.is_none();
             if needs_value {
-                let mut node = self.children.get_mut(first).unwrap();
+                let node = self.children.get_mut(first).unwrap();
                 node.value = Some(next_id);
                 return LookupResult::New(next_id)
             } else {


### PR DESCRIPTION
This sequence of patches significantly improves the performance of syntax highlighting, using a smart caching approach to retain syntect state for some of the lines of the source file. The eviction policy for the cache is designed to balance LRU-like behavior and also keep the average gap between entries small; the latter minimizes recomputing the highlights, especially for large files.

This is an implementation of the concepts in the "rope science 11" blog post.

End to end performance is significantly improved (especially latency between an edit and the correct highlighting) but there are still issues due to the lack of minimal invalidation. Ironically, on large files responsiveness is often better on debug builds than release builds, because in the former case syntect is so slow computing the highlighting that the (largely macOS-limited) front end can keep up.

Some rough edges (and a number of TODOs) remain but it feels fairly solid. I've been using this as my daily driver.