### PR TITLE
config notification

### DIFF
--- a/doc/frontend.md
+++ b/doc/frontend.md
@@ -248,6 +248,15 @@ use the new theme to set colors as appropriate. The `Theme` object is
 directly serialized from a [`syntect::highlighting::ThemeSettings`](https://github.com/trishume/syntect/blob/master/src/highlighting/theme.rs#L27)
 instance.
 
+#### config_changed
+
+`config_changed {"view_id": "view-id-1", "changes": {} }`
+
+Notifies the client that the config settings for a view have changed.
+This is called once when a new view is created, with `changes` containing
+all config settings; afterwards `changes` only contains the key/value
+pairs that have new values.
+
 ### plugins
 
 #### available_plugins

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -76,17 +76,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "config"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "crossbeam"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,14 +251,6 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "odds 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "nom"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -514,7 +495,6 @@ dependencies = [
 name = "xi-core-lib"
 version = "0.2.0"
 dependencies = [
- "config 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -572,7 +552,6 @@ dependencies = [
 "checksum bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c129aff112dcc562970abb69e2508b40850dd24c274761bb50fb8a0067ba6c27"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum chrono 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d9123be86fd2a8f627836c235ecdf331fdd067ecf7ac05aa1a68fbcf2429f056"
-"checksum config 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "257ad7eba1f5e97f478f9a98f4e70b0c4fab8fb85df99681c1a98aed824223ed"
 "checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
 "checksum digest 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a68d759d7a66a4f63d5bd2a2b14ad7e8cf93fe8c9be227031cd4e72ab0e9ee8"
 "checksum digest-buffer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4eb92364e9f6d3da159257250532d448b218406d2acb149f724e8f48e9f5cb9a"
@@ -595,7 +574,6 @@ dependencies = [
 "checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"
 "checksum nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bfb3ddedaa14746434a02041940495bf11325c22f6d36125d3bdd56090d50a79"
 "checksum nodrop 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "52cd74cd09beba596430cc6e3091b74007169a56246e1262f0ba451ea95117b2"
-"checksum nom 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06989cbd367e06f787a451f3bc67d8c3e0eaa10b461cc01152ffab24261a31b1"
 "checksum notify 4.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "745bdfd0d0764c71525e880c6d7662b721cb5658ddb2feaa71c3193ec359aef8"
 "checksum num 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "2c3a3dc9f30bf824141521b30c908a859ab190b76e20435fcd89f35eb6583887"
 "checksum num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "ef1a4bf6f9174aa5783a9b4cc892cacd11aebad6c69ad027a0b65c6ca5f8aa37"

--- a/rust/core-lib/Cargo.toml
+++ b/rust/core-lib/Cargo.toml
@@ -18,13 +18,6 @@ xi-rope = { path = "../rope", version = "0.2" }
 xi-unicode = { path = "../unicode", version = "0.1.0" }
 xi-rpc = { path = "../rpc", version = "0.2.0" }
 
-[dependencies.config]
-git = "https://github.com/cmyr/config-rs.git"
-branch = "partialeq-value"
-version = "0.7"
-default-features = false
-features = ["toml"]
-
 [dependencies.syntect]
 version = "1.7"
 default-features = false

--- a/rust/core-lib/Cargo.toml
+++ b/rust/core-lib/Cargo.toml
@@ -19,6 +19,8 @@ xi-unicode = { path = "../unicode", version = "0.1.0" }
 xi-rpc = { path = "../rpc", version = "0.2.0" }
 
 [dependencies.config]
+git = "https://github.com/cmyr/config-rs.git"
+branch = "partialeq-value"
 version = "0.7"
 default-features = false
 features = ["toml"]

--- a/rust/core-lib/assets/defaults.toml
+++ b/rust/core-lib/assets/defaults.toml
@@ -1,4 +1,6 @@
 tab_size = 4
 translate_tabs_to_spaces = true
 plugin_search_path = ["plugins"]
-newline = "\n"
+line_ending = "\n"
+font_face = "InconsolataGo"
+font_size = 14

--- a/rust/core-lib/assets/windows.toml
+++ b/rust/core-lib/assets/windows.toml
@@ -1,1 +1,1 @@
-newline = "\r\n"
+line_ending = "\r\n"

--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -161,8 +161,8 @@ pub struct ConfigManager {
     extras_dir: Option<PathBuf>,
 }
 
-/// A collection of config tables representing a heirarchy, with each
-/// table's keys superceding keys in preceding tables.
+/// A collection of config tables representing a hierarchy, with each
+/// table's keys superseding keys in preceding tables.
 #[derive(Debug, Clone, Default)]
 struct TableStack(Vec<Arc<Table>>);
 
@@ -529,7 +529,7 @@ impl Error for ConfigError {
             IllegalKey( .. ) => "illegal key",
             UnknownDomain( .. ) => "unknown domain",
             Parse( _, ref e ) => e.description(),
-            Io( ref e) => e.description(),
+            Io( ref e ) => e.description(),
         }
     }
 }

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -40,7 +40,7 @@ use plugins::rpc_types::{PluginUpdate, PluginEdit, ScopeSpan, PluginBufferInfo,
 ClientPluginInfo};
 use plugins::{PluginPid, Command};
 use layers::Scopes;
-use config::Config;
+use config::BufferConfig;
 
 
 #[cfg(not(target_os = "fuchsia"))]
@@ -85,7 +85,7 @@ pub struct Editor {
 
     styles: Scopes,
     doc_ctx: DocumentCtx,
-    config: Config,
+    config: BufferConfig,
     revs_in_flight: usize,
 
     /// Used only on Fuchsia for syncing
@@ -118,7 +118,7 @@ impl EditType {
 
 impl Editor {
     /// Creates a new `Editor` with a new empty buffer.
-    pub fn new(doc_ctx: DocumentCtx, config: Config,
+    pub fn new(doc_ctx: DocumentCtx, config: BufferConfig,
                buffer_id: BufferIdentifier,
                initial_view_id: ViewIdentifier) -> Editor {
         Self::with_text(doc_ctx, config, buffer_id,
@@ -126,7 +126,7 @@ impl Editor {
     }
 
     /// Creates a new `Editor`, loading text into a new buffer.
-    pub fn with_text(doc_ctx: DocumentCtx, config: Config,
+    pub fn with_text(doc_ctx: DocumentCtx, config: BufferConfig,
                      buffer_id: BufferIdentifier,
                      initial_view_id: ViewIdentifier, text: String) -> Editor {
 
@@ -215,7 +215,7 @@ impl Editor {
         }
     }
 
-    pub fn set_config(&mut self, conf: Config) {
+    pub fn set_config(&mut self, conf: BufferConfig) {
         self.config = conf;
     }
 
@@ -572,7 +572,7 @@ impl Editor {
 
     fn insert_newline(&mut self) {
         self.this_edit_type = EditType::InsertChars;
-        let text = self.config.newline.clone();
+        let text = self.config.items.newline.clone();
         self.insert(&text);
     }
 
@@ -580,9 +580,9 @@ impl Editor {
         let mut builder = delta::Builder::new(self.text.len());
         for region in self.view.sel_regions() {
             let iv = Interval::new_closed_open(region.min(), region.max());
-            let tab_text = if self.config.translate_tabs_to_spaces {
+            let tab_text = if self.config.items.translate_tabs_to_spaces {
                     let (_, col) = self.view.offset_to_line_col(&self.text, region.start);
-                    let tab_size = self.config.tab_size;
+                    let tab_size = self.config.items.tab_size;
                     let n = tab_size - (col % tab_size);
                     n_spaces(n)
             } else {

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -21,7 +21,6 @@ extern crate serde_json;
 extern crate serde_derive;
 extern crate time;
 extern crate syntect;
-extern crate config as config_rs;
 extern crate toml;
 extern crate notify;
 

--- a/rust/core-lib/src/plugins/manager.rs
+++ b/rust/core-lib/src/plugins/manager.rs
@@ -413,11 +413,11 @@ impl WeakPluginManagerRef {
 }
 
 impl PluginManagerRef {
-    pub fn new(buffers: BufferContainerRef, paths: Vec<PathBuf>) -> Self {
+    pub fn new(buffers: BufferContainerRef) -> Self {
         PluginManagerRef(Arc::new(Mutex::new(
             PluginManager {
                 // TODO: actually parse these from manifest files
-                catalog: PluginCatalog::from_paths(paths),
+                catalog: PluginCatalog::from_paths(Vec::new()),
                 buffer_plugins: BTreeMap::new(),
                 global_plugins: PluginGroup::new(),
                 buffers: buffers,
@@ -433,6 +433,16 @@ impl PluginManagerRef {
     /// Creates a new `WeakPluginManagerRef`.
     pub fn to_weak(&self) -> WeakPluginManagerRef {
         WeakPluginManagerRef(Arc::downgrade(&self.0))
+    }
+
+    pub fn set_plugin_search_path(&self, paths: Vec<PathBuf>) {
+        // hacky: we don't handle unloading plugins if the path changes.
+        // this assumes that we only set the path once, when we get
+        // `client_init`.
+        let mut inner = self.lock();
+        assert!(inner.catalog.iter().count() == 0);
+        inner.catalog = PluginCatalog::from_paths(paths);
+
     }
 
 

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -288,8 +288,7 @@ impl Documents {
     pub fn new() -> Documents {
         let buffers = BufferContainerRef::new();
         let config_manager = ConfigManager::default();
-        let plugin_path = config_manager.get_config(None, None).plugin_search_path;
-        let plugin_manager = PluginManagerRef::new(buffers.clone(), plugin_path);
+        let plugin_manager = PluginManagerRef::new(buffers.clone());
         let (update_tx, update_rx) = mpsc::channel();
 
         plugins::start_update_thread(update_rx, &plugin_manager);
@@ -590,6 +589,8 @@ impl Documents {
             })
         };
 
+        let plugin_paths = self.config_manager.plugin_search_path();
+        self.plugins.set_plugin_search_path(plugin_paths);
         rpc_peer.send_rpc_notification("available_themes", &params);
     }
 

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -25,7 +25,6 @@ use std::sync::{Arc, Mutex, MutexGuard, Weak, mpsc};
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
 use serde_json::value::Value;
-use config_rs::Value as ConfigValue;
 use notify::{RecursiveMode, DebouncedEvent};
 
 use xi_rope::rope::Rope;
@@ -342,8 +341,6 @@ impl Documents {
                 self.do_set_theme(rpc_ctx.get_peer(), &theme_name),
             DebugOverrideSetting { view_id, key, value } => {
                 if let Some(buffer_id) = self.buffers.buffer_for_view(view_id) {
-                    let value = ConfigValue::deserialize(&value)
-                        .expect("config value should already be validated");
                     self.config_manager.set_override(&key, value, buffer_id, true)
                         .expect(&format!("setting override failed for key {}", key));
                     self.after_config_change();
@@ -641,10 +638,8 @@ impl Documents {
         for (token, event) in events.drain(..) {
             match token {
                 CONFIG_EVENT_TOKEN => {
-                    //TODO: we should be more efficient about this update,
+                    //TODO: we should(?) be more efficient about this update,
                     // with config_manager returning whether it's necessary.
-                    // The simplest version of this is blocked on
-                    // https://github.com/mehcode/config-rs/issues/51
                     self.handle_config_fs_event(event);
                     config_changed = true;
                 }


### PR DESCRIPTION
(duplicated from #429)

This adds a new RPC method, `config_changed`, which notifies the client of the config values for each view. 

Some of these may be of particular interest to the client (such as font settings) and some of these may be useful for updating other state, such as indicating the current indentation setting in a status bar.

It means you can do this (on xi-mac, see https://github.com/google/xi-mac/pull/75)

![font_config](https://user-images.githubusercontent.com/3330916/32856860-0d697c86-ca14-11e7-893e-baa6b1c8c1e5.gif)

- progress towards #410 