### PR TITLE
refactor core-lib to use typed RPC system

### DIFF
--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -12,7 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! RPC handling for communications with front-end.
+//! The main RPC protocol, for communication between `xi-core` and the client.
+//!
+//! We rely on [Serde] for serialization and deserialization between
+//! the JSON-RPC protocol and the types here.
+//!
+//! [Serde]: https://serde.rs
+
 
 use serde_json::{self, Value};
 use serde::de::{self, Deserialize, Deserializer};
@@ -27,29 +33,227 @@ use plugins::PlaceholderRpc;
 // =============================================================================
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[doc(hidden)]
 pub struct EmptyStruct {}
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "method", content = "params")]
+/// The notifications which make up the base of the protocol.
+///
+/// # Note
+///
+/// For serialization, all identifiers are converted to "snake_case".
+/// 
+/// # Examples
+///
+/// The `close_view` command:
+///
+/// ```
+/// # extern crate xi_core_lib as xi_core;
+/// extern crate serde_json;
+/// # fn main() {
+/// use xi_core::rpc::CoreNotification;
+///
+/// let json = r#"{
+///     "method": "close_view",
+///     "params": { "view_id": "view-id-1" }
+///     }"#;
+///
+/// let cmd: CoreNotification = serde_json::from_str(&json).unwrap();
+/// match cmd {
+///     CoreNotification::CloseView { .. } => (), // expected
+///     other => panic!("Unexpected variant"),
+/// }
+/// # }
+/// ```
+///
+/// The `client_started` command:
+///
+/// ```
+/// # extern crate xi_core_lib as xi_core;
+/// extern crate serde_json;
+/// # fn main() {
+/// use xi_core::rpc::CoreNotification;
+///
+/// let json = r#"{
+///     "method": "client_started",
+///     "params": {}
+///     }"#;
+///
+/// let cmd: CoreNotification = serde_json::from_str(&json).unwrap();
+/// match cmd {
+///     CoreNotification::ClientStarted( .. )  => (), // expected
+///     other => panic!("Unexpected variant"),
+/// }
+/// # }
+/// ```
 pub enum CoreNotification {
+    /// The 'edit' namespace, for view-specific editor actions.
+    ///
+    /// The params object has internal `method` and `params` members,
+    /// which are parsed into the appropriate `EditNotification`.
+    ///
+    /// # Note:
+    ///
+    /// All edit commands (notifications and requests) include in their
+    /// inner params object a `view_id` field. On the xi-core side, we
+    /// pull out this value during parsing, and use it for routing.
+    ///
+    /// For more on the edit commands, see [`EditNotification`] and
+    /// [`EditRequest`].
+    ///
+    /// [`EditNotification`]: enum.EditNotification.html
+    /// [`EditRequest`]: enum.EditRequest.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate xi_core_lib as xi_core;
+    /// #[macro_use]
+    /// extern crate serde_json;
+    /// use xi_core::rpc::*;
+    /// # fn main() {
+    /// let edit = EditCommand {
+    ///     view_id: "view-id-1".into(),
+    ///     cmd: EditNotification::Insert { chars: "hello!".into() },
+    /// };
+    /// let rpc = CoreNotification::Edit(edit);
+    /// let expected = json!({
+    ///     "method": "edit",
+    ///     "params": {
+    ///         "method": "insert",
+    ///         "params": {
+    ///             "view_id": "view-id-1",
+    ///             "chars": "hello!",
+    ///         }
+    ///     }
+    /// });
+    /// assert_eq!(serde_json::to_value(&rpc).unwrap(), expected);
+    /// # }
+    /// ```
     Edit(EditCommand<EditNotification>),
+    /// The 'plugin' namespace, for interacting with plugins.
+    ///
+    /// As with edit commands, the params object has is a nested RPC,
+    /// with the name of the command included as the `command` field.
+    ///
+    /// (this should be changed to more accurately reflect the behaviour
+    /// of the edit commands).
+    ///
+    ///For the available commands, see [`PluginNotification`].
+    ///
+    /// [`PluginNotification`]: enum.PluginNotification.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate xi_core_lib as xi_core;
+    /// #[macro_use]
+    /// extern crate serde_json;
+    /// use xi_core::rpc::*;
+    /// # fn main() {
+    /// let rpc = CoreNotification::Plugin(
+    ///     PluginNotification::Start {
+    ///         view_id: "view-id-1".into(),
+    ///         plugin_name: "syntect".into(),
+    ///     });
+    ///
+    /// let expected = json!({
+    ///     "method": "plugin",
+    ///     "params": {
+    ///         "command": "start",
+    ///         "view_id": "view-id-1",
+    ///         "plugin_name": "syntect",
+    ///     }
+    /// });
+    /// assert_eq!(serde_json::to_value(&rpc).unwrap(), expected);
+    /// # }
+    /// ```
     Plugin(PluginNotification),
+    /// Tells `xi-core` to close the specified view.
     CloseView { view_id: ViewIdentifier },
+    /// Tells `xi-core` to save the contents of the specified view's
+    /// buffer to the specified path.
     Save { view_id: ViewIdentifier, file_path: String },
+    /// Tells `xi-core` to set the theme.
     SetTheme { theme_name: String },
+    /// Notifies `xi-core` that the client has started.
+    //TODO: this should be a unit, but we have a minor issue with serde.
+    //see https://github.com/google/xi-editor/issues/400
     ClientStarted(EmptyStruct),
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "method", content = "params")]
+/// The requests which make up the base of the protocol.
+///
+/// All requests expect a response.
+///
+/// # Examples
+///
+/// The `new_view` command:
+/// ```
+/// # extern crate xi_core_lib as xi_core;
+/// extern crate serde_json;
+/// # fn main() {
+/// use xi_core::rpc::CoreRequest;
+///
+/// let json = r#"{
+///     "method": "new_view",
+///     "params": { "file_path": "~/my_very_fun_file.rs" }
+///     }"#;
+///
+/// let cmd: CoreRequest = serde_json::from_str(&json).unwrap();
+/// match cmd {
+///     CoreRequest::NewView { .. } => (), // expected
+///     other => panic!("Unexpected variant {:?}", other),
+/// }
+/// # }
+/// ```
 pub enum CoreRequest {
+    /// The 'edit' namespace, for view-specific requests.
     Edit(EditCommand<EditRequest>),
+    /// Tells `xi-core` to create a new view. If the `file_path`
+    /// argument is present, `xi-core` should attemp to open the file
+    /// at that location.
+    ///
+    /// Returns the view identifier that should be used to interact
+    /// with the newly created view.
     NewView { file_path: Option<String> },
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// A helper type, which extracts the `view_id` field from edit
+/// requests and notifications.
+///
+/// Edit requests and notifications have 'method', 'params', and
+/// 'view_id' param members. We use this wrapper, which has custom
+/// `Deserialize` and `Serialize` implementations, to pull out the
+/// `view_id` field.
+///
+/// # Examples
+///
+/// ```
+/// # extern crate xi_core_lib as xi_core;
+/// extern crate serde_json;
+/// # fn main() {
+/// use xi_core::rpc::*;
+///
+/// let json = r#"{
+///     "view_id": "view-id-1",
+///     "method": "scroll",
+///     "params": [0, 6]
+///     }"#;
+///
+/// let cmd: EditCommand<EditNotification> = serde_json::from_str(&json).unwrap();
+/// match cmd.cmd {
+///     EditNotification::Scroll( .. ) => (), // expected
+///     other => panic!("Unexpected variant {:?}", other),
+/// }
+/// # }
+/// ```
 pub struct EditCommand<T> {
     pub view_id: ViewIdentifier,
     pub cmd: T,
@@ -62,16 +266,22 @@ pub enum GestureType {
     ToggleSel,
 }
 
-// NOTE:
-// Several core protocol commands use a params array to pass arguments
-// which are named, internally. these two types use custom Serialize /
-// Deserialize impls to accomodate this.
+/// An inclusive range.
+///
+/// # Note:
+///
+/// Several core protocol commands use a params array to pass arguments
+/// which are named, internally. this type use custom Serialize /
+/// Deserialize impls to accomodate this.
 #[derive(PartialEq, Eq, Debug)]
 pub struct LineRange {
     pub first: i64,
     pub last: i64,
 }
 
+/// A mouse event. See the note for [`LineRange`].
+///
+/// [`LineRange`]: enum.LineRange.html
 #[derive(PartialEq, Eq, Debug)]
 pub struct MouseAction {
     pub line: u64,
@@ -83,6 +293,10 @@ pub struct MouseAction {
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "method", content = "params")]
+/// The edit-related notifications.
+///
+/// Alongside the [`EditRequest`] members, these commands constitute
+/// the API for interacting with a particular window and document.
 pub enum EditNotification {
     Insert { chars: String },
     DeleteForward,
@@ -139,15 +353,26 @@ pub enum EditNotification {
     FindNext { wrap_around: Option<bool>, allow_same: Option<bool> },
     FindPrevious { wrap_around: Option<bool> },
     DebugRewrap,
+    /// Prints the style spans present in the active selection.
     DebugPrintSpans,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "method", content = "params")]
+/// The edit related requests.
 pub enum EditRequest {
+    /// Cuts the active selection, returning their contents,
+    /// or `Null` if the selection was empty.
     Cut,
+    /// Copies the active selection, returning their contents or
+    /// or `Null` if the selection was empty.
     Copy,
+    /// Searches the document for `chars`, if present, falling back on
+    /// the last selection region if `chars` is `None`.
+    ///
+    /// If `chars` is `None` and there is an active selection, returns
+    /// the string value used for the search, else returns `Null`.
     Find { chars: Option<String>, case_sensitive: bool },
 }
 
@@ -155,6 +380,7 @@ pub enum EditRequest {
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(tag = "command")]
 #[serde(rename_all = "snake_case")]
+/// The plugin related notifications.
 pub enum PluginNotification {
     Start { view_id: ViewIdentifier, plugin_name: String },
     Stop { view_id: ViewIdentifier, plugin_name: String },

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -14,66 +14,77 @@
 
 //! RPC handling for communications with front-end.
 
-use std::error;
-use std::fmt;
 use serde_json::{self, Value};
-use xi_rpc::{dict_get_u64, dict_get_string, dict_get_bool, arr_get_u64, arr_get_i64};
+use serde::de::{self, Deserialize, Deserializer};
+use serde::ser::{self, Serialize, Serializer};
+
 use tabs::ViewIdentifier;
 use plugins::PlaceholderRpc;
 
-// =============================================================================
-//  Request handling
-// =============================================================================
-
-impl<'a> Request<'a> {
-    pub fn from_json(method: &'a str, params: &'a Value) -> Result<Self, Error> {
-        CoreCommand::from_json(method, params).map(|cmd|
-            Request::CoreCommand { core_command: cmd})
-    }
-}
 
 // =============================================================================
 //  Command types
 // =============================================================================
 
-#[derive(Debug, PartialEq)]
-pub enum Request<'a> {
-    CoreCommand { core_command: CoreCommand<'a> }
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct EmptyStruct {}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
+#[serde(tag = "method", content = "params")]
+pub enum CoreNotification {
+    Edit(EditCommand<EditNotification>),
+    Plugin(PluginNotification),
+    CloseView { view_id: ViewIdentifier },
+    Save { view_id: ViewIdentifier, file_path: String },
+    SetTheme { theme_name: String },
+    ClientStarted(EmptyStruct),
 }
 
-/// An enum representing a core command, parsed from JSON.
-#[derive(Debug, PartialEq)]
-pub enum CoreCommand<'a> {
-    Edit { view_id: ViewIdentifier, edit_command: EditCommand<'a> },
-    /// A command from the client to a plugin.
-    Plugin {  plugin_command: PluginCommand },
-    /// Request a new view, opening a file if `file_path` is Some, else creating an empty buffer.
-    NewView { file_path: Option<&'a str> },
-    CloseView { view_id: ViewIdentifier },
-    Save { view_id: ViewIdentifier, file_path: &'a str },
-    SetTheme { theme_name: &'a str },
-    ClientStarted
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
+#[serde(tag = "method", content = "params")]
+pub enum CoreRequest {
+    Edit(EditCommand<EditRequest>),
+    NewView { file_path: Option<String> },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct EditCommand<T> {
+    pub view_id: ViewIdentifier,
+    pub cmd: T,
 }
 
 /// An enum representing touch and mouse gestures applied to the text.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum GestureType {
     ToggleSel,
 }
 
-impl GestureType {
-    fn from_str(s: &str) -> Option<GestureType> {
-        match s {
-            "toggle_sel" => Some(GestureType::ToggleSel),
-            _ => None
-        }
-    }
+// NOTE:
+// Several core protocol commands use a params array to pass arguments
+// which are named, internally. these two types use custom Serialize /
+// Deserialize impls to accomodate this.
+#[derive(PartialEq, Eq, Debug)]
+pub struct LineRange {
+    pub first: i64,
+    pub last: i64,
 }
 
-/// An enum representing an edit command, parsed from JSON.
-#[derive(Debug, PartialEq, Eq)]
-pub enum EditCommand<'a> {
-    Insert { chars: &'a str },
+#[derive(PartialEq, Eq, Debug)]
+pub struct MouseAction {
+    pub line: u64,
+    pub column: u64,
+    pub flags: u64,
+    pub click_count: Option<u64>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
+#[serde(tag = "method", content = "params")]
+pub enum EditNotification {
+    Insert { chars: String },
     DeleteForward,
     DeleteBackward,
     DeleteWordForward,
@@ -87,8 +98,12 @@ pub enum EditCommand<'a> {
     MoveDown,
     MoveDownAndModifySelection,
     MoveLeft,
+    // synoynm for `MoveLeft`
+    MoveBackward,
     MoveLeftAndModifySelection,
     MoveRight,
+    // synoynm for `MoveRight`
+    MoveForward,
     MoveRightAndModifySelection,
     MoveWordLeft,
     MoveWordLeftAndModifySelection,
@@ -111,253 +126,129 @@ pub enum EditCommand<'a> {
     SelectAll,
     AddSelectionAbove,
     AddSelectionBelow,
-    Scroll { first: i64, last: i64 },
+    Scroll(LineRange),
     GotoLine { line: u64 },
-    RequestLines { first: i64, last: i64 },
+    RequestLines(LineRange),
     Yank,
     Transpose,
-    Click { line: u64, column: u64, flags: u64, click_count: u64 },
-    Drag { line: u64, column: u64, flags: u64 },
+    Click(MouseAction),
+    Drag(MouseAction),
     Gesture { line: u64, column: u64, ty: GestureType},
     Undo,
     Redo,
-    Cut,
-    Copy,
-    Find { chars: Option<&'a str>, case_sensitive: bool },
-    FindNext { wrap_around: bool, allow_same: bool },
-    FindPrevious { wrap_around: bool },
+    FindNext { wrap_around: Option<bool>, allow_same: Option<bool> },
+    FindPrevious { wrap_around: Option<bool> },
     DebugRewrap,
     DebugPrintSpans,
 }
 
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
+#[serde(tag = "method", content = "params")]
+pub enum EditRequest {
+    Cut,
+    Copy,
+    Find { chars: Option<String>, case_sensitive: bool },
+}
 
-//TODO: just prototyping, these should be borrows
+
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(tag = "command")]
 #[serde(rename_all = "snake_case")]
-pub enum PluginCommand {
+pub enum PluginNotification {
     Start { view_id: ViewIdentifier, plugin_name: String },
     Stop { view_id: ViewIdentifier, plugin_name: String },
     PluginRpc { view_id: ViewIdentifier, receiver: String, rpc: PlaceholderRpc },
 }
 
-impl<'a> CoreCommand<'a> {
-    pub fn from_json(method: &str, params: &'a Value) -> Result<Self, Error> {
-        use self::CoreCommand::*;
-        use self::Error::*;
+// Serialize / Deserialize
 
-        match method {
-            "close_view" => params.as_object().and_then(|dict| {
-                dict_get_string(dict, "view_id").map(|view_id| CloseView { view_id: ViewIdentifier::from(view_id) })
-            }).ok_or_else(|| MalformedCoreParams(method.to_string(), params.clone())),
-
-            "new_view" => params.as_object()
-                .map(|dict| NewView { file_path: dict_get_string(dict, "file_path") }) // optional
-                .ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
-
-            "set_theme" => params.as_object().and_then(|dict| {
-                dict_get_string(dict, "theme_name").map(|theme_name| SetTheme { theme_name: theme_name })
-            }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
-
-            "save" => params.as_object().and_then(|dict| {
-                dict_get_string(dict, "view_id").and_then(|view_id| {
-                    dict_get_string(dict, "file_path").map(|file_path| {
-                        Save { view_id: ViewIdentifier::from(view_id), file_path: file_path }
-                       })
-                    })
-                }).ok_or_else(|| MalformedCoreParams(method.to_string(), params.clone())),
-
-            "edit" => params.as_object()
-                .ok_or_else(|| MalformedCoreParams(method.to_string(), params.clone()))
-                .and_then(|dict| {
-                    if let (Some(view_id), Some(method), Some(edit_params)) =
-                        (dict_get_string(dict, "view_id"), dict_get_string(dict, "method"), dict.get("params")) {
-                            EditCommand::from_json(method, edit_params)
-                                .map(|cmd| Edit { view_id: ViewIdentifier::from(view_id), edit_command: cmd })
-                        } else { Err(MalformedCoreParams(method.to_string(), params.clone())) }
-                }),
-            "plugin" => serde_json::from_value::<PluginCommand>(params.clone())
-                .map(|cmd| Plugin { plugin_command: cmd })
-                .map_err(|_| MalformedPluginParams(method.to_string(), params.clone())),
-
-            "client_started" => Ok(ClientStarted),
-
-            _ => Err(UnknownCoreMethod(method.to_string()))
-        }
+impl<T: Serialize> Serialize for EditCommand<T>
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        let mut v = serde_json::to_value(&self.cmd).map_err(ser::Error::custom)?;
+        v["params"]["view_id"] = json!(self.view_id);
+        v.serialize(serializer)
     }
 }
 
-impl<'a> EditCommand<'a> {
-    /// Try to read an edit command with the given method and parameters.
-    pub fn from_json(method: &str, params: &'a Value) -> Result<Self, Error> {
-        use self::EditCommand::*;
-        use self::Error::*;
-
-        match method {
-            "insert" => params.as_object().and_then(|dict| {
-                dict_get_string(dict, "chars").map(|chars| Insert { chars: chars })
-            }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
-
-            "delete_forward" => Ok(DeleteForward),
-            "delete_backward" => Ok(DeleteBackward),
-            "delete_word_forward" => Ok(DeleteWordForward),
-            "delete_word_backward" => Ok(DeleteWordBackward),
-            "delete_to_end_of_paragraph" => Ok(DeleteToEndOfParagraph),
-            "delete_to_beginning_of_line" => Ok(DeleteToBeginningOfLine),
-            "insert_newline" => Ok(InsertNewline),
-            "insert_tab" => Ok(InsertTab),
-            "move_up" => Ok(MoveUp),
-            "move_up_and_modify_selection" => Ok(MoveUpAndModifySelection),
-            "move_down" => Ok(MoveDown),
-            "move_down_and_modify_selection" => Ok(MoveDownAndModifySelection),
-            "move_left" | "move_backward" => Ok(MoveLeft),
-            "move_left_and_modify_selection" => Ok(MoveLeftAndModifySelection),
-            "move_word_left" => Ok(MoveWordLeft),
-            "move_word_left_and_modify_selection" => Ok(MoveWordLeftAndModifySelection),
-            "move_word_right" => Ok(MoveWordRight),
-            "move_word_right_and_modify_selection" => Ok(MoveWordRightAndModifySelection),
-            "move_right" | "move_forward" => Ok(MoveRight),
-            "move_right_and_modify_selection" => Ok(MoveRightAndModifySelection),
-            "move_to_beginning_of_paragraph" => Ok(MoveToBeginningOfParagraph),
-            "move_to_end_of_paragraph" => Ok(MoveToEndOfParagraph),
-            "move_to_left_end_of_line" => Ok(MoveToLeftEndOfLine),
-            "move_to_left_end_of_line_and_modify_selection" => Ok(MoveToLeftEndOfLineAndModifySelection),
-            "move_to_right_end_of_line" => Ok(MoveToRightEndOfLine),
-            "move_to_right_end_of_line_and_modify_selection" => Ok(MoveToRightEndOfLineAndModifySelection),
-            "move_to_beginning_of_document" => Ok(MoveToBeginningOfDocument),
-            "move_to_beginning_of_document_and_modify_selection" => Ok(MoveToBeginningOfDocumentAndModifySelection),
-            "move_to_end_of_document" => Ok(MoveToEndOfDocument),
-            "move_to_end_of_document_and_modify_selection" => Ok(MoveToEndOfDocumentAndModifySelection),
-            "scroll_page_up" | "page_up" => Ok(ScrollPageUp),
-            "page_up_and_modify_selection" => Ok(PageUpAndModifySelection),
-            "scroll_page_down" |
-            "page_down" => Ok(ScrollPageDown),
-            "page_down_and_modify_selection" => Ok(PageDownAndModifySelection),
-            "select_all" => Ok(SelectAll),
-            "add_selection_above" => Ok(AddSelectionAbove),
-            "add_selection_below" => Ok(AddSelectionBelow),
-
-            "scroll" => params.as_array().and_then(|arr| {
-                if let (Some(first), Some(last)) =
-                    (arr_get_i64(arr, 0), arr_get_i64(arr, 1)) {
-
-                    Some(Scroll { first: first, last: last })
-                } else { None }
-            }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
-
-            "goto_line" => params.as_object().and_then(|dict| {
-                dict_get_u64(dict, "line").map(|line| GotoLine { line: line })
-            }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
-
-            "request_lines" => params.as_array().and_then(|arr| {
-                if let (Some(first), Some(last)) =
-                    (arr_get_i64(arr, 0), arr_get_i64(arr, 1)) {
-
-                    Some(RequestLines { first: first, last: last })
-                } else { None }
-            }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
-
-            "yank" => Ok(Yank),
-            "transpose" => Ok(Transpose),
-
-            "click" => params.as_array().and_then(|arr| {
-                if let (Some(line), Some(column), Some(flags), Some(click_count)) =
-                    (arr_get_u64(arr, 0), arr_get_u64(arr, 1), arr_get_u64(arr, 2), arr_get_u64(arr, 3)) {
-
-                        Some(Click { line: line, column: column, flags: flags, click_count: click_count })
-                    } else { None }
-            }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
-
-            "drag" => params.as_array().and_then(|arr| {
-                if let (Some(line), Some(column), Some(flags)) =
-                    (arr_get_u64(arr, 0), arr_get_u64(arr, 1), arr_get_u64(arr, 2)) {
-
-                        Some(Drag { line: line, column: column, flags: flags })
-                    } else { None }
-            }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
-
-            "gesture" => params.as_object().and_then(|dict| {
-                if let (Some(line), Some(column), Some(ty)) =
-                    (dict_get_u64(dict, "line"),
-                        dict_get_u64(dict, "col"),
-                        dict_get_string(dict, "ty").and_then(GestureType::from_str))
-                {
-                    Some(Gesture { line: line, column: column, ty: ty })
-                } else { None }
-            }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
-
-            "undo" => Ok(Undo),
-            "redo" => Ok(Redo),
-            "cut" => Ok(Cut),
-            "copy" => Ok(Copy),
-
-            "find" => params.as_object().map(|dict| {
-                let chars = dict_get_string(dict, "chars");
-                let case_sensitive = dict_get_bool(dict, "case_sensitive").unwrap_or(false);
-                Find { chars: chars, case_sensitive: case_sensitive }
-            }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
-            "find_next" =>  params.as_object().map(|dict| {
-                let wrap_around = dict_get_bool(dict, "wrap_around").unwrap_or(false);
-                let allow_same = dict_get_bool(dict, "allow_same").unwrap_or(false);
-                FindNext { wrap_around: wrap_around, allow_same: allow_same }
-            }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
-            "find_previous" =>  params.as_object().map(|dict| {
-                let wrap_around = dict_get_bool(dict, "wrap_around").unwrap_or(false);
-                FindPrevious { wrap_around: wrap_around }
-            }).ok_or_else(|| MalformedEditParams(method.to_string(), params.clone())),
-
-            "debug_rewrap" => Ok(DebugRewrap),
-            "debug_print_spans" => Ok(DebugPrintSpans),
-
-            _ => Err(UnknownEditMethod(method.to_string())),
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for EditCommand<T>
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>
+    {
+        #[derive(Deserialize)]
+        struct InnerId {
+            view_id: ViewIdentifier,
         }
+
+        let mut v = Value::deserialize(deserializer)?;
+        let helper = InnerId::deserialize(&v).map_err(de::Error::custom)?;
+        let InnerId { view_id } = helper;
+        // if params are empty, remove them
+        let remove_params = match v.get("params") {
+            Some(&Value::Object(ref obj)) => obj.is_empty(),
+            Some(&Value::Array(ref arr)) => arr.is_empty(),
+            Some(_) => return Err(de::Error::custom("'params' field, if present, must be object or array.")),
+            None => false,
+        };
+
+        if remove_params {
+            v.as_object_mut().map(|v| v.remove("params"));
+        }
+
+        let cmd = T::deserialize(v).map_err(de::Error::custom)?;
+        Ok(EditCommand { view_id, cmd })
     }
 }
 
-// =============================================================================
-//  Error types
-// =============================================================================
+impl Serialize for MouseAction
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        #[derive(Serialize)]
+        struct Helper(u64, u64, u64, Option<u64>);
 
-/// An error that occurred while parsing an edit command.
-#[derive(Debug, PartialEq)]
-pub enum Error {
-    UnknownCoreMethod(String), // method name
-    MalformedCoreParams(String, Value), // method name, malformed params
-    UnknownEditMethod(String), // method name
-    MalformedEditParams(String, Value), // method name, malformed params
-    MalformedPluginParams(String, Value), // method name, malformed params
-}
-
-impl fmt::Display for Error {
-    // TODO: Provide information about the parameter format expected when
-    // displaying malformed parameter errors
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::Error::*;
-
-        match *self {
-            UnknownCoreMethod(ref method) => write!(f, "Error: Unknown core method '{}'", method),
-            MalformedCoreParams(ref method, ref params) =>
-                write!(f, "Error: Malformed core parameters with method '{}', parameters: {:?}", method, params),
-            UnknownEditMethod(ref method) => write!(f, "Error: Unknown edit method '{}'", method),
-            MalformedEditParams(ref method, ref params) =>
-                write!(f, "Error: Malformed edit parameters with method '{}', parameters: {:?}", method, params),
-
-            MalformedPluginParams(ref method, ref params) =>
-                write!(f, "Error: Malformed plugin parameters with method '{}', parameters: {:?}", method, params),
-        }
+        let as_tup = Helper(self.line, self.column, self.flags, self.click_count);
+        let v = serde_json::to_value(&as_tup).map_err(ser::Error::custom)?;
+        v.serialize(serializer)
     }
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        use self::Error::*;
+impl<'de> Deserialize<'de> for MouseAction
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>
+    {
+        let v: Vec<u64> = Vec::deserialize(deserializer)?;
+        let click_count = if v.len() == 4 { Some(v[3]) } else { None };
+        Ok(MouseAction { line: v[0], column: v[1], flags: v[2], click_count: click_count })
+    }
+}
 
-        match *self {
-            UnknownCoreMethod(_) => "Unknown core method",
-            MalformedCoreParams(_, _) => "Malformed core parameters",
-            UnknownEditMethod(_) => "Unknown edit method",
-            MalformedEditParams(_, _) => "Malformed edit parameters",
-            MalformedPluginParams(_, _) => "Malformed plugin parameters",
-        }
+impl Serialize for LineRange
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        let as_tup = (self.first, self.last);
+        let v = serde_json::to_value(&as_tup).map_err(ser::Error::custom)?;
+        v.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for LineRange
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>
+    {
+        #[derive(Deserialize)]
+        struct TwoTuple(i64, i64);
+
+        let tup = TwoTuple::deserialize(deserializer)?;
+        Ok(LineRange { first: tup.0, last: tup.1 })
     }
 }


### PR DESCRIPTION
This builds on the work done in #393.

A benefit of this work is that (potentially) the generated documentation for `core_lib::rpc` can eventually serve as the canonical documentation of the RPC protocol, using doctests to ensure that the documentation is up to date with protocol changes.