### PR TITLE
Revert unintended "col" to "column" rename

### DIFF
--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -985,7 +985,7 @@ impl Editor {
             Drag (MouseAction {line, column, flags, ..}) => {
                 self.do_drag(line, column, flags);
             }
-            Gesture { line, column, ty } => self.do_gesture(line, column, ty),
+            Gesture { line, col, ty } => self.do_gesture(line, col, ty),
             Undo => self.do_undo(),
             Redo => self.do_redo(),
             FindNext { wrap_around, allow_same } => self.do_find_next(false, wrap_around.unwrap_or(false), allow_same.unwrap_or(false)),

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -347,7 +347,7 @@ pub enum EditNotification {
     Transpose,
     Click(MouseAction),
     Drag(MouseAction),
-    Gesture { line: u64, column: u64, ty: GestureType},
+    Gesture { line: u64, col: u64, ty: GestureType},
     Undo,
     Redo,
     FindNext { wrap_around: Option<bool>, allow_same: Option<bool> },

--- a/rust/core-lib/tests/rpc.rs
+++ b/rust/core-lib/tests/rpc.rs
@@ -210,6 +210,7 @@ const OTHER_EDIT_RPCS: &str = r#"{"method":"edit","params":{"view_id":"view-id-1
 {"method":"edit","params":{"view_id":"view-id-1","method":"request_lines","params":[0,1]}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"click","params":[6,0,0,1]}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"drag","params":[17,15,0]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"gesture","params":{"line": 1, "col": 2, "ty": "toggle_sel"}}}
 {"id":4,"method":"edit","params":{"view_id":"view-id-1","method":"find","params":{"case_sensitive":false,"chars":"m"}}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"find_next","params":{"wrap_around":true}}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"find_previous","params":{"wrap_around":true}}}


### PR DESCRIPTION
The recent RPC changes renamed the "col" parameter in the "gesture"
command to "column", which broke gestures. This reverts that change.