### PR TITLE
Barebones user config, plus plugin loading

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -61,6 +61,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +158,14 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "odds 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nom"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -310,6 +329,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "typenum"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,12 +370,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "xi-core-lib"
 version = "0.2.0"
 dependencies = [
+ "config 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntect 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "xi-rope 0.2.0",
  "xi-rpc 0.2.0",
  "xi-unicode 0.1.0",
@@ -395,6 +424,7 @@ dependencies = [
 "checksum bytecount 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1e8f09fbc8c6726a4b616dcfbd4f54491068d6bb1b93ac03c78ac18ff9a5924a"
 "checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
 "checksum chrono 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d9123be86fd2a8f627836c235ecdf331fdd067ecf7ac05aa1a68fbcf2429f056"
+"checksum config 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "257ad7eba1f5e97f478f9a98f4e70b0c4fab8fb85df99681c1a98aed824223ed"
 "checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
 "checksum digest 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a68d759d7a66a4f63d5bd2a2b14ad7e8cf93fe8c9be227031cd4e72ab0e9ee8"
 "checksum digest-buffer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4eb92364e9f6d3da159257250532d448b218406d2acb149f724e8f48e9f5cb9a"
@@ -408,6 +438,7 @@ dependencies = [
 "checksum libflate 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "59fa4619e0f202f63fde6046eafe0e754e829369c5e892abeca0c22a12dcfec9"
 "checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
 "checksum nodrop 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "52cd74cd09beba596430cc6e3091b74007169a56246e1262f0ba451ea95117b2"
+"checksum nom 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06989cbd367e06f787a451f3bc67d8c3e0eaa10b461cc01152ffab24261a31b1"
 "checksum num 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "2c3a3dc9f30bf824141521b30c908a859ab190b76e20435fcd89f35eb6583887"
 "checksum num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "ef1a4bf6f9174aa5783a9b4cc892cacd11aebad6c69ad027a0b65c6ca5f8aa37"
 "checksum num-iter 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "f7d1891bd7b936f12349b7d1403761c8a0b85a18b148e9da4429d5d102c1a41e"
@@ -426,6 +457,7 @@ dependencies = [
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum syntect 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f436345e5b6ebbfdf51b20b95cd9bcb82576262c340bad9cf815078d76b082a"
 "checksum time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "ffd7ccbf969a892bf83f1e441126968a07a3941c24ff522a26af9f9f4585d1a3"
+"checksum toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7540f4ffc193e0d3c94121edb19b055670d369f77d5804db11ae053a45b6e7e"
 "checksum typenum 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7242a7857c31d13620847d78af39ecac8d6c90aac23286e84aefe624c77c9c14"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bb08f9e670fab86099470b97cd2b252d6527f0b3cc1401acdb595ffc9dd288ff"

--- a/rust/core-lib/Cargo.toml
+++ b/rust/core-lib/Cargo.toml
@@ -11,6 +11,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 time = "0.1"
+toml = "0.4"
 
 xi-rope = { path = "../rope", version = "0.2" }
 xi-unicode = { path = "../unicode", version = "0.1.0" }

--- a/rust/core-lib/Cargo.toml
+++ b/rust/core-lib/Cargo.toml
@@ -11,11 +11,15 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 time = "0.1"
-toml = "0.4"
 
 xi-rope = { path = "../rope", version = "0.2" }
 xi-unicode = { path = "../unicode", version = "0.1.0" }
 xi-rpc = { path = "../rpc", version = "0.2.0" }
+
+[dependencies.config]
+version = "0.7"
+default-features = false
+features = ["toml"]
 
 [dependencies.syntect]
 version = "1.7"

--- a/rust/core-lib/assets/defaults.toml
+++ b/rust/core-lib/assets/defaults.toml
@@ -1,0 +1,7 @@
+theme = "base16-ocean.light"
+font_face = "InconsolataGo"
+font_size = 14
+
+tab_size = 4
+translate_tabs_to_spaces = false
+plugin_search_path = ["plugins"]

--- a/rust/core-lib/assets/defaults.toml
+++ b/rust/core-lib/assets/defaults.toml
@@ -1,7 +1,3 @@
-theme = "base16-ocean.light"
-font_face = "InconsolataGo"
-font_size = 14
-
 tab_size = 4
 translate_tabs_to_spaces = true
 plugin_search_path = ["plugins"]

--- a/rust/core-lib/assets/defaults.toml
+++ b/rust/core-lib/assets/defaults.toml
@@ -3,5 +3,5 @@ font_face = "InconsolataGo"
 font_size = 14
 
 tab_size = 4
-translate_tabs_to_spaces = false
+translate_tabs_to_spaces = true
 plugin_search_path = ["plugins"]

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -40,6 +40,7 @@ use plugins::rpc_types::{PluginUpdate, PluginEdit, ScopeSpan, PluginBufferInfo,
 ClientPluginInfo};
 use plugins::{PluginPid, Command};
 use layers::Scopes;
+use prefs::Config;
 
 
 #[cfg(not(target_os = "fuchsia"))]
@@ -52,8 +53,6 @@ const FLAG_SELECT: u64 = 2;
 // TODO This could go much higher without issue but while developing it is
 // better to keep it low to expose bugs in the GC during casual testing.
 const MAX_UNDOS: usize = 20;
-
-const TAB_SIZE: usize = 4;
 
 // Maximum returned result from plugin get_data RPC.
 const MAX_SIZE_LIMIT: usize = 1024 * 1024;
@@ -86,6 +85,7 @@ pub struct Editor {
 
     styles: Scopes,
     doc_ctx: DocumentCtx,
+    config: Config,
     revs_in_flight: usize,
 
     /// Used only on Fuchsia for syncing
@@ -118,13 +118,16 @@ impl EditType {
 
 impl Editor {
     /// Creates a new `Editor` with a new empty buffer.
-    pub fn new(doc_ctx: DocumentCtx, buffer_id: BufferIdentifier,
+    pub fn new(doc_ctx: DocumentCtx, config: Config,
+               buffer_id: BufferIdentifier,
                initial_view_id: &ViewIdentifier) -> Editor {
-        Self::with_text(doc_ctx, buffer_id, initial_view_id, "".to_owned())
+        Self::with_text(doc_ctx, config, buffer_id,
+                        initial_view_id, "".to_owned())
     }
 
     /// Creates a new `Editor`, loading text into a new buffer.
-    pub fn with_text(doc_ctx: DocumentCtx, buffer_id: BufferIdentifier,
+    pub fn with_text(doc_ctx: DocumentCtx, config: Config,
+                     buffer_id: BufferIdentifier,
                      initial_view_id: &ViewIdentifier, text: String) -> Editor {
 
         let engine = Engine::new(Rope::from(text));
@@ -154,6 +157,7 @@ impl Editor {
             scroll_to: Some(0),
             styles: Scopes::default(),
             doc_ctx: doc_ctx,
+            config: config,
             revs_in_flight: 0,
             sync_store: None,
             last_synced_rev: last_rev_id,
@@ -568,9 +572,17 @@ impl Editor {
         let mut builder = delta::Builder::new(self.text.len());
         for region in self.view.sel_regions() {
             let iv = Interval::new_closed_open(region.min(), region.max());
-            let (_, col) = self.view.offset_to_line_col(&self.text, region.start);
-            let n = TAB_SIZE - (col % TAB_SIZE);
-            builder.replace(iv, Rope::from(n_spaces(n)));
+            let tab_text = match self.config.get_bool("translate_tabs_to_spaces")
+                .unwrap() {
+                    true => {
+                        let (_, col) = self.view.offset_to_line_col(&self.text, region.start);
+                        let tab_size = self.config.get_int("tab_size").unwrap() as usize;
+                        let n = tab_size - (col % tab_size);
+                        n_spaces(n)
+                    }
+                    false => "\t",
+                };
+            builder.replace(iv, Rope::from(tab_text));
         }
         self.this_edit_type = EditType::InsertChars;
         self.add_delta(builder.build());

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -572,16 +572,14 @@ impl Editor {
         let mut builder = delta::Builder::new(self.text.len());
         for region in self.view.sel_regions() {
             let iv = Interval::new_closed_open(region.min(), region.max());
-            let tab_text = match self.config.get_bool("translate_tabs_to_spaces")
-                .unwrap() {
-                    true => {
-                        let (_, col) = self.view.offset_to_line_col(&self.text, region.start);
-                        let tab_size = self.config.get_int("tab_size").unwrap() as usize;
-                        let n = tab_size - (col % tab_size);
-                        n_spaces(n)
-                    }
-                    false => "\t",
-                };
+            let tab_text = if self.config.translate_tabs_to_spaces {
+                    let (_, col) = self.view.offset_to_line_col(&self.text, region.start);
+                    let tab_size = self.config.tab_size;
+                    let n = tab_size - (col % tab_size);
+                    n_spaces(n)
+            } else {
+                "\t"
+            };
             builder.replace(iv, Rope::from(tab_text));
         }
         self.this_edit_type = EditType::InsertChars;

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -64,6 +64,7 @@ pub mod internal {
     pub mod movement;
     pub mod syntax;
     pub mod layers;
+    pub mod prefs;
 }
 
 use internal::tabs;
@@ -78,6 +79,7 @@ use internal::selection;
 use internal::movement;
 use internal::syntax;
 use internal::layers;
+use internal::prefs;
 #[cfg(target_os = "fuchsia")]
 use internal::fuchsia;
 

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -21,6 +21,7 @@ extern crate serde_json;
 extern crate serde_derive;
 extern crate time;
 extern crate syntect;
+extern crate toml;
 
 #[cfg(target_os = "fuchsia")]
 extern crate magenta;

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -22,6 +22,7 @@ extern crate serde_derive;
 extern crate time;
 extern crate syntect;
 extern crate config;
+extern crate toml;
 
 #[cfg(target_os = "fuchsia")]
 extern crate magenta;

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -21,7 +21,7 @@ extern crate serde_json;
 extern crate serde_derive;
 extern crate time;
 extern crate syntect;
-extern crate toml;
+extern crate config;
 
 #[cfg(target_os = "fuchsia")]
 extern crate magenta;

--- a/rust/core-lib/src/plugins/catalog.rs
+++ b/rust/core-lib/src/plugins/catalog.rs
@@ -12,20 +12,44 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::{io, fs};
+use std::io::Read;
+use std::path::{Path, PathBuf};
 use std::collections::HashMap;
 
+use toml;
+
 use super::{PluginName, PluginDescription};
-use super::manifest::debug_plugins;
 
 /// A catalog of all available plugins.
 pub struct PluginCatalog {
     items: HashMap<PluginName, PluginDescription>,
 }
 
+/// Errors that can occur while trying to load a plugin.
+#[derive(Debug)]
+pub enum PluginLoadError {
+    Io(io::Error),
+    /// Malformed manifest
+    Parse(toml::de::Error),
+}
+
 impl <'a>PluginCatalog {
-    /// For use during development: returns the debug plugins
-    pub fn debug() -> Self {
-        PluginCatalog::new(&debug_plugins())
+    /// Loads plugins from the user's search paths
+    pub fn from_paths(paths: Vec<PathBuf>) -> Self {
+        let plugins = paths.iter()
+            .flat_map(|path| {
+                match load_plugins(path) {
+                    Ok(plugins) => plugins,
+                    Err(err) => {
+                        print_err!("error loading plugins from {:?}, error:\n{:?}",
+                                   path, err);
+                        Vec::new()
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
+        PluginCatalog::new(&plugins)
     }
 
     pub fn new(plugins: &[PluginDescription]) -> Self {
@@ -63,5 +87,49 @@ impl <'a>PluginCatalog {
         self.iter()
             .filter(|item| predicate(item))
             .collect::<Vec<_>>()
+    }
+}
+
+fn load_plugins(plugin_dir: &Path) -> io::Result<Vec<PluginDescription>> {
+    let mut plugins = Vec::new();
+    for path in plugin_dir.read_dir()? {
+        let path = path?;
+        let path = path.path();
+        if !path.is_dir() { continue }
+        let manif_path = path.join("manifest.toml");
+        if !manif_path.exists() { continue }
+        match load_manifest(&manif_path) {
+            Ok(manif) => plugins.push(manif),
+            Err(err) => print_err!("Error reading manifest {:?}, error:\n{:?}",
+                                   &manif_path, err),
+        }
+    }
+    Ok(plugins)
+}
+
+fn load_manifest(path: &Path) -> Result<PluginDescription, PluginLoadError> {
+    let mut file = fs::File::open(&path)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+    let mut manifest: PluginDescription = toml::from_str(&contents)?;
+    // normalize relative paths
+    if manifest.exec_path.starts_with("./") {
+        manifest.exec_path = path.parent()
+            .unwrap()
+            .join(manifest.exec_path)
+            .canonicalize()?;
+    }
+    Ok(manifest)
+}
+
+impl From<io::Error> for PluginLoadError {
+    fn from(err: io::Error) -> PluginLoadError {
+        PluginLoadError::Io(err)
+    }
+}
+
+impl From<toml::de::Error> for PluginLoadError {
+    fn from(err: toml::de::Error) -> PluginLoadError {
+        PluginLoadError::Parse(err)
     }
 }

--- a/rust/core-lib/src/plugins/manager.rs
+++ b/rust/core-lib/src/plugins/manager.rs
@@ -16,6 +16,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::io;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex, Weak, MutexGuard};
 
 use std::path::Path;
@@ -413,11 +414,11 @@ impl WeakPluginManagerRef {
 }
 
 impl PluginManagerRef {
-    pub fn new(buffers: BufferContainerRef) -> Self {
+    pub fn new(buffers: BufferContainerRef, paths: Vec<PathBuf>) -> Self {
         PluginManagerRef(Arc::new(Mutex::new(
             PluginManager {
                 // TODO: actually parse these from manifest files
-                catalog: PluginCatalog::debug(),
+                catalog: PluginCatalog::from_paths(paths),
                 buffer_plugins: BTreeMap::new(),
                 global_plugins: PluginGroup::new(),
                 buffers: buffers,

--- a/rust/core-lib/src/prefs.rs
+++ b/rust/core-lib/src/prefs.rs
@@ -12,11 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::env;
-use std::path::PathBuf;
+use std::{env, fs, io, fmt};
+use std::io::Read;
+use std::path::{PathBuf, Path};
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use toml;
+use toml::value::{Value, Table};
+
+use syntax::SyntaxDefinition;
 
 static XI_CONFIG_DIR: &'static str = "XI_CONFIG_DIR";
+static XI_CONFIG_FILE: &'static str = "preferences.xiconfig";
 static XDG_CONFIG_HOME: &'static str = "XDG_CONFIG_HOME";
+
+mod defaults {
+    pub const BASE: &'static str = include_str!("../assets/defaults.toml");
+}
 
 /// Returns the location of the active config directory.
 ///
@@ -45,6 +58,133 @@ fn get_config_dir() -> PathBuf {
                     xdg_var.as_ref().map(String::as_ref))
 }
 
+
+fn init_config() -> ConfigSources {
+    let config_dir = get_config_dir();
+    if !config_dir.exists() {
+        fs::create_dir(&config_dir);
+    }
+    let base_conf: Table = toml::from_str(defaults::BASE).unwrap();
+    ConfigSources::new(base_conf, &config_dir)
+}
+
+fn load_config(path: &Path) -> Result<Table, ConfigError> {
+    let mut file = fs::File::open(&path)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+    let config: Table = toml::from_str(&contents)?;
+    Ok(config)
+}
+
+fn load_syntax_configs(path: &Path) -> Vec<(PathBuf, Table)> {
+    let mut result = Vec::new();
+    let contents = match path.read_dir() {
+        Ok(contents) => contents,
+        Err(err) => {
+            print_err!("Error reading config directory: {:?}", err);
+            return result
+        }
+    };
+
+    for item in contents {
+        if let Ok(item) = item {
+            let path = item.path();
+            let skip = path.extension().map(|ext| ext != "xiconfig")
+                .unwrap_or(true)
+                || path.file_stem().map(|stem| stem == "preferences")
+                .unwrap_or(true);
+            if skip { continue }
+
+            match load_config(&path) {
+                Ok(prefs) => result.push((path, prefs)),
+                Err(err) => print_err!("Error reading config file {:?}", &path),
+            }
+        }
+    }
+    result
+}
+
+#[derive(Debug)]
+enum ConfigError {
+    FileMissing,
+    IoError(io::Error),
+    Parse(toml::de::Error),
+}
+
+impl From<io::Error> for ConfigError {
+    fn from(err: io::Error) -> ConfigError {
+        ConfigError::IoError(err)
+    }
+}
+
+impl From<toml::de::Error> for ConfigError {
+    fn from(err: toml::de::Error) -> ConfigError {
+        ConfigError::Parse(err)
+    }
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ConfigError::FileMissing => write!(f, "File missing"),
+            ConfigError::IoError(ref err) => write!(f, "IO Error: {:?}", err),
+            ConfigError::Parse(ref err) => write!(f, "TOML Error: {:?}", err),
+        }
+    }
+}
+
+pub struct ConfigSources {
+    base: Rc<Table>,
+    syntax: HashMap<SyntaxDefinition, Rc<Table>>,
+    user: Rc<Table>,
+    user_syntax: HashMap<SyntaxDefinition, Rc<Table>>,
+}
+
+pub struct ConfigSet {
+    sources: Vec<Rc<Table>>
+}
+
+impl ConfigSources {
+    fn new(base: Table, config_dir: &Path) -> Self {
+        let user_pref_path = config_dir.join(XI_CONFIG_FILE);
+        let user_prefs = match load_config(&user_pref_path) {
+            Ok(prefs) => prefs,
+            Err(err) => {
+                print_err!("Error loading user prefs: {:?}", err);
+                Table::new()
+            }
+        };
+
+        let user_syntax = HashMap::new();
+        let syntax_prefs = load_syntax_configs(&config_dir);
+        if !syntax_prefs.is_empty() {
+            panic!("actually using user syntax preferences is not implemented")
+        }
+
+        //TODO: keep a files-to-watch list
+
+        ConfigSources {
+            base: Rc::new(base),
+            syntax: HashMap::new(),
+            user: Rc::new(user_prefs),
+            user_syntax: user_syntax,
+        }
+    }
+
+    fn get_config(&self, syntax: SyntaxDefinition) -> ConfigSet {
+        let mut sources = vec![self.base.clone(), self.user.clone()];
+        if let Some(syntax_specific) = self.syntax.get(&syntax) {
+            sources.push(syntax_specific.clone());
+        }
+
+        if let Some(syntax_specific) = self.user_syntax.get(&syntax) {
+            sources.push(syntax_specific.clone());
+        }
+
+        sources.reverse();
+        ConfigSet { sources }
+    }
+}
 
 
 #[cfg(test)]

--- a/rust/core-lib/src/prefs.rs
+++ b/rust/core-lib/src/prefs.rs
@@ -16,7 +16,7 @@ use std::env;
 use std::path::{PathBuf, Path};
 use std::collections::HashMap;
 
-use config::{self, Source, Value, ConfigError, FileFormat};
+use config::{self, Source, Value, FileFormat};
 
 
 static XI_CONFIG_DIR: &'static str = "XI_CONFIG_DIR";
@@ -31,6 +31,82 @@ mod defaults {
 }
 
 pub type Table = HashMap<String, Value>;
+
+pub struct ConfigManager {
+    config_dir: PathBuf,
+    /// The default config
+    base: Table,
+    /// The user's custom config
+    user: Table,
+    /// A cache of the merged configs
+    cache: Table,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+/// A container for all user-modifiable settings.
+pub struct Config {
+    pub tab_size: usize,
+    pub translate_tabs_to_spaces: bool,
+    pub plugin_search_path: Vec<PathBuf>,
+}
+
+impl ConfigManager {
+    fn new<P: AsRef<Path>>(config_dir: P, user_config: Table) -> Self {
+        let base_config = config::File::from_str(&defaults::BASE,
+                                                 config::FileFormat::Toml)
+            .collect()
+            .expect("base configuration settings must load.");
+        let mut conf = ConfigManager {
+            config_dir: config_dir.as_ref().to_owned(),
+            base: base_config,
+            user: user_config,
+            cache: Table::default(),
+        };
+        conf.rebuild();
+        conf
+    }
+
+    fn rebuild(&mut self) {
+        let mut cache = self.base.clone();
+        for (k, v) in self.user.iter() {
+            cache.insert(k.to_owned(), v.clone());
+        }
+        self.cache = cache;
+    }
+
+    /// Generates a snapshot of the currently loaded configuration.
+    pub fn get_config(&self) -> Config {
+        let settings: Value = self.cache.clone().into();
+        let mut settings: Config = settings.try_into().unwrap();
+        // relative entries in plugin search path should be relative to
+        // the config directory.
+        settings.plugin_search_path = settings.plugin_search_path
+            .iter()
+            .map(|p| self.config_dir.join(p))
+            .collect();
+        // If present, append the location of plugins bundled by client
+        if let Ok(sys_path) = env::var(XI_SYS_PLUGIN_PATH) {
+            print_err!("including client bundled plugins from {}", &sys_path);
+            settings.plugin_search_path.push(sys_path.into());
+        }
+        settings
+    }
+}
+
+impl Default for ConfigManager {
+    fn default() -> ConfigManager {
+        let path = get_config_dir();
+        let config_path = path.join(XI_CONFIG_FILE_NAME);
+        let user_config: config::File<_> = config_path.into();
+        let user_config = user_config
+            .format(FileFormat::Toml)
+            .collect()
+            .map_err(|e| print_err!("Error reading config: {:?}", e))
+            .unwrap_or_default();
+
+        ConfigManager::new(&path, user_config)
+    }
+}
 
 /// Returns the location of the active config directory.
 ///
@@ -59,111 +135,6 @@ fn get_config_dir() -> PathBuf {
                     xdg_var.as_ref().map(String::as_ref))
 }
 
-pub struct ConfigManager {
-    config_dir: PathBuf,
-    /// The default config
-    base: Table,
-    /// The user's custom config
-    user: Table,
-    /// A cache of the merged configs
-    cache: Table,
-}
-
-#[derive(Debug, Clone)]
-pub struct Config(Table, PathBuf);
-
-impl ConfigManager {
-    fn new(config_dir: &Path) -> Self {
-        let base_config = config::File::from_str(&defaults::BASE,
-                                                 config::FileFormat::Toml)
-            .collect()
-            .expect("base configuration settings must load.");
-        let config_path = config_dir.join(XI_CONFIG_FILE_NAME);
-        let user_config: config::File<_> = config_path.into();
-        let user_config = user_config
-            .format(FileFormat::Toml)
-            .collect()
-            .map_err(|e| print_err!("Error reading config: {:?}", e))
-            .unwrap_or_default();
-
-        let mut conf = ConfigManager {
-            config_dir: config_dir.to_owned(),
-            base: base_config,
-            user: user_config,
-            cache: Table::default(),
-        };
-        conf.rebuild();
-        conf
-    }
-
-    fn rebuild(&mut self) {
-        let mut cache = self.base.clone();
-        for (k, v) in self.user.iter() {
-            cache.insert(k.to_owned(), v.clone());
-        }
-        self.cache = cache;
-    }
-
-    //TODO: this should accept a 'syntax' argument eventually
-    pub fn get_config(&self) -> Config {
-        Config(self.cache.clone(), self.config_dir.clone())
-    }
-}
-
-impl Default for ConfigManager {
-    fn default() -> ConfigManager {
-        let path = get_config_dir();
-        ConfigManager::new(&path)
-    }
-}
-
-impl Config {
-    fn get(&self, key: &str) -> Result<Value, ConfigError> {
-        self.0.get(key).map(|v| v.clone())
-            .ok_or(ConfigError::NotFound(key.to_owned()))
-    }
-
-    pub fn get_str(&self, key: &str) -> Result<String, ConfigError> {
-        self.get(key).and_then(Value::into_str)
-    }
-
-    pub fn get_int(&self, key: &str) -> Result<i64, ConfigError> {
-        self.get(key).and_then(Value::into_int)
-    }
-
-    pub fn get_float(&self, key: &str) -> Result<f64, ConfigError> {
-        self.get(key).and_then(Value::into_float)
-    }
-
-    pub fn get_bool(&self, key: &str) -> Result<bool, ConfigError> {
-        self.get(key).and_then(Value::into_bool)
-    }
-
-    pub fn get_table(&self, key: &str) -> Result<Table, ConfigError> {
-        self.get(key).and_then(Value::into_table)
-    }
-
-    pub fn get_array(&self, key: &str) -> Result<Vec<Value>, ConfigError> {
-        self.get(key).and_then(Value::into_array)
-    }
-
-    pub fn plugin_search_path(&self) -> Vec<PathBuf> {
-        let mut search_path: Vec<PathBuf> = self.get("plugin_search_path")
-            .and_then(Value::try_into::<Vec<PathBuf>>)
-            .unwrap_or_default()
-            .iter()
-            // relative paths should be relative to the config directory
-            .map(|p| self.1.join(p))
-            .collect();
-
-            if let Ok(sys_path) = env::var(XI_SYS_PLUGIN_PATH) {
-                print_err!("including client bundled plugins from {}", &sys_path);
-                search_path.push(sys_path.into());
-            }
-        search_path
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -188,11 +159,20 @@ mod tests {
 
     #[test]
     fn test_defaults() {
-        let manager = ConfigManager::default();
-        let mut config = manager.get_config();
-        assert_eq!(config.get_int("tab_size").unwrap(), 4);
-        assert!(config.get_int("font_face").is_err());
-        config.1 = "BASE_PATH".into();
-        assert_eq!(config.plugin_search_path(), vec![PathBuf::from("BASE_PATH/plugins")])
+        let manager = ConfigManager::new("BASE_PATH", Table::default());
+        let config = manager.get_config();
+        assert_eq!(config.tab_size, 4);
+        assert_eq!(config.plugin_search_path, vec![PathBuf::from("BASE_PATH/plugins")])
+    }
+
+    #[test]
+    fn test_overrides() {
+        let user_config = r#"tab_size = 42"#;
+        let user_config = config::File::from_str(user_config, FileFormat::Toml)
+            .collect()
+            .unwrap();
+        let manager = ConfigManager::new("", user_config);
+        let config = manager.get_config();
+        assert_eq!(config.tab_size, 42);
     }
 }

--- a/rust/core-lib/src/prefs.rs
+++ b/rust/core-lib/src/prefs.rs
@@ -16,7 +16,7 @@ use std::env;
 use std::path::{PathBuf, Path};
 use std::collections::HashMap;
 
-use config::{self, Source, Value, ConfigError};
+use config::{self, Source, Value, ConfigError, FileFormat};
 
 
 static XI_CONFIG_DIR: &'static str = "XI_CONFIG_DIR";
@@ -69,6 +69,7 @@ pub struct ConfigManager {
     cache: Table,
 }
 
+#[derive(Debug, Clone)]
 pub struct Config(Table, PathBuf);
 
 impl ConfigManager {
@@ -80,6 +81,7 @@ impl ConfigManager {
         let config_path = config_dir.join(XI_CONFIG_FILE_NAME);
         let user_config: config::File<_> = config_path.into();
         let user_config = user_config
+            .format(FileFormat::Toml)
             .collect()
             .map_err(|e| print_err!("Error reading config: {:?}", e))
             .unwrap_or_default();
@@ -191,6 +193,6 @@ mod tests {
         assert_eq!(config.get_int("tab_size").unwrap(), 4);
         assert!(config.get_int("font_face").is_err());
         config.1 = "BASE_PATH".into();
-        assert_eq!(config.plugin_search_paths(), vec![PathBuf::from("BASE_PATH/plugins")])
+        assert_eq!(config.plugin_search_path(), vec![PathBuf::from("BASE_PATH/plugins")])
     }
 }

--- a/rust/core-lib/src/prefs.rs
+++ b/rust/core-lib/src/prefs.rs
@@ -1,0 +1,71 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::env;
+use std::path::PathBuf;
+
+static XI_CONFIG_DIR: &'static str = "XI_CONFIG_DIR";
+static XDG_CONFIG_HOME: &'static str = "XDG_CONFIG_HOME";
+
+/// Returns the location of the active config directory.
+///
+/// env vars are passed in as Option<&str> for easier testing.
+fn config_dir_impl(xi_var: Option<&str>, xdg_var: Option<&str>) -> PathBuf {
+    xi_var.map(PathBuf::from)
+        .unwrap_or_else(|| {
+            let mut xdg_config = xdg_var.map(PathBuf::from)
+                .unwrap_or_else(|| {
+                    env::var("HOME").map(PathBuf::from)
+                        .map(|mut p| {
+                            p.push(".config");
+                            p
+                        })
+                        .expect("$HOME is required by POSIX")
+                });
+            xdg_config.push("xi");
+            xdg_config
+        })
+}
+
+fn get_config_dir() -> PathBuf {
+    let xi_var = env::var(XI_CONFIG_DIR).ok();
+    let xdg_var = env::var(XDG_CONFIG_HOME).ok();
+    config_dir_impl(xi_var.as_ref().map(String::as_ref),
+                    xdg_var.as_ref().map(String::as_ref))
+}
+
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_config() {
+       let p = _get_config_dir(Some("custom/xi/conf"), None);
+       assert_eq!(p, PathBuf::from("custom/xi/conf"));
+
+       let p = _get_config_dir(Some("custom/xi/conf"), Some("/me/config"));
+       assert_eq!(p, PathBuf::from("custom/xi/conf"));
+
+       let p = _get_config_dir(None, Some("/me/config"));
+       assert_eq!(p, PathBuf::from("/me/config/xi"));
+
+       let p = _get_config_dir(None, None);
+       let exp = env::var("HOME").map(PathBuf::from)
+           .map(|mut p| { p.push(".config/xi"); p })
+           .unwrap();
+       assert_eq!(p, exp);
+    }
+}

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -44,7 +44,7 @@ pub struct EmptyStruct {}
 /// # Note
 ///
 /// For serialization, all identifiers are converted to "snake_case".
-/// 
+///
 /// # Examples
 ///
 /// The `close_view` command:

--- a/rust/core-lib/src/syntax.rs
+++ b/rust/core-lib/src/syntax.rs
@@ -16,7 +16,7 @@
 
 use std::fmt;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "lowercase")]
 pub enum SyntaxDefinition {
     Plaintext, Markdown, Python, Rust, C, Go, Dart, Swift, Toml,

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -311,7 +311,7 @@ impl Documents {
     pub fn new() -> Documents {
         let buffers = BufferContainerRef::new();
         let config_manager = ConfigManager::default();
-        let plugin_path = config_manager.get_config().plugin_search_path();
+        let plugin_path = config_manager.get_config().plugin_search_path;
         let plugin_manager = PluginManagerRef::new(buffers.clone(), plugin_path);
         let (update_tx, update_rx) = mpsc::channel();
 

--- a/rust/syntect-plugin/manifest.toml
+++ b/rust/syntect-plugin/manifest.toml
@@ -1,0 +1,4 @@
+name = "syntect"
+version = "0.1"
+exec_path = "./bin/xi-syntect-plugin"
+activations = ["autorun"]


### PR DESCRIPTION
This PR implements very basic user config loading, and piggybacks on that to load plugins from disk.

There is a bunch of stuff this doesn't do: settings are global and only load once, there are no syntax-specific or platform-specific settings. (I guess a tracking/discussion issue for this would be nice; I'll do that shortly)

## Config

We ship with default config settings, in `core-lib/assets/default.toml`. Additionally, we look for a user config directory, first by checking the `XI_CONFIG_DIR` env var, and then falling back to `$XDG_CONFIG_HOME/xi`, or `$HOME/.config/xi`. We look for a TOML file in this directory named `preferences.xiconfig`; if present, any valid fields in this file override the defaults.

This config file now lets the user specify a global preference for tabs and spaces (#381), as well as spaces-per-tab, in addition to specifying the `plugin_search_path`, about which:

## Plugin Manifests

Plugins now require manifest files. These tell the editor where to find the plugin executable and when to run the plugin, and generally describe plugin capabilities.

Plugins are loaded by looking for files named `manifest.toml` in any directory that is a child of a directory in the `plugin_search_path`.

### Client installed plugins

If a client ships with some plugins (like we do on xi-mac, with the syntect plugin) they can install them in a directory outside of the user's `XI_CONFIG_DIR`, to conflicts with any of the user's plugins. In this case, the client should set the `XI_SYS_PLUGIN_PATH` environment variable to point to the folder containing the client's bundled plugins; this directory will be appended to the user's `plugin_search_path`, meaning these plugins won't load if an identically named plugin is in the user's `plugin_search_path`.

### xi-mac example
(A companion PR is available here: https://github.com/google/xi-mac/pull/68)

On xi-mac, we now include in our app bundle a folder called `plugins`, with the following structure:
```
plugins/
  syntect/
    manifest.toml
    bin/
      xi-syntect-plugin
```

and manifest.toml looks like this:

```toml
name = "syntect"
version = "0.1"
exec_path = "./bin/xi-syntect-plugin"
activations = ["autorun"]
```

At runtime, we set `$XI_SYS_PLUGIN_PATH` to the location of this folder within our app bundle, and syntect loads and runs as expected.