### PR TITLE
Start implementation of minimal invalidation

### DIFF
--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -128,7 +128,7 @@ impl Editor {
         let buffer = engine.get_head().clone();
         let last_rev_id = engine.get_head_rev_id();
 
-        let editor = Editor {
+        let mut editor = Editor {
             text: buffer,
             buffer_id: buffer_id,
             path: None,
@@ -155,6 +155,7 @@ impl Editor {
             sync_store: None,
             last_synced_rev: last_rev_id,
         };
+        editor.view.set_dirty(&editor.text);
         editor
     }
 

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -653,7 +653,7 @@ impl Editor {
     }
 
     fn select_all(&mut self) {
-        self.view.select_all(self.text.len());
+        self.view.select_all(&self.text);
     }
 
     fn add_selection_by_movement(&mut self, movement: Movement) {
@@ -696,7 +696,6 @@ impl Editor {
         let first = max(first, 0) as usize;
         let last = last as usize;
         self.view.set_scroll(first, last);
-        self.view.send_update_for_scroll(&self.text, &self.doc_ctx, self.styles.get_merged(), first, last);
     }
 
     /// Sets the cursor and scrolls to the beginning of the given line.
@@ -706,7 +705,7 @@ impl Editor {
     }
 
     fn do_request_lines(&mut self, first: i64, last: i64) {
-        self.view.send_update(&self.text, &self.doc_ctx, self.styles.get_merged(), first as usize, last as usize);
+        self.view.request_lines(&self.text, &self.doc_ctx, self.styles.get_merged(), first as usize, last as usize);
     }
 
     fn do_click(&mut self, line: u64, col: u64, flags: u64, click_count: u64) {
@@ -772,7 +771,7 @@ impl Editor {
     fn do_gesture(&mut self, line: u64, col: u64, ty: GestureType) {
         let offset = self.view.line_col_to_offset(&self.text, line as usize, col as usize);
         match ty {
-            GestureType::ToggleSel => self.view.toggle_sel(offset),
+            GestureType::ToggleSel => self.view.toggle_sel(&self.text, offset),
         }
     }
 

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -877,17 +877,17 @@ impl Editor {
         };
 
         if search_string.is_none() {
-            self.view.unset_find();
+            self.view.unset_find(&self.text);
             return Value::Null;
         }
 
         let search_string = search_string.unwrap();
         if search_string.len() == 0 {
-            self.view.unset_find();
+            self.view.unset_find(&self.text);
             return Value::Null;
         }
 
-        self.view.set_find(&search_string, case_sensitive);
+        self.view.set_find(&self.text, &search_string, case_sensitive);
 
         Value::String(search_string.to_string())
     }

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -688,7 +688,7 @@ impl Editor {
 
         self.pristine_rev_id = self.last_rev_id;
         self.view.set_pristine();
-        self.view.set_dirty();
+        self.view.set_dirty(&self.text);
         self.render();
     }
 
@@ -778,7 +778,7 @@ impl Editor {
 
     fn debug_rewrap(&mut self) {
         self.view.rewrap(&self.text, 72);
-        self.view.set_dirty();
+        self.view.set_dirty(&self.text);
     }
 
     fn debug_print_spans(&self) {
@@ -999,7 +999,7 @@ impl Editor {
 
     pub fn theme_changed(&mut self) {
         self.styles.theme_changed(&self.doc_ctx);
-        self.view.set_dirty();
+        self.view.set_dirty(&self.text);
         self.render();
     }
 
@@ -1045,7 +1045,7 @@ impl Editor {
         }
         let iv = Interval::new_closed_closed(start, end_offset);
         self.styles.update_layer(plugin, iv, spans);
-        self.view.set_dirty();
+        self.view.set_dirty(&self.text);
         self.render();
     }
 
@@ -1117,7 +1117,7 @@ impl Editor {
         where T: Into<Option<ViewIdentifier>> {
         {
             self.styles.remove_layer(plugin_id);
-            self.view.set_dirty();
+            self.view.set_dirty(&self.text);
             self.render();
         }
         let view_id = view_id.into().unwrap_or(self.view.view_id);

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -65,6 +65,7 @@ pub mod internal {
     pub mod layers;
     pub mod config;
     pub mod watcher;
+    pub mod line_cache_shadow;
 }
 
 use internal::tabs;
@@ -81,6 +82,7 @@ use internal::syntax;
 use internal::layers;
 use internal::config;
 use internal::watcher;
+use internal::line_cache_shadow;
 #[cfg(target_os = "fuchsia")]
 use internal::fuchsia;
 

--- a/rust/core-lib/src/line_cache_shadow.rs
+++ b/rust/core-lib/src/line_cache_shadow.rs
@@ -1,0 +1,290 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A data structure that tracks the state of the front-end's line cache.
+
+use std::cmp::{max, min};
+
+const SCROLL_SLOP: usize = 2;
+const PRESERVE_EXTENT: usize = 1000;
+
+/// The line cache shadow tracks the state of the line cache in the front-end.
+/// Any content marked as valid here is up-to-date in the current state of the
+/// view. Also, if `dirty` is false, then the entire line cache is valid.
+pub struct LineCacheShadow {
+    spans: Vec<Span>,
+    dirty: bool,
+}
+
+pub const TEXT_VALID: u8 = 1;
+pub const STYLES_VALID: u8 = 2;
+pub const CURSOR_VALID: u8 = 4;
+pub const ALL_VALID: u8 = 7;
+
+pub struct Span {
+    /// Number of lines in this span. Units are visual lines in the
+    /// current state of the view.
+    pub n: usize,
+    /// Starting line number. Units are visual lines in the front end's
+    /// current cache state (i.e. the last one rendered). Note: this is
+    /// irrelevant if validity is 0.
+    pub start_line_num: usize,
+    /// Validity of lines in this span, consisting of the above constants or'ed.
+    pub validity: u8,
+}
+
+/// Builder for `LineCacheShadow` object.
+pub struct Builder {
+    spans: Vec<Span>,
+    dirty: bool,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum RenderTactic {
+    /// Discard all content for this span. Used to keep storage reasonable.
+    Discard,
+    /// Preserve existing content.
+    Preserve,
+    /// Render content if it is invalid.
+    Render,
+}
+
+pub struct RenderPlan {
+    /// Each span is a number of lines and a tactic.
+    pub spans: Vec<(usize, RenderTactic)>,
+}
+pub struct PlanIterator<'a> {
+    lc_shadow: &'a LineCacheShadow,
+    plan: &'a RenderPlan,
+    shadow_ix: usize,
+    shadow_line_num: usize,
+    plan_ix: usize,
+    plan_line_num: usize,
+}
+
+pub struct PlanSegment {
+    /// Line number of start of segment, visual lines in current view state.
+    pub our_line_num: usize,
+    /// Line number of start of segment, visual lines in client's cache, if validity != 0.
+    pub their_line_num: usize,
+    /// Number of visual lines in this segment.
+    pub n: usize,
+    /// Validity of this segment in client's cache.
+    pub validity: u8,
+    /// Tactic for rendering this segment.
+    pub tactic: RenderTactic,
+}
+
+impl Builder {
+    pub fn new() -> Builder {
+        Builder { spans: Vec::new(), dirty: false }
+    }
+
+    pub fn build(self) -> LineCacheShadow {
+        LineCacheShadow { spans: self.spans, dirty: self.dirty }
+    }
+
+    pub fn add_span(&mut self, n: usize, start_line_num: usize, validity: u8) {
+        if n > 0 {
+            if let Some(last) = self.spans.last_mut() {
+                if last.validity == validity &&
+                    (validity == 0 || last.start_line_num + last.n == start_line_num)
+                {
+                    last.n += n;
+                    return;
+                }
+            }
+            self.spans.push(Span { n, start_line_num, validity });
+        }
+    }
+
+    pub fn set_dirty(&mut self, dirty: bool) {
+        self.dirty = dirty;
+    }
+}
+
+impl LineCacheShadow {
+    pub fn edit(&mut self, start: usize, end: usize, replace: usize) {
+        let mut b = Builder::new();
+        let mut line_num = 0;
+        let mut i = 0;
+        while i < self.spans.len() {
+            let span = &self.spans[i];
+            if line_num + span.n <= start {
+                b.add_span(span.n, span.start_line_num, span.validity);
+                line_num += span.n;
+                i += 1;
+            } else {
+                b.add_span(start - line_num, span.start_line_num, span.validity);
+                break;
+            }
+        }
+        b.add_span(replace, 0, 0);
+        for span in &self.spans[i..] {
+            if line_num + span.n > end {
+                let offset = end.saturating_sub(line_num);
+                b.add_span(span.n - offset, span.start_line_num + offset, span.validity);
+            }
+            line_num += span.n;
+        }
+        b.set_dirty(true);
+        *self = b.build();
+    }
+
+    pub fn partial_invalidate(&mut self, start: usize, end: usize, invalid: u8) {
+        let mut clean = true;
+        let mut line_num = 0;
+        for span in &self.spans {
+            if start < line_num + span.n && end > line_num && (span.validity & invalid) != 0 {
+                clean = false;
+                break;
+            }
+            line_num += span.n;
+        }
+        if clean {
+            return;
+        }
+
+        let mut b = Builder::new();
+        let mut line_num = 0;
+        for span in &self.spans {
+            if start > line_num {
+                b.add_span(min(span.n, start - line_num), span.start_line_num, span.validity);
+            }
+            let invalid_start = max(start, line_num);
+            let invalid_end = min(end, line_num + span.n);
+            if invalid_end > invalid_start {
+                b.add_span(invalid_end - invalid_start,
+                    span.start_line_num + (invalid_start - line_num),
+                    span.validity & !invalid);
+            }
+            if line_num + span.n > end {
+                let offset = end.saturating_sub(line_num);
+                b.add_span(span.n - offset, span.start_line_num + offset, span.validity);
+            }
+            line_num += span.n;
+        }
+        b.set_dirty(true);
+        *self = b.build();
+    }
+
+    pub fn needs_render(&self, plan: &RenderPlan) -> bool {
+        self.dirty || self.iter_with_plan(plan).any(|seg|
+            seg.tactic == RenderTactic::Render && seg.validity != ALL_VALID
+        )
+    }
+
+    pub fn spans(&self) -> &[Span] {
+        &self.spans
+    }
+
+    pub fn iter_with_plan<'a>(&'a self, plan: &'a RenderPlan) -> PlanIterator<'a> {
+        PlanIterator { lc_shadow: self, plan,
+            shadow_ix: 0, shadow_line_num: 0, plan_ix: 0, plan_line_num: 0 }
+    }
+}
+
+impl Default for LineCacheShadow {
+    fn default() -> LineCacheShadow {
+        Builder::new().build()
+    }
+}
+
+impl<'a> Iterator for PlanIterator<'a> {
+    type Item = PlanSegment;
+
+    fn next(&mut self) -> Option<PlanSegment> {
+        if self.shadow_ix == self.lc_shadow.spans.len() || self.plan_ix == self.plan.spans.len() {
+            return None;
+        }
+        let shadow_span = &self.lc_shadow.spans[self.shadow_ix];
+        let plan_span = &self.plan.spans[self.plan_ix];
+        let start = max(self.shadow_line_num, self.plan_line_num);
+        let end = min(self.shadow_line_num + shadow_span.n, self.plan_line_num + plan_span.0);
+        let result = PlanSegment {
+            our_line_num: start,
+            their_line_num: shadow_span.start_line_num + (start - self.shadow_line_num),
+            n: end - start,
+            validity: shadow_span.validity,
+            tactic: plan_span.1,
+        };
+        if end == self.shadow_line_num + shadow_span.n {
+            self.shadow_line_num = end;
+            self.shadow_ix += 1;
+        }
+        if end == self.plan_line_num + plan_span.0 {
+            self.plan_line_num = end;
+            self.plan_ix += 1;
+        }
+        Some(result)
+    }
+}
+
+
+impl RenderPlan {
+    /// This function implements the policy of what to discard, what to preserve, and
+    /// what to render.
+    pub fn create(total_height: usize, first_line: usize, height: usize) -> RenderPlan {
+        let mut spans = Vec::new();
+        if first_line > PRESERVE_EXTENT {
+            spans.push((first_line - PRESERVE_EXTENT, RenderTactic::Discard));
+        }
+        if first_line > SCROLL_SLOP {
+            let n = first_line - SCROLL_SLOP - spans.len();
+            spans.push((n, RenderTactic::Preserve));
+        }
+        let render_end = min(first_line + height + SCROLL_SLOP, total_height);
+        let n = render_end - spans.len();
+        spans.push((n, RenderTactic::Render));
+        let preserve_end = min(first_line + height + PRESERVE_EXTENT, total_height);
+        if preserve_end > spans.len() {
+            let n = preserve_end - spans.len();
+            spans.push((n, RenderTactic::Preserve));
+        }
+        if total_height > spans.len() {
+            let n = total_height - spans.len();
+            spans.push((n, RenderTactic::Discard));
+        }
+        RenderPlan { spans }
+    }
+
+    /// Upgrade a range of lines to the "Render" tactic.
+    pub fn request_lines(&mut self, start: usize, end: usize) {
+        let mut spans: Vec<(usize, RenderTactic)> = Vec::new();
+        let mut i = 0;
+        let mut line_num = 0;
+        while i < self.spans.len() {
+            let span = &self.spans[i];
+            if line_num + span.0 <= start {
+                spans.push(*span);
+                line_num += span.0;
+                i += 1;
+            } else {
+                if line_num < start {
+                    spans.push((start - line_num, span.1));
+                }
+                break;
+            }
+        }
+        spans.push((end - start, RenderTactic::Render));
+        for span in &self.spans[i..] {
+            if line_num + span.0 > end {
+                let offset = end.saturating_sub(line_num);
+                spans.push((span.0 - offset, span.1));
+            }
+            line_num += span.0;
+        }
+        self.spans = spans;
+    }
+}

--- a/rust/core-lib/src/line_cache_shadow.rs
+++ b/rust/core-lib/src/line_cache_shadow.rs
@@ -64,6 +64,7 @@ pub struct RenderPlan {
     /// Each span is a number of lines and a tactic.
     pub spans: Vec<(usize, RenderTactic)>,
 }
+
 pub struct PlanIterator<'a> {
     lc_shadow: &'a LineCacheShadow,
     plan: &'a RenderPlan,

--- a/rust/core-lib/src/line_cache_shadow.rs
+++ b/rust/core-lib/src/line_cache_shadow.rs
@@ -238,24 +238,26 @@ impl RenderPlan {
     /// what to render.
     pub fn create(total_height: usize, first_line: usize, height: usize) -> RenderPlan {
         let mut spans = Vec::new();
+        let mut last = 0;
         if first_line > PRESERVE_EXTENT {
-            spans.push((first_line - PRESERVE_EXTENT, RenderTactic::Discard));
+            last = first_line - PRESERVE_EXTENT;
+            spans.push((last, RenderTactic::Discard));
         }
         if first_line > SCROLL_SLOP {
-            let n = first_line - SCROLL_SLOP - spans.len();
+            let n = first_line - SCROLL_SLOP - last;
             spans.push((n, RenderTactic::Preserve));
+            last += n;
         }
         let render_end = min(first_line + height + SCROLL_SLOP, total_height);
-        let n = render_end - spans.len();
-        spans.push((n, RenderTactic::Render));
+        spans.push((render_end - last, RenderTactic::Render));
+        last = render_end;
         let preserve_end = min(first_line + height + PRESERVE_EXTENT, total_height);
-        if preserve_end > spans.len() {
-            let n = preserve_end - spans.len();
-            spans.push((n, RenderTactic::Preserve));
+        if preserve_end > last {
+            spans.push((preserve_end - last, RenderTactic::Preserve));
+            last = preserve_end;
         }
-        if total_height > spans.len() {
-            let n = total_height - spans.len();
-            spans.push((n, RenderTactic::Discard));
+        if total_height > last {
+            spans.push((total_height - last, RenderTactic::Discard));
         }
         RenderPlan { spans }
     }

--- a/rust/core-lib/src/line_cache_shadow.rs
+++ b/rust/core-lib/src/line_cache_shadow.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! A data structure that tracks the state of the front-end's line cache.
+//! Data structures for tracking the state of the front-end's line cache
+//! and preparing render plans to update it.
 
 use std::cmp::{max, min};
 

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -33,7 +33,6 @@ use line_cache_shadow::{self, LineCacheShadow, RenderPlan, RenderTactic};
 
 use linewrap;
 
-const SCROLL_SLOP: usize = 2;
 const BACKWARDS_FIND_CHUNK_SIZE: usize = 32_768;
 
 pub struct View {
@@ -53,13 +52,6 @@ pub struct View {
     /// description for the invariant.
     lc_shadow: LineCacheShadow,
 
-    // Ranges of lines held by the line cache in the front-end that are considered
-    // valid.
-    // TODO: separate tracking of text, cursors, and styles
-    valid_lines: IndexSet,
-
-    // The selection state was updated.
-    sel_dirty: bool,
     // The occurrences, which determine the highlights, have been updated.
     hls_dirty: bool,
 
@@ -113,8 +105,6 @@ impl View {
             breaks: None,
             wrap_col: 0,
             lc_shadow: LineCacheShadow::default(),
-            valid_lines: IndexSet::new(),
-            sel_dirty: true,
             hls_dirty: true,
             dirty: true,
             pristine: true,
@@ -145,17 +135,18 @@ impl View {
     }
 
     /// Toggles a caret at the given offset.
-    pub fn toggle_sel(&mut self, offset: usize) {
-        self.sel_dirty = true;
-        if !self.selection.regions_in_range(offset, offset).is_empty() {
-            self.selection.delete_range(offset, offset, true);
-            if !self.selection.is_empty() {
+    pub fn toggle_sel(&mut self, text: &Rope, offset: usize) {
+        // We could probably reduce the cloning of selections by being clever.
+        let mut selection = self.selection.clone();
+        if !selection.regions_in_range(offset, offset).is_empty() {
+            selection.delete_range(offset, offset, true);
+            if !selection.is_empty() {
                 self.drag_state = None;
                 return;
             }
         }
         self.drag_state = Some(DragState {
-            base_sel: self.selection.clone(),
+            base_sel: selection.clone(),
             offset: offset,
             min: offset,
             max: offset,
@@ -166,7 +157,8 @@ impl View {
             horiz: None,
             affinity: Affinity::default(),
         };
-        self.selection.add_region(region);
+        selection.add_region(region);
+        self.set_selection_raw(text, selection);
     }
 
     /// Move the selection by the given movement. Return value is the offset of
@@ -185,29 +177,35 @@ impl View {
     /// Set the selection to a new value. Return value is the offset of a
     /// point that should be scrolled into view.
     pub fn set_selection(&mut self, text: &Rope, sel: Selection) -> Option<usize> {
-        self.selection = sel;
+        self.set_selection_raw(text, sel);
         // We somewhat arbitrarily choose the last region for setting the old-style
         // selection state, and for scrolling it into view if needed. This choice can
         // likely be improved.
         let region = self.selection.last().unwrap().clone();
-        self.sel_dirty = true;
         self.scroll_to_cursor(text);
         Some(region.end)
+    }
+
+    /// Sets the selection to a new value, invalidating the line cache as needed. This
+    /// function does not perform any scrolling.
+    fn set_selection_raw(&mut self, text: &Rope, sel: Selection) {
+        // TODO: fine grained invalidation.
+        self.selection = sel;
+        self.set_dirty(text);
     }
 
     /// Select entire buffer.
     ///
     /// Note: unlike movement based selection, this does not scroll.
-    pub fn select_all(&mut self, len: usize) {
+    pub fn select_all(&mut self, text: &Rope) {
         let mut selection = Selection::new();
         selection.add_region(SelRegion {
             start: 0,
-            end: len,
+            end: text.len(),
             horiz: None,
             affinity: Default::default(),
         });
-        self.selection = selection;
-        self.sel_dirty = true;
+        self.set_selection_raw(text, selection);
     }
 
     /// Starts a drag operation.
@@ -333,104 +331,6 @@ impl View {
         rendered_styles
     }
 
-    pub fn send_update(&mut self, text: &Rope, tab_ctx: &DocumentCtx, style_spans: &Spans<Style>,
-        first_line: usize, last_line: usize)
-    {
-        let dirty = self.dirty || self.sel_dirty;
-        if dirty {
-            self.valid_lines.clear();
-        }
-        let height = self.offset_to_line_col(text, text.len()).0 + 1;
-        let last_line = min(last_line, height);
-
-        // update find for given region
-        if self.hls_dirty {
-            self.update_find_for_lines(text, first_line, last_line);
-        }
-
-        let mut ops = Vec::new();
-        if first_line > 0 {
-            let op = if dirty { "invalidate" } else { "copy" };
-            ops.push(self.build_update_op(op, None, first_line));
-        }
-        let first_line_offset = self.offset_of_line(text, first_line);
-        let mut line_cursor = Cursor::new(text, first_line_offset);
-        let mut soft_breaks = self.breaks.as_ref().map(|breaks|
-            Cursor::new(breaks, first_line_offset)
-        );
-
-        let mut rendered_lines = Vec::new();
-        for line_num in first_line..last_line {
-            rendered_lines.push(self.render_line(tab_ctx, text,
-                &mut line_cursor, soft_breaks.as_mut(), style_spans, line_num));
-        }
-        ops.push(self.build_update_op("ins", Some(rendered_lines), last_line - first_line));
-        if last_line < height {
-            if !dirty {
-                ops.push(self.build_update_op("skip", None, last_line - first_line));
-            }
-            let op = if dirty { "invalidate" } else { "copy" };
-            ops.push(self.build_update_op(op, None, height - last_line));
-        }
-        let params = json!({
-            "ops": ops,
-            "pristine": self.pristine,
-        });
-        tab_ctx.update_view(self.view_id, &params);
-        self.valid_lines.union_one_range(first_line, last_line);
-    }
-
-
-    /// Send lines within given region (plus slop) that the front-end does not already
-    /// have.
-    pub fn send_update_for_scroll(&mut self, text: &Rope, tab_ctx: &DocumentCtx, style_spans: &Spans<Style>,
-        first_line: usize, last_line: usize)
-    {
-        let first_line = max(first_line, SCROLL_SLOP) - SCROLL_SLOP;
-        let last_line = last_line + SCROLL_SLOP;
-        let height = self.offset_to_line_col(text, text.len()).0 + 1;
-        let last_line = min(last_line, height);
-
-        // update find for given region
-        self.update_find_for_lines(text, first_line, last_line);
-
-        let mut ops = Vec::new();
-        let mut line = 0;
-        for (start, end) in self.valid_lines.minus_one_range(first_line, last_line) {
-            // TODO: this has some duplication with send_update in the non-dirty case.
-            if start > line {
-                ops.push(self.build_update_op("copy", None, start - line));
-            }
-            let start_offset = self.offset_of_line(text, start);
-            let mut line_cursor = Cursor::new(text, start_offset);
-            let mut soft_breaks = self.breaks.as_ref().map(|breaks|
-                Cursor::new(breaks, start_offset)
-            );
-            let mut rendered_lines = Vec::new();
-            for line_num in start..end {
-                rendered_lines.push(self.render_line(tab_ctx, text,
-                                                     &mut line_cursor, soft_breaks.as_mut(),
-                                                     style_spans, line_num));
-            }
-            ops.push(self.build_update_op("ins", Some(rendered_lines), end - start));
-            ops.push(self.build_update_op("skip", None, end - start));
-            line = end;
-        }
-        if line == 0 {
-            // Front-end already has all lines, no need to send any more.
-            return;
-        }
-        if line < height {
-            ops.push(self.build_update_op("copy", None, height - line));
-        }
-        let params = json!({
-            "ops": ops,
-            "pristine": self.pristine,
-        });
-        tab_ctx.update_view(self.view_id, &params);
-        self.valid_lines.union_one_range(first_line, last_line);
-    }
-
     fn build_update_op(&self, op: &str, lines: Option<Vec<Value>>, n: usize) -> Value {
         let mut update = json!({
             "op": op,
@@ -509,15 +409,21 @@ impl View {
     }
 
     // Update front-end with any changes to view since the last time sent.
-    pub fn render_if_dirty(&mut self, text: &Rope, tab_ctx: &DocumentCtx, style_spans: &Spans<Style>) {
-        if self.sel_dirty || self.hls_dirty || self.dirty {
-            let first_line = max(self.first_line, SCROLL_SLOP) - SCROLL_SLOP;
-            let last_line = self.first_line + self.height + SCROLL_SLOP;
-            self.send_update(text, tab_ctx, style_spans, first_line, last_line);
-            self.sel_dirty = false;
-            self.hls_dirty = false;
-            self.dirty = false;
-        }
+    pub fn render_if_dirty(&mut self, text: &Rope, tab_ctx: &DocumentCtx,
+        style_spans: &Spans<Style>)
+    {
+        let height = self.offset_to_line_col(text, text.len()).0 + 1;
+        let plan = RenderPlan::create(height, self.first_line, self.height);
+        self.send_update_for_plan(text, tab_ctx, style_spans, &plan);
+    }
+
+    // Send the requested lines even if they're outside the current scroll region.
+    pub fn request_lines(&mut self, text: &Rope, tab_ctx: &DocumentCtx, style_spans: &Spans<Style>,
+        first_line: usize, last_line: usize) {
+        let height = self.offset_to_line_col(text, text.len()).0 + 1;
+        let mut plan = RenderPlan::create(height, self.first_line, self.height);
+        plan.request_lines(first_line, last_line);
+        self.send_update_for_plan(text, tab_ctx, style_spans, &plan);
     }
 
     /// Invalidates client's entire line cache, forcing a full render at the next update


### PR DESCRIPTION
Start implementation of minimal invalidation

This patch uses a fancy data structure to track the state of the
front-end's line cache on a fine grained basis, and construct a
minimal delta to be sent on update.

As of this patch, the data structure is done, but most changes to
the view just invalidate the whole thing. Thus, the visible effect
is minimal. That said, the core is in control of eviction of the
front-end's cache, so the unbounded growth is not possible, and it
also won't keep resending the same content, which should help with
scrolling performance.

Fixes #270 and is good progress towards #317.
