### PR TITLE
Add RPC protocol methods for getting and modifying configs

### DIFF
--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -96,7 +96,7 @@ pub type Table = serde_json::Map<String, Value>;
 
 /// A `ConfigDomain` describes a level or category of user settings.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all="snake_case")]
 pub enum ConfigDomain {
     /// The general user preferences
     General,
@@ -748,6 +748,12 @@ translate_tabs_to_spaces = true"#).unwrap();
         assert!(ConfigDomain::try_from_path(Path::new("hi/preferences.xiconfig")).is_ok());
         assert!(ConfigDomain::try_from_path(Path::new("hi/rust.xiconfig")).is_ok());
         assert!(ConfigDomain::try_from_path(Path::new("hi/unknown.xiconfig")).is_err());
+
+        assert_eq!(serde_json::to_string(&ConfigDomain::General).unwrap(), "\"general\"");
+        let d = ConfigDomain::UserOverride(ViewIdentifier::from("view-id-1"));
+        assert_eq!(serde_json::to_string(&d).unwrap(), "{\"user_override\":\"view-id-1\"}");
+        let d = ConfigDomain::Syntax(SyntaxDefinition::Swift);
+        assert_eq!(serde_json::to_string(&d).unwrap(), "{\"syntax\":\"swift\"}");
     }
 
     #[test]

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -232,6 +232,11 @@ impl Editor {
         self.buffer_id
     }
 
+    /// returns the `ViewIdentifier` of the current view.
+    pub fn get_main_view_id(&self) -> ViewIdentifier {
+        self.view.view_id
+    }
+
     // each outstanding plugin edit represents a rev_in_flight.
     pub fn increment_revs_in_flight(&mut self) {
         self.revs_in_flight += 1;

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -222,6 +222,10 @@ impl Editor {
         }
     }
 
+    pub fn get_config(&self) -> &BufferConfig {
+        &self.config
+    }
+
     /// Returns this `Editor`'s active `SyntaxDefinition`.
     pub fn get_syntax(&self) -> &SyntaxDefinition {
         &self.syntax

--- a/rust/core-lib/tests/rpc.rs
+++ b/rust/core-lib/tests/rpc.rs
@@ -33,12 +33,17 @@ fn test_startup() {
     let json = make_reader(r#"{"method":"client_started","params":{}}
 {"method":"set_theme","params":{"theme_name":"InspiredGitHub"}}"#);
     assert!(rpc_looper.mainloop(|| json, &mut state).is_ok());
-    assert_eq!(rx.expect_object().get_method(), Some("available_themes"));
-    assert_eq!(rx.expect_object().get_method(), Some("theme_changed"));
+    rx.expect_rpc("available_themes");
+    rx.expect_rpc("theme_changed");
 
     let json = make_reader(r#"{"id":0,"method":"new_view","params":{}}"#);
     assert!(rpc_looper.mainloop(|| json, &mut state).is_ok());
     assert_eq!(rx.expect_response(), Ok(json!("view-id-1")));
+    rx.expect_rpc("available_plugins");
+    rx.expect_rpc("config_changed");
+    rx.expect_rpc("update");
+    rx.expect_rpc("scroll_to");
+    rx.expect_nothing();
 }
 
 

--- a/rust/rpc/src/lib.rs
+++ b/rust/rpc/src/lib.rs
@@ -254,6 +254,11 @@ impl<W: Write + Send> RpcLoop<W> {
                 let json = match read_result {
                     Ok(json) => json,
                     Err(err) => {
+                        // finish idle work before disconnecting;
+                        // this is mostly useful for integration tests.
+                        if let Some(idle_token) = peer.try_get_idle() {
+                            handler.idle(&ctx, idle_token);
+                        }
                         peer.disconnect();
                         return err
                     }

--- a/rust/rpc/src/parse.rs
+++ b/rust/rpc/src/parse.rs
@@ -40,7 +40,7 @@ pub struct MessageReader(String);
 /// occur on the read thread. If the message looks like a request, it
 /// is passed to the main thread for handling.
 #[derive(Debug, Clone)]
-pub struct RpcObject(Value);
+pub struct RpcObject(pub Value);
 
 #[derive(Debug, Clone, PartialEq)]
 /// An RPC call, which may be either a notification or a request.


### PR DESCRIPTION
This is the last major component of #410; with this in place we should have a simple and fairly robust system for handling user preferences and general per-view configuration.

In addition to two new protocol methods, this includes a fairly big refactor of config.rs, some new tests and some tweaks in support of easier testing.

The only thing currently missing is updating `frontend.md` to include an overview of the config system and how it should be approached by frontend authors.