### PR TITLE
Config validation

### DIFF
--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -13,12 +13,15 @@
 // limitations under the License.
 
 use std::env;
-use std::fmt::Debug;
+use std::io;
+use std::borrow::Borrow;
+use std::error::Error;
+use std::ffi::OsStr;
+use std::fmt;
 use std::rc::Rc;
 use std::path::{PathBuf, Path};
 use std::collections::{HashMap, HashSet};
 
-use notify::DebouncedEvent;
 use config_rs::{self, Source, Value, FileFormat};
 
 use syntax::SyntaxDefinition;
@@ -29,7 +32,6 @@ static XI_CONFIG_DIR: &'static str = "XI_CONFIG_DIR";
 static XDG_CONFIG_HOME: &'static str = "XDG_CONFIG_HOME";
 /// A client can use this to pass a path to bundled plugins
 static XI_SYS_PLUGIN_PATH: &'static str = "XI_SYS_PLUGIN_PATH";
-static XI_CONFIG_FILE_NAME: &'static str = "preferences.xiconfig";
 
 /// Namespace for various default settings.
 #[allow(unused)]
@@ -81,17 +83,32 @@ mod defaults {
     }
 }
 
+/// A map of config keys to settings
 pub type Table = HashMap<String, Value>;
 
-#[derive(Debug, Clone)]
-pub enum ConfigError {
-    IllegalKey(String),
-    IllegalValue,
-    UnknownTable(String),
-    FileParse,
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all="lowercase")]
+/// A `ConfigDomain` describes a level or category of user settings.
+pub enum ConfigDomain {
+    /// The general user preferences
+    Preferences,
+    /// The overrides for a particular syntax.
+    SyntaxSpecific(SyntaxDefinition),
 }
 
-pub trait Validator: Debug {
+#[derive(Debug, Clone)]
+/// The errors that can occur when managing configs.
+pub enum ConfigError {
+    /// The config contains a key that is invalid for its domain.
+    IllegalKey(String),
+    /// The config domain was not recognized.
+    UnknownDomain(String),
+    /// A file-based config could not be loaded or parsed.
+    FileParse(PathBuf),
+}
+
+/// A `Validator` is responsible for validating a config table.
+pub trait Validator: fmt::Debug {
     fn validate(&self, key: &str, value: &Value) -> Result<(), ConfigError>;
     fn validate_table(&self, table: &Table) -> Result<(), ConfigError> {
         for (key, value) in table.iter() {
@@ -102,37 +119,9 @@ pub trait Validator: Debug {
 }
 
 #[derive(Debug, Clone)]
+/// An implementation of `Validator` that checks keys against a whitelist.
 pub struct KeyValidator {
     keys: HashSet<String>,
-}
-
-impl KeyValidator {
-    pub fn for_syntax_config() -> Rc<Self> {
-        let keys = defaults::GENERAL_KEYS.iter()
-            .map(|s| String::from(*s))
-            .collect();
-        Rc::new(KeyValidator { keys })
-    }
-
-    pub fn for_general_config() -> Rc<Self> {
-        let keys = defaults::GENERAL_KEYS.iter()
-            .chain(defaults::TOP_LEVEL_KEYS.iter())
-            .map(|s| String::from(*s))
-            .collect();
-        Rc::new(KeyValidator { keys })
-
-    }
-}
-
-impl Validator for KeyValidator {
-    fn validate(&self, key: &str, _value: &Value) -> Result<(), ConfigError>
-    {
-        if self.keys.contains(key) {
-            Ok(())
-        } else {
-            Err(ConfigError::IllegalKey(key.to_owned()))
-        }
-    }
 }
 
 /// Represents the common pattern of default settings masked by
@@ -157,6 +146,8 @@ pub struct ConfigManager {
     syntax_specific: HashMap<SyntaxDefinition, ConfigPair>,
     /// per-session overrides
     overrides: HashMap<BufferIdentifier, ConfigPair>,
+    /// A map of paths to file based configs.
+    sources: HashMap<PathBuf, ConfigDomain>,
     /// If using file-based config, this is the base config directory
     /// (perhaps `$HOME/.config/xi`, by default).
     config_dir: Option<PathBuf>,
@@ -243,75 +234,48 @@ impl ConfigPair {
 }
 
 impl ConfigManager {
-    /// Sets `self.config_dir`, and handles loading initial configs.
     pub fn set_config_dir<P: AsRef<Path>>(&mut self, path: P) {
-        let config_dir = path.as_ref().to_owned();
-        let user_config_path = config_dir.join(XI_CONFIG_FILE_NAME);
-        let user_config = load_config(&user_config_path).unwrap_or_default();
-        let syntax_specific = load_syntax_configs(&config_dir);
-        self.config_dir = Some(config_dir);
-        self.set_user_configs(Some(user_config), Some(syntax_specific));
+        self.config_dir = Some(path.as_ref().to_owned());
     }
 
     pub fn set_extras_dir<P: AsRef<Path>>(&mut self, path: P) {
         self.extras_dir = Some(path.as_ref().to_owned())
     }
 
-    /// Bulk apply initial user configs.
-    fn set_user_configs(&mut self, defaults: Option<Table>,
-                        syntax: Option<HashMap<SyntaxDefinition, Table>>) {
-        if let Some(mut syntax_settings) = syntax {
-            for (syntax, config) in syntax_settings.drain() {
-                if let Err(e) = self.set_user_syntax(syntax.clone(), config) {
-                    eprintln!("malformed config for syntax {:?} error:\n{:?}",
-                              syntax, e);
-                }
-            }
-        }
+    /// Sets the config for the given domain, removing any existing config.
+    pub fn update_config<P>(&mut self, domain: ConfigDomain, new_config: Table,
+                            path: P) -> Result<(), ConfigError>
+        where P: Into<Option<PathBuf>>,
+    {
+       let result = match domain {
+            ConfigDomain::Preferences => self.defaults.set_user(new_config),
+            ConfigDomain::SyntaxSpecific(s) => self.set_user_syntax(s, new_config),
+        };
 
-        if let Some(defaults) = defaults {
-            if let Err(e) = self.defaults.set_user(defaults) {
-                eprintln!("malformed preferences: {:?}", e);
-            }
+       if result.is_ok() {
+           if let Some(p) = path.into() {
+               self.sources.insert(p, domain);
+           }
+       }
+       result
+    }
+
+    /// If `path` points to a loaded config file, unloads the associated config.
+    pub fn remove_source(&mut self, source: &Path) {
+        if let Some(domain) = self.sources.remove(source) {
+            self.update_config(domain, Table::new(), None)
+                .expect("Empty table is always valid");
         }
     }
 
-    /// Handle a file system event in `self.config_dir`; mostly this
-    /// means reload a changed configuration.
-    pub fn handle_fs_event(&mut self, event: DebouncedEvent)
-                           -> Result<(), ConfigError> {
-        use self::DebouncedEvent::*;
-        match event {
-            Create(ref path) | Write(ref path) => {
-                let ext = path.extension()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("");
-                if ext == "xiconfig" {
-                    let file_stem = path.file_stem().unwrap().to_string_lossy();
-                    match load_config(path) {
-                        Ok(config) => self.update_config(&file_stem, config),
-                        Err(_) => Err(ConfigError::FileParse),
-                    }
-                } else {
-                    Ok(())
-                }
-            }
-            //other => eprintln!("other config fs event:;\n{:?}", &other),
-            _ => Ok(()),
-        }
-    }
+    /// Checks whether a given file should be loaded, i.e. whether it is a
+    /// config file and whether it is in an expected location.
+    pub fn should_load_file<P: AsRef<Path>>(&self, path: P) -> bool {
+        let path = path.as_ref();
 
-    /// Replace the user config with the given name with a new config.
-    fn update_config(&mut self, config_name: &str, new_config: Table)
-                    -> Result<(), ConfigError> {
-        if config_name == "preferences" {
-            self.defaults.set_user(new_config)
-        } else if let Some(s) = SyntaxDefinition::try_from_name(config_name) {
-            self.set_user_syntax(s, new_config)
-        } else {
-            eprintln!("Unknown config name {}", config_name);
-            Err(ConfigError::UnknownTable(config_name.to_owned()))
-        }
+        path.extension() == Some(OsStr::new("xiconfig")) &&
+            ConfigDomain::try_from_path(path).is_ok() &&
+            self.config_dir.as_ref().map(|p| Some(p.borrow()) == path.parent()).unwrap_or(false)
     }
 
     fn set_user_syntax(&mut self, syntax: SyntaxDefinition, config: Table)
@@ -398,49 +362,96 @@ impl Default for ConfigManager {
             defaults: defaults,
             syntax_specific: syntax_specific,
             overrides: HashMap::new(),
+            sources: HashMap::new(),
             config_dir: None,
             extras_dir: extras_dir,
         }
     }
 }
 
-fn load_config(path: &Path) -> Result<Table, ()> {
-    let conf: config_rs::File<_> = path.into();
-    conf.format(FileFormat::Toml)
-        .collect()
-        .map_err(|e| eprintln!("Error reading config: {:?}", e))
-}
-
-/// Loads all of the syntax-specific config files in the target directory.
-fn load_syntax_configs(config_dir: &Path) -> HashMap<SyntaxDefinition, Table> {
-    let contents = config_dir.read_dir()
-        .map(|dir| {
-            dir.flat_map(Result::ok)
-                .map(|p| p.path())
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-
-    let mut result = HashMap::new();
-    for config_path in contents {
-        // config is invalid if path isn't utf-8; lossy gives better errors
-        let file_name = config_path.file_name().unwrap().to_string_lossy();
-        if !file_name.ends_with(".xiconfig") || file_name == XI_CONFIG_FILE_NAME {
-            continue
-        }
-
-        let file_stem = config_path.file_stem().unwrap().to_string_lossy();
-        let syntax = SyntaxDefinition::try_from_name(&file_stem);
-        let conf = load_config(&config_path);
-        match (syntax, conf) {
-            (Some(s), Ok(c)) => { result.insert(s, c); }
-            (None, _) => eprintln!("unrecognized syntax name: {:?}",
-                                           &file_stem),
-            (_, Err(err)) => eprintln!("Error parsing config {:?}\n{:?}",
-                                        &config_path, err),
+impl ConfigDomain {
+    /// Given a file path, attempts to parse the file name into a `ConfigDomain`.
+    /// Returns an error if the file name does not correspond to a domain.
+    pub fn try_from_path(path: &Path) -> Result<Self, ConfigError> {
+        let file_stem = path.file_stem().unwrap().to_string_lossy();
+        if file_stem == "preferences" {
+            Ok(ConfigDomain::Preferences)
+        } else if let Some(syntax) = SyntaxDefinition::try_from_name(&file_stem) {
+            Ok(ConfigDomain::SyntaxSpecific(syntax))
+        } else {
+            Err(ConfigError::UnknownDomain(file_stem.into_owned()))
         }
     }
-    result
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::ConfigError::*;
+        match self {
+            &IllegalKey(ref s) |
+                &UnknownDomain(ref s) => write!(f, "{}: {}", self, s),
+            &FileParse(ref p) => write!(f, "{}: {:?}", self, p),
+        }
+    }
+}
+
+impl Error for ConfigError {
+    fn description(&self) -> &str {
+        use self::ConfigError::*;
+        match *self {
+            IllegalKey( .. ) => "illegal key",
+            UnknownDomain( .. ) => "unknown domain",
+            FileParse( .. ) => "failed to parse file",
+        }
+    }
+}
+
+impl KeyValidator {
+    pub fn for_syntax_config() -> Rc<Self> {
+        let keys = defaults::GENERAL_KEYS.iter()
+            .map(|s| String::from(*s))
+            .collect();
+        Rc::new(KeyValidator { keys })
+    }
+
+    pub fn for_general_config() -> Rc<Self> {
+        let keys = defaults::GENERAL_KEYS.iter()
+            .chain(defaults::TOP_LEVEL_KEYS.iter())
+            .map(|s| String::from(*s))
+            .collect();
+        Rc::new(KeyValidator { keys })
+
+    }
+}
+
+impl Validator for KeyValidator {
+    fn validate(&self, key: &str, _value: &Value) -> Result<(), ConfigError>
+    {
+        if self.keys.contains(key) {
+            Ok(())
+        } else {
+            Err(ConfigError::IllegalKey(key.to_owned()))
+        }
+    }
+}
+
+pub fn iter_config_files(dir: &Path) -> io::Result<Box<Iterator<Item=PathBuf>>> {
+    let contents = dir.read_dir()?;
+    let iter = contents.flat_map(Result::ok)
+        .map(|p| p.path())
+        .filter(|p| {
+            p.extension().and_then(OsStr::to_str).unwrap_or("") == "xiconfig"
+        });
+    Ok(Box::new(iter))
+}
+
+/// Attempts to load a config from a file. The config's domain is determined
+/// by the file name.
+pub fn try_load_from_file(path: &Path) -> Result<(ConfigDomain, Table), Box<Error>> {
+    let domain = ConfigDomain::try_from_path(path)?;
+    let conf: config_rs::File<_> = path.into();
+    let table = conf.format(FileFormat::Toml).collect()?;
+    Ok((domain, table))
 }
 
 /// Returns the location of the active config directory.
@@ -519,13 +530,15 @@ mod tests {
             .collect()
             .unwrap();
 
-        let mut user_syntax = HashMap::new();
-        user_syntax.insert(SyntaxDefinition::Rust, rust_config);
-
         let mut manager = ConfigManager::default();
-        manager.set_user_configs(Some(user_config), Some(user_syntax));
+        manager.update_config(ConfigDomain::SyntaxSpecific(SyntaxDefinition::Rust),
+                              rust_config, None).unwrap();
+
+        manager.update_config(ConfigDomain::Preferences, user_config, None)
+            .unwrap();
+
         let buf_id = BufferIdentifier::new(1);
-        manager.set_override("tab_size", 67, buf_id.clone(), false);
+        manager.set_override("tab_size", 67, buf_id.clone(), false).unwrap();
 
         let config = manager.get_config(None, None);
         assert_eq!(config.tab_size, 42);
@@ -540,8 +553,29 @@ mod tests {
         assert_eq!(config.tab_size, 67);
 
         // user override trumps everything
-        manager.set_override("tab_size", 85, buf_id.clone(), true);
+        manager.set_override("tab_size", 85, buf_id.clone(), true).unwrap();
         let config = manager.get_config(SyntaxDefinition::Rust, buf_id.clone());
         assert_eq!(config.tab_size, 85);
+    }
+
+    #[test]
+    fn test_config_domain_serde() {
+        assert!(ConfigDomain::try_from_path(Path::new("hi/python.xiconfig")).is_ok());
+        assert!(ConfigDomain::try_from_path(Path::new("hi/preferences.xiconfig")).is_ok());
+        assert!(ConfigDomain::try_from_path(Path::new("hi/rust.xiconfig")).is_ok());
+        assert!(ConfigDomain::try_from_path(Path::new("hi/unknown.xiconfig")).is_err());
+    }
+
+    #[test]
+    fn test_should_load() {
+        let mut manager = ConfigManager::default();
+        let config_dir = PathBuf::from("/home/config/xi");
+        manager.set_config_dir(&config_dir);
+        assert!(manager.should_load_file(&config_dir.join("preferences.xiconfig")));
+        assert!(manager.should_load_file(&config_dir.join("rust.xiconfig")));
+        assert!(!manager.should_load_file(&config_dir.join("fake?.xiconfig")));
+        assert!(!manager.should_load_file(&config_dir.join("preferences.toml")));
+        assert!(!manager.should_load_file(Path::new("/home/rust.xiconfig")));
+        assert!(!manager.should_load_file(Path::new("/home/config/xi/subdir/rust.xiconfig")));
     }
 }

--- a/rust/core-lib/src/syntax.rs
+++ b/rust/core-lib/src/syntax.rs
@@ -15,9 +15,10 @@
 //! Very basic syntax detection.
 
 use std::fmt;
+use serde::de::{value, Deserialize, IntoDeserializer};
 use serde_json;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[serde(rename_all = "lowercase")]
 pub enum SyntaxDefinition {
     Plaintext, Markdown, Python, Rust, C, Go, Dart, Swift, Toml,
@@ -67,8 +68,9 @@ impl SyntaxDefinition {
     /// This uses serde deserialization under the hood; this governs what
     /// names are expected to work.
     pub fn try_from_name<S: AsRef<str>>(name: S) -> Option<Self> {
-        serde_json::from_str(&format!("\"{}\"", name.as_ref()))
-            .ok()
+        let r: Result<Self, value::Error> = Self::deserialize(
+            name.as_ref().into_deserializer());
+        r.ok()
     }
 }
 

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -340,7 +340,8 @@ impl Documents {
                 if let Some(buffer_id) = self.buffers.buffer_for_view(&view_id) {
                     let value = ConfigValue::deserialize(&value)
                         .expect("config value should already be validated");
-                    self.config_manager.set_override(key, value, buffer_id, true);
+                    self.config_manager.set_override(&key, value, buffer_id, true)
+                        .expect(&format!("setting override failed for key {}", key));
                     self.after_config_change();
                 }
             }
@@ -626,7 +627,9 @@ impl Documents {
         for (token, event) in events.drain(..) {
             match token {
                 CONFIG_EVENT_TOKEN => {
-                    self.config_manager.handle_fs_event(event);
+                    if let Err(e) = self.config_manager.handle_fs_event(event) {
+                        eprintln!("Error handling config file change: {:?}", e);
+                    }
                     //TODO: we should be more efficient about this update,
                     // with config_manager returning whether it's necessary.
                     // The simplest version of this is blocked on

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -700,7 +700,7 @@ impl Documents {
     {
         if let Err(e) = self.config_manager.update_config(domain, table, path.into()) {
             //TODO: report this error to the peer
-            eprintln!("Error updating config {:?}, error:\n{:?}", domain, e);
+            eprintln!("Error updating config {:?}: {:?}", domain, e);
         }
     }
 


### PR DESCRIPTION
(this includes #427, and should generally be ignored until that PR is merged)

This PR adds a mechanism for validating a given config. Currently this is based around a whitelist of keys, but in the future it could be based on something like [json-schema](http://json-schema.org) or [relax ng](http://relaxng.org).

It also begins to lay out some infrastructure for doing non-file-based config later on. In particular, it moves the initial loading of config files into `Documents`, to make error reporting clearer.

This has also highlighted for me the need to clarify our error reporting strategy. 😕 

(progress on #410)