### PR TITLE
Add cancel operation

### DIFF
--- a/doc/frontend.md
+++ b/doc/frontend.md
@@ -129,6 +129,12 @@ inner methods described below:
 
 Inserts the `chars` string at the current cursor location.
 
+#### cancel_operation
+
+`cancel_operation`
+
+Currently, this collapses selections and multiple cursors, and dehighlights
+searches.
 
 #### scroll
 

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -901,6 +901,11 @@ impl Editor {
         }
     }
 
+    fn cancel_operation(&mut self) {
+        self.view.unset_find();
+        self.view.collapse_selections();
+    }
+
     fn cmd_prelude(&mut self) {
         self.this_edit_type = EditType::Other;
     }
@@ -977,6 +982,7 @@ impl Editor {
             FindPrevious { wrap_around } => self.do_find_next(true, wrap_around.unwrap_or(false), true),
             DebugRewrap => self.debug_rewrap(),
             DebugPrintSpans => self.debug_print_spans(),
+            CancelOperation => self.cancel_operation(),
         };
 
         self.cmd_postlude();

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -901,7 +901,7 @@ impl Editor {
         }
     }
 
-    fn cancel_operation(&mut self) {
+    fn do_cancel_operation(&mut self) {
         self.view.unset_find();
         self.view.collapse_selections(&self.text);
     }
@@ -982,7 +982,7 @@ impl Editor {
             FindPrevious { wrap_around } => self.do_find_next(true, wrap_around.unwrap_or(false), true),
             DebugRewrap => self.debug_rewrap(),
             DebugPrintSpans => self.debug_print_spans(),
-            CancelOperation => self.cancel_operation(),
+            CancelOperation => self.do_cancel_operation(),
         };
 
         self.cmd_postlude();

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -903,7 +903,7 @@ impl Editor {
 
     fn cancel_operation(&mut self) {
         self.view.unset_find();
-        self.view.collapse_selections();
+        self.view.collapse_selections(&self.text);
     }
 
     fn cmd_prelude(&mut self) {

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -373,6 +373,7 @@ pub enum EditNotification {
     DebugRewrap,
     /// Prints the style spans present in the active selection.
     DebugPrintSpans,
+    CancelOperation,
 }
 
 /// The edit related requests.

--- a/rust/core-lib/src/selection.rs
+++ b/rust/core-lib/src/selection.rs
@@ -45,6 +45,12 @@ impl Selection {
         self.regions.clear();
     }
 
+    /// Collapse all selections into a single caret
+    pub fn collapse(&mut self) {
+        self.regions.truncate(1);
+        self.regions[0].start = self.regions[0].end;
+    }
+
     // The smallest index so that offset > region.max() for all preceding
     // regions.
     pub fn search(&self, offset: usize) -> usize {

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -233,6 +233,11 @@ impl View {
         &self.selection
     }
 
+    /// Collapse all selections in this view into a single caret
+    pub fn collapse_selections(&mut self) {
+        &self.selection.collapse();
+    }
+
     /// Determines whether the offset is in any selection (counting carets and
     /// selection edges).
     pub fn is_point_in_selection(&self, offset: usize) -> bool {

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -234,8 +234,10 @@ impl View {
     }
 
     /// Collapse all selections in this view into a single caret
-    pub fn collapse_selections(&mut self) {
-        &self.selection.collapse();
+    pub fn collapse_selections(&mut self, text: &Rope) {
+        let mut sel = self.selection.clone();
+        sel.collapse();
+        &self.set_selection(text, sel);
     }
 
     /// Determines whether the offset is in any selection (counting carets and


### PR DESCRIPTION
This adds a cancel_operation method that collapses all cursors/selections and dehighlights searches. Let me know if I missed anything - it's my first time poking around in Xi :)

Closes #324 