### PR TITLE
per-session config

### DIFF
--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -178,6 +178,8 @@ pub enum CoreNotification {
     Save { view_id: ViewIdentifier, file_path: String },
     /// Tells `xi-core` to set the theme.
     SetTheme { theme_name: String },
+    /// Overrides an editor setting for the given buffer.
+    DebugOverrideSetting { view_id: ViewIdentifier, key: String, value: Value },
     /// Notifies `xi-core` that the client has started.
     //TODO: this should be a unit, but we have a minor issue with serde.
     //see https://github.com/google/xi-editor/issues/400

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -45,7 +45,7 @@ use apps_ledger_services_public::{Ledger_Proxy};
 pub struct ViewIdentifier(String);
 
 /// BufferIdentifiers uniquely identify open buffers.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
 pub struct BufferIdentifier(usize);
 
 impl fmt::Display for ViewIdentifier {
@@ -311,7 +311,7 @@ impl Documents {
     pub fn new() -> Documents {
         let buffers = BufferContainerRef::new();
         let config_manager = ConfigManager::default();
-        let plugin_path = config_manager.get_config(None).plugin_search_path;
+        let plugin_path = config_manager.get_config(None, None).plugin_search_path;
         let plugin_manager = PluginManagerRef::new(buffers.clone(), plugin_path);
         let (update_tx, update_rx) = mpsc::channel();
 
@@ -456,7 +456,7 @@ impl Documents {
     fn new_empty_view(&mut self, rpc_peer: &MainPeer, view_id: &ViewIdentifier,
                       buffer_id: BufferIdentifier) {
         let editor = Editor::new(self.new_tab_ctx(rpc_peer),
-                                 self.config_manager.get_config(None),
+                                 self.config_manager.get_config(None, None),
                                  buffer_id, view_id);
         self.add_editor(view_id, &buffer_id, editor, None);
     }
@@ -466,14 +466,14 @@ impl Documents {
         match self.read_file(&path) {
             Ok(contents) => {
                 let syntax = SyntaxDefinition::new(path.to_str());
-                let ed = Editor::with_text(self.new_tab_ctx(rpc_peer),
-                                           self.config_manager.get_config(syntax),
+                let config = self.config_manager.get_config(syntax, buffer_id);
+                let ed = Editor::with_text(self.new_tab_ctx(rpc_peer), config,
                                            buffer_id, view_id, contents);
                 self.add_editor(view_id, &buffer_id, ed, Some(path));
             }
             Err(err) => {
                 let ed = Editor::new(self.new_tab_ctx(rpc_peer),
-                                     self.config_manager.get_config(None),
+                                     self.config_manager.get_config(None, None),
                                      buffer_id, view_id);
                 if path.exists() {
                     // if this is a read error of an actual file, we don't set path
@@ -538,7 +538,10 @@ impl Documents {
 
         if prev_syntax != new_syntax {
             self.plugins.document_syntax_changed(view_id, init_info);
-            let new_config = self.config_manager.get_config(new_syntax);
+            let buffer_id = self.buffers.buffer_for_view(view_id)
+                .expect("buffer should be present while saving");
+            let new_config = self.config_manager.get_config(new_syntax,
+                                                            buffer_id);
             self.buffers.lock().editor_for_view_mut(view_id)
                 .unwrap().set_config(new_config);
         }
@@ -814,7 +817,7 @@ mod tests {
     #[test]
     fn test_save_as() {
         let container_ref = BufferContainerRef::new();
-        let config = ConfigManager::default().get_config(None);
+        let config = ConfigManager::default().get_config(None, None);
         assert!(!container_ref.has_open_file("a fake file, for sure"));
         let view_id_1 = ViewIdentifier::from("view-id-1");
         let buf_id_1 = BufferIdentifier(1);

--- a/rust/core-lib/tests/rpc.rs
+++ b/rust/core-lib/tests/rpc.rs
@@ -119,9 +119,9 @@ fn test_movement_cmds() {
 {"method":"set_theme","params":{"theme_name":"InspiredGitHub"}}
 {"id":0,"method":"new_view","params":{}}"#);
     assert!(rpc_looper.mainloop(|| json, &mut state).is_ok());
-    
+
     let json = make_reader(MOVEMENT_RPCS);
-    assert!(rpc_looper.mainloop(|| json, &mut state).is_ok());
+    rpc_looper.mainloop(|| json, &mut state).unwrap();
 }
 
 #[test]
@@ -136,9 +136,9 @@ fn test_text_commands() {
 {"method":"set_theme","params":{"theme_name":"InspiredGitHub"}}
 {"id":0,"method":"new_view","params":{}}"#);
     assert!(rpc_looper.mainloop(|| json, &mut state).is_ok());
-    
+
     let json = make_reader(TEXT_EDIT_RPCS);
-    assert!(rpc_looper.mainloop(|| json, &mut state).is_ok());
+    rpc_looper.mainloop(|| json, &mut state).unwrap();
 }
 
 #[test]
@@ -151,10 +151,27 @@ fn test_other_edit_commands() {
 {"method":"set_theme","params":{"theme_name":"InspiredGitHub"}}
 {"id":0,"method":"new_view","params":{}}"#);
     assert!(rpc_looper.mainloop(|| json, &mut state).is_ok());
-    
+
     let json = make_reader(OTHER_EDIT_RPCS);
-    assert!(rpc_looper.mainloop(|| json, &mut state).is_ok());
+    rpc_looper.mainloop(|| json, &mut state).unwrap();
 }
+
+
+#[test]
+fn test_settings_commands() {
+    let mut state = MainState::new();
+    let write = io::sink();
+    let mut rpc_looper = RpcLoop::new(write);
+    // init a new view
+    let json = make_reader(r#"{"method":"client_started","params":{}}
+{"method":"set_theme","params":{"theme_name":"InspiredGitHub"}}
+{"id":0,"method":"new_view","params":{}}"#);
+    assert!(rpc_looper.mainloop(|| json, &mut state).is_ok());
+    let json = make_reader(r#"{"method":"debug_override_setting","params":{"view_id":"view-id-1","key":"tab_size","value":15}}"#);
+    rpc_looper.mainloop(|| json, &mut state).unwrap();
+}
+
+
 
 //TODO: test saving rpc
 //TODO: test plugin rpc


### PR DESCRIPTION
This adds the ability to override config settings on a per-session basis.

It also adds a temporary RPC method exposing this functionality to the client.