### PR TITLE
Improve style resolution performance

### DIFF
--- a/rust/core-lib/src/layers.rs
+++ b/rust/core-lib/src/layers.rs
@@ -47,7 +47,6 @@ pub struct ScopeLayer {
     /// compute styles of child spans.
     style_cache: BTreeMap<Vec<Scope>, StyleModifier>,
     /// Human readable scope names, for debugging
-    name_lookup: Vec<Vec<String>>,
     scope_spans: Spans<u32>,
     style_spans: Spans<Style>,
 }
@@ -137,7 +136,7 @@ impl Scopes {
             if spans.iter().next().is_some() {
                 eprintln!("scopes for layer {:?}:", id);
                 for (iv, val) in spans.iter() {
-                    eprintln!("{}: {:?}", iv, layer.name_lookup[*val as usize]);
+                    eprintln!("{}: {:?}", iv, layer.stack_lookup[*val as usize]);
                 }
                 eprintln!("styles:");
                 for (iv, val) in styles.iter() {
@@ -160,7 +159,6 @@ impl Default for ScopeLayer {
         ScopeLayer {
             stack_lookup: Vec::new(),
             style_lookup: Vec::new(),
-            name_lookup: Vec::new(),
             style_cache: BTreeMap::new(),
             scope_spans: Spans::default(),
             style_spans: Spans::default(),
@@ -174,7 +172,6 @@ impl ScopeLayer {
         ScopeLayer {
             stack_lookup: Vec::new(),
             style_lookup: Vec::new(),
-            name_lookup: Vec::new(),
             style_cache: BTreeMap::new(),
             scope_spans: SpansBuilder::new(len).build(),
             style_spans: SpansBuilder::new(len).build(),
@@ -210,7 +207,6 @@ impl ScopeLayer {
                 .map(|s| s.unwrap())
                 .collect::<Vec<_>>();
             stacks.push(scopes);
-            self.name_lookup.push(stack);
         }
 
         let mut new_styles = self.styles_for_stacks(stacks.as_slice(), doc_ctx);

--- a/rust/core-lib/src/layers.rs
+++ b/rust/core-lib/src/layers.rs
@@ -18,7 +18,7 @@
 //! Scope information originating from any number of plugins can be resolved
 //! into styles using a theme, augmented with additional style definitions.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use syntect::parsing::Scope;
 use syntect::highlighting::StyleModifier;
 
@@ -45,7 +45,7 @@ pub struct ScopeLayer {
     // a prefix tree.
     /// style state of existing scope spans, so we can more efficiently
     /// compute styles of child spans.
-    style_cache: BTreeMap<Vec<Scope>, StyleModifier>,
+    style_cache: HashMap<Vec<Scope>, StyleModifier>,
     /// Human readable scope names, for debugging
     scope_spans: Spans<u32>,
     style_spans: Spans<Style>,
@@ -159,7 +159,7 @@ impl Default for ScopeLayer {
         ScopeLayer {
             stack_lookup: Vec::new(),
             style_lookup: Vec::new(),
-            style_cache: BTreeMap::new(),
+            style_cache: HashMap::new(),
             scope_spans: Spans::default(),
             style_spans: Spans::default(),
         }
@@ -172,7 +172,7 @@ impl ScopeLayer {
         ScopeLayer {
             stack_lookup: Vec::new(),
             style_lookup: Vec::new(),
-            style_cache: BTreeMap::new(),
+            style_cache: HashMap::new(),
             scope_spans: SpansBuilder::new(len).build(),
             style_spans: SpansBuilder::new(len).build(),
         }


### PR DESCRIPTION
This patch significantly improves the speed at which we resolve scope spans into styles and greatly improves startup performance, especially noticeable on debug builds.

### before:
![screen shot 2017-12-14 at 8 17 09 pm](https://user-images.githubusercontent.com/3330916/34022275-5ea59c92-e10c-11e7-9994-0506487c8b67.png)

### after:
![screen shot 2017-12-14 at 8 18 00 pm](https://user-images.githubusercontent.com/3330916/34022284-69568480-e10c-11e7-843d-0996e64645a2.png)

