### PR TITLE
Feature/config cleanup

### DIFF
--- a/rust/core-lib/assets/client_example.toml
+++ b/rust/core-lib/assets/client_example.toml
@@ -1,0 +1,20 @@
+#####################################################################
+# User settings must be in $XI_CONFIG/preferences.xiconfig, where   #
+# '$XI_CONFIG' is the Xi configuration directory for your platform. #
+#                                                                   #
+# These settings can also be overridden for a particular syntax;    #
+# add your overrides in (for example) '$XI_CONFIG/rust.xiconfig'.   #
+#####################################################################
+
+
+# The width of a tab, in spaces.
+tab_size = 4
+# Insert spaces when the tab key is pressed.
+translate_tabs_to_spaces = true
+
+# List of paths to additional plugins
+plugin_search_path = []
+
+font_face = "InconsolataGo"
+# In points
+font_size = 14

--- a/rust/core-lib/assets/defaults.toml
+++ b/rust/core-lib/assets/defaults.toml
@@ -1,6 +1,6 @@
 tab_size = 4
 translate_tabs_to_spaces = true
-plugin_search_path = ["plugins"]
+plugin_search_path = []
 line_ending = "\n"
 font_face = "InconsolataGo"
 font_size = 14

--- a/rust/core-lib/assets/defaults.toml
+++ b/rust/core-lib/assets/defaults.toml
@@ -1,6 +1,14 @@
+# These are the base default settings. Settings here may be overriden
+# for a given platform. Not all keys here are necessarily intended to
+# be exposed to the user; for a sample user preferences file, see
+# `client_example.toml` in this directory.
+
 tab_size = 4
 translate_tabs_to_spaces = true
+
 plugin_search_path = []
-line_ending = "\n"
+
 font_face = "InconsolataGo"
 font_size = 14
+
+line_ending = "\n"

--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -552,6 +552,13 @@ impl Validator for KeyValidator {
     }
 }
 
+/// Creates initial config directory structure
+pub fn init_config_dir(dir: &Path) -> io::Result<()> {
+    let builder = fs::DirBuilder::new();
+    builder.create(dir)?;
+    Ok(builder.create(dir.join("plugins"))?)
+}
+
 pub fn iter_config_files(dir: &Path) -> io::Result<Box<Iterator<Item=PathBuf>>> {
     let contents = dir.read_dir()?;
     let iter = contents.flat_map(Result::ok)

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -17,7 +17,6 @@
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::fmt;
-use std::env;
 use std::io::{self, Read};
 use std::path::{PathBuf, Path};
 use std::fs::File;
@@ -46,9 +45,6 @@ use plugins::rpc_types::{PluginUpdate, ClientPluginInfo};
 
 #[cfg(target_os = "fuchsia")]
 use apps_ledger_services_public::{Ledger_Proxy};
-
-/// A client can use this to pass a path to bundled plugins
-static XI_SYS_PLUGIN_PATH: &'static str = "XI_SYS_PLUGIN_PATH";
 
 /// Token for config-related file change events
 const CONFIG_EVENT_TOKEN: EventToken = EventToken(1);
@@ -569,13 +565,6 @@ impl Documents {
 
     fn do_client_init(&mut self, rpc_peer: &MainPeer, config_dir: Option<PathBuf>,
                       client_extras_dir: Option<PathBuf>) {
-        // If no config argument, fallback on environment variable
-        // TODO: deprecate env var approach and remove this
-        let config_dir = config_dir.or(Some(config::get_config_dir()));
-        let client_extras_dir = client_extras_dir
-            .or(env::var(XI_SYS_PLUGIN_PATH).map(PathBuf::from).ok());
-
-
         if let Some(ref d) = config_dir {
             self.config_manager.set_config_dir(&d);
             if let Err(e) = self.init_file_based_configs(d, rpc_peer) {

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -688,6 +688,9 @@ impl Documents {
     /// for file system events if the directory exists and can be read.
     fn init_file_based_configs(&mut self, config_dir: &Path,
                                rpc_peer: &MainPeer) -> io::Result<()> {
+        if !config_dir.exists() {
+            config::init_config_dir(config_dir)?;
+        }
         let config_files = config::iter_config_files(config_dir)?;
         config_files.for_each(|p| self.load_file_based_config(&p));
 


### PR DESCRIPTION
Final cleanup of env-var related config stuff.

The client must now specify a config directory and a plugin search path in the `client_started` RPC.

This also includes one bug fix around default plugin search paths.