### PR TITLE
Move idle queue behind a Mutex

### DIFF
--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -128,16 +128,16 @@ impl Handler for MainState {
     type Notification = CoreNotification;
     type Request = CoreRequest;
 
-    fn handle_notification(&mut self, mut ctx: RpcCtx, rpc: Self::Notification) {
-        self.tabs.handle_notification(rpc, &mut ctx)
+    fn handle_notification(&mut self, ctx: &RpcCtx, rpc: Self::Notification) {
+        self.tabs.handle_notification(rpc, ctx)
     }
 
-    fn handle_request(&mut self, mut ctx: RpcCtx, rpc: Self::Request)
+    fn handle_request(&mut self, ctx: &RpcCtx, rpc: Self::Request)
                       -> Result<Value, RemoteError> {
-        self.tabs.handle_request(rpc, &mut ctx)
+        self.tabs.handle_request(rpc, ctx)
     }
 
-    fn idle(&mut self, _ctx: RpcCtx, _token: usize) {
+    fn idle(&mut self, _ctx: &RpcCtx, _token: usize) {
         self.tabs.handle_idle();
     }
 }

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -74,7 +74,7 @@ impl Clone for PluginRef {
 impl Handler for PluginRef {
     type Notification = PluginNotification;
     type Request = PluginRequest;
-    fn handle_notification(&mut self, _ctx: RpcCtx, rpc: Self::Notification) {
+    fn handle_notification(&mut self, _ctx: &RpcCtx, rpc: Self::Notification) {
         let plugin_manager = {
             self.0.lock().unwrap().manager.upgrade()
         };
@@ -84,7 +84,7 @@ impl Handler for PluginRef {
         }
     }
 
-    fn handle_request(&mut self, _ctx: RpcCtx, rpc: Self::Request) ->
+    fn handle_request(&mut self, _ctx: &RpcCtx, rpc: Self::Request) ->
         Result<Value, RemoteError> {
         let plugin_manager = {
             self.0.lock().unwrap().manager.upgrade()

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -354,8 +354,8 @@ impl Documents {
         BufferIdentifier(self.id_counter)
     }
 
-    pub fn handle_notification<'a>(&mut self, cmd: rpc::CoreNotification,
-                               rpc_ctx: &mut RpcCtx<'a>) {
+    pub fn handle_notification(&mut self, cmd: rpc::CoreNotification,
+                               rpc_ctx: &RpcCtx) {
         use rpc::CoreNotification::*;
         match cmd {
             ClientStarted(..) => self.do_client_init(rpc_ctx.get_peer()),
@@ -371,8 +371,8 @@ impl Documents {
         }
     }
 
-    pub fn handle_request<'a>(&mut self, cmd: rpc::CoreRequest,
-                              rpc_ctx: &mut RpcCtx<'a>) -> Result<Value, RemoteError> {
+    pub fn handle_request(&mut self, cmd: rpc::CoreRequest,
+                          rpc_ctx: &RpcCtx) -> Result<Value, RemoteError> {
         use rpc::CoreRequest::*;
         match cmd {
             NewView { file_path } => {

--- a/rust/plugin-lib/src/caching_plugin.rs
+++ b/rust/plugin-lib/src/caching_plugin.rs
@@ -17,6 +17,8 @@
 use std::path::PathBuf;
 use serde_json::Value;
 
+use xi_rpc::ReadError;
+
 use plugin_base;
 use plugin_base::PluginRequest;
 
@@ -128,12 +130,12 @@ impl<'a, H: Handler> plugin_base::Handler for MyHandler<'a, H> {
     }
 }
 
-pub fn mainloop<H: Handler>(handler: &mut H) {
+pub fn mainloop<H: Handler>(handler: &mut H) -> Result<(), ReadError> {
     let mut my_handler = MyHandler {
         handler: handler,
         state: State::default(),
     };
-    plugin_base::mainloop(&mut my_handler);
+    plugin_base::mainloop(&mut my_handler)
 }
 
 impl<'a> PluginCtx<'a> {

--- a/rust/rpc/tests/integration.rs
+++ b/rust/rpc/tests/integration.rs
@@ -30,8 +30,8 @@ pub struct EchoHandler;
 impl Handler for EchoHandler {
     type Notification = RpcCall;
     type Request = RpcCall;
-    fn handle_notification(&mut self, ctx: RpcCtx, rpc: Self::Notification) {}
-    fn handle_request(&mut self, ctx: RpcCtx, rpc: Self::Request)
+    fn handle_notification(&mut self, ctx: &RpcCtx, rpc: Self::Notification) {}
+    fn handle_request(&mut self, ctx: &RpcCtx, rpc: Self::Request)
                       -> Result<Value, RemoteError> {
         Ok(rpc.params)
     }


### PR DESCRIPTION
This is a commit I had sitting around from earlier work. It removes a lot of the hassle around having to declare a lifetime for RpcCtx, and lets us potentially remove it completely, moving idle handling into `RpcPeer`. I think it stands alone as a patch though; if this is an okay direction I'll PR that other commit.

I've been focusing much less on the RPC lib right now, so I'd like to PR a few of these little cleanup commits I have sitting in various working branches.