### PR TITLE
very, very, really quite basic auto indent

### DIFF
--- a/rust/core-lib/assets/client_example.toml
+++ b/rust/core-lib/assets/client_example.toml
@@ -18,3 +18,6 @@ plugin_search_path = []
 font_face = "InconsolataGo"
 # In points
 font_size = 14
+
+# automatically match current indentation level on newline
+auto_indent = true

--- a/rust/core-lib/assets/defaults.toml
+++ b/rust/core-lib/assets/defaults.toml
@@ -12,3 +12,5 @@ font_face = "InconsolataGo"
 font_size = 14
 
 line_ending = "\n"
+
+auto_indent = true

--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -46,6 +46,7 @@ mod defaults {
         "translate_tabs_to_spaces",
         "font_face",
         "font_size",
+        "auto_indent",
     ];
     /// config keys that are only legal at the top level
     pub const TOP_LEVEL_KEYS: &'static [&'static str] = &[
@@ -187,6 +188,7 @@ pub struct BufferItems {
     pub translate_tabs_to_spaces: bool,
     pub font_face: String,
     pub font_size: f32,
+    pub auto_indent: bool,
 }
 
 pub type BufferConfig = Config<BufferItems>;

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -72,6 +72,7 @@ pub use plugins::rpc as plugin_rpc;
 pub use plugins::PluginPid;
 pub use tabs::ViewIdentifier;
 pub use syntax::SyntaxDefinition;
+pub use config::{BufferItems as BufferConfig, Table as ConfigTable};
 
 use internal::tabs;
 use internal::editor;

--- a/rust/core-lib/src/plugins/manager.rs
+++ b/rust/core-lib/src/plugins/manager.rs
@@ -28,6 +28,7 @@ use serde_json::{self, Value};
 use xi_rpc::{RpcCtx, Handler, RemoteError};
 
 use tabs::{BufferIdentifier, ViewIdentifier, BufferContainerRef};
+use config::Table;
 
 use super::{PluginCatalog, PluginRef, start_plugin_process, PluginPid};
 use super::rpc::{PluginNotification, PluginRequest, PluginCommand,
@@ -472,6 +473,13 @@ impl PluginManagerRef {
             .collect::<Vec<String>>();
 
         self.start_plugins(view_id, &init_info, &to_run);
+    }
+
+    /// Notifies plugins of a user config change
+    pub fn document_config_changed(&self, view_id: ViewIdentifier,
+                                   changes: &Table) {
+        self.lock().notify_plugins(view_id, false, "config_changed",
+                                   &json!({"view_id": view_id, "changes": changes}));
     }
 
     /// Launches and initializes the named plugin.

--- a/rust/core-lib/src/plugins/rpc.rs
+++ b/rust/core-lib/src/plugins/rpc.rs
@@ -266,7 +266,7 @@ mod tests {
              "nb_lines": 5,
              "path": "some_path",
              "syntax": "toml",
-            "config": {"some_key": 420}}"#;
+             "config": {"some_key": 420}}"#;
 
         let val: PluginBufferInfo = match serde_json::from_str(json) {
             Ok(val) => val,

--- a/rust/core-lib/src/plugins/rpc.rs
+++ b/rust/core-lib/src/plugins/rpc.rs
@@ -23,6 +23,7 @@ use serde_json::{self, Value};
 use super::PluginPid;
 use syntax::SyntaxDefinition;
 use tabs::{BufferIdentifier, ViewIdentifier};
+use config::Table;
 
 //TODO: At the moment (May 08, 2017) this is all very much in flux.
 // At some point, it will be stabalized and then perhaps will live in another crate,
@@ -45,6 +46,7 @@ pub struct PluginBufferInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
     pub syntax: SyntaxDefinition,
+    pub config: Table,
 }
 
 //TODO: very likely this should be merged with PluginDescription
@@ -100,6 +102,7 @@ pub enum HostNotification {
     Ping(EmptyStruct),
     Initialize { plugin_id: PluginPid, buffer_info: Vec<PluginBufferInfo> },
     DidSave { view_id: ViewIdentifier, path: PathBuf },
+    ConfigChanged { view_id: ViewIdentifier, changes: Table },
     NewBuffer { buffer_info: Vec<PluginBufferInfo> },
     DidClose { view_id: ViewIdentifier },
     Shutdown(EmptyStruct),
@@ -201,11 +204,13 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for PluginCommand<T>
 impl PluginBufferInfo {
     pub fn new(buffer_id: BufferIdentifier, views: &[ViewIdentifier],
                rev: u64, buf_size: usize, nb_lines: usize,
-               path: Option<PathBuf>, syntax: SyntaxDefinition) -> Self {
+               path: Option<PathBuf>, syntax: SyntaxDefinition,
+               config: Table) -> Self {
         //TODO: do make any current assertions about paths being valid utf-8? do we want to?
         let path = path.map(|p| p.to_str().unwrap().to_owned());
         let views = views.to_owned();
-        PluginBufferInfo { buffer_id, views, rev, buf_size, nb_lines, path, syntax }
+        PluginBufferInfo { buffer_id, views, rev, buf_size,
+        nb_lines, path, syntax, config }
     }
 }
 

--- a/rust/core-lib/src/plugins/rpc.rs
+++ b/rust/core-lib/src/plugins/rpc.rs
@@ -265,7 +265,8 @@ mod tests {
              "buf_size": 20,
              "nb_lines": 5,
              "path": "some_path",
-             "syntax": "toml"}"#;
+             "syntax": "toml",
+            "config": {"some_key": 420}}"#;
 
         let val: PluginBufferInfo = match serde_json::from_str(json) {
             Ok(val) => val,

--- a/rust/syntect-plugin/src/main.rs
+++ b/rust/syntect-plugin/src/main.rs
@@ -275,7 +275,12 @@ impl<'a> state_cache::Plugin for PluginState<'a> {
     fn update(&mut self, mut ctx: PluginCtx<State>, start: usize, end: usize,
               new_len: usize, rev: usize, text: &Option<String>) -> Option<Value> {
         ctx.schedule_idle(0);
-        self.do_indentation(&mut ctx, start, end, new_len, rev, text)
+        let should_auto_indent = ctx.get_config().auto_indent;
+        if should_auto_indent {
+            self.do_indentation(&mut ctx, start, end, new_len, rev, text)
+        } else {
+            None
+        }
     }
 
     fn did_save(&mut self, ctx: PluginCtx<State>) {

--- a/rust/syntect-plugin/src/main.rs
+++ b/rust/syntect-plugin/src/main.rs
@@ -201,13 +201,8 @@ impl<'a> PluginState<'a> {
                       text: &Option<String>) -> Option<Value> {
         // don't touch indentation if this is not a simple edit
         if end != start { return None }
-        let is_newline = {
-            let line_ending = &ctx.get_config().line_ending;
-                text.as_ref()
-                .map(|t| t.ends_with(line_ending))
-                .unwrap_or(false)
-        };
 
+        let is_newline = Some(&ctx.get_config().line_ending) == text.as_ref();
         if is_newline {
             let line_num = ctx.find_offset(start).err();
 

--- a/rust/syntect-plugin/src/main.rs
+++ b/rust/syntect-plugin/src/main.rs
@@ -202,20 +202,17 @@ impl<'a> PluginState<'a> {
         // don't touch indentation if this is not a simple edit
         if end != start { return None }
         let is_newline = {
-            let user_line_ending = ctx.get_config().get("line_ending")
-                .unwrap().as_str().unwrap();
-            text.as_ref()
-                .map(|t| t.ends_with(user_line_ending))
+            let line_ending = &ctx.get_config().line_ending;
+                text.as_ref()
+                .map(|t| t.ends_with(line_ending))
                 .unwrap_or(false)
         };
 
         if is_newline {
             let line_num = ctx.find_offset(start).err();
 
-            let use_spaces = ctx.get_config().get("translate_tabs_to_spaces")
-                .unwrap().as_bool().unwrap();
-            let tab_size = ctx.get_config().get("tab_size").unwrap()
-                .as_u64().unwrap() as usize;
+            let use_spaces = ctx.get_config().translate_tabs_to_spaces;
+            let tab_size = ctx.get_config().tab_size;
             if let Some(line) = line_num.and_then(|idx| ctx.get_line(idx).ok()) {
                 let indent = self.indent_for_next_line(line, use_spaces, tab_size);
                 let edit = json!({


### PR DESCRIPTION
This is a first stab at bolting simple auto-indent onto syntect.

This depends on #406, which should go in first.

This is very naive. If a newline is entered, it matches the indentation of the previous line; if the previous line ended in one of '{', '[', ':', or '(', it increases the indentation level by whatever the current indentation preferences indicate.

This is **not** our long-term auto indentation solution, which involves fuller-featured language definitions. However this _is_ hopefully an improvement over the current behaviour!

To dos:

- [ ] be at least a little language aware
- [x] add a config flag to disable this feature
- [x] make it so that all indentation can be removed with a single backspace, where appropriate. I think this should live in core, but it _could_ be done in the plugin.