### PR TITLE
Backspace deletes tab_size worth of spaces

### DIFF
--- a/rust/core-lib/assets/client_example.toml
+++ b/rust/core-lib/assets/client_example.toml
@@ -9,12 +9,18 @@
 
 # The width of a tab, in spaces.
 tab_size = 4
+
 # Insert spaces when the tab key is pressed.
 translate_tabs_to_spaces = true
+
+# If translate_tabs_to_spaces is true, backspace will delete multiple
+# spaces, up to the previous tab stop.
+use_tab_stops = true
 
 # List of paths to additional plugins
 plugin_search_path = []
 
 font_face = "InconsolataGo"
+
 # In points
 font_size = 14

--- a/rust/core-lib/assets/defaults.toml
+++ b/rust/core-lib/assets/defaults.toml
@@ -4,11 +4,15 @@
 # `client_example.toml` in this directory.
 
 tab_size = 4
+
 translate_tabs_to_spaces = true
+
+use_tab_stops = true
 
 plugin_search_path = []
 
 font_face = "InconsolataGo"
+
 font_size = 14
 
 line_ending = "\n"

--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -44,6 +44,7 @@ mod defaults {
         "tab_size",
         "line_ending",
         "translate_tabs_to_spaces",
+        "use_tab_stops",
         "font_face",
         "font_size",
     ];
@@ -185,6 +186,7 @@ pub struct BufferItems {
     pub line_ending: String,
     pub tab_size: usize,
     pub translate_tabs_to_spaces: bool,
+    pub use_tab_stops: bool,
     pub font_face: String,
     pub font_size: f32,
 }

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -476,16 +476,20 @@ impl Editor {
                 region.min()
             } else {
                 // backspace deletes max(1, tab_size) contiguous spaces
-                let tab_size = self.config.items.tab_size;
+                let (_, c) = self.view.offset_to_line_col(&self.text,
+                                                          region.start);
                 let use_spaces = self.config.items.translate_tabs_to_spaces;
-                let preceded_by_spaces = (0..tab_size)
-                    .map(|i| (region.max() - 1) - i)
-                    .all(|i| self.text.byte_at(i) == b' ');
+                let tab_size = self.config.items.tab_size;
+                let tab_size = if c % tab_size == 0 { tab_size } else { c % tab_size };
+                let preceded_by_spaces = (1..tab_size + 1)
+                    .map(|i| region.start.saturating_sub(i))
+                    .all(|i| self.text.len() > 0 && self.text.byte_at(i) == b' ');
                if preceded_by_spaces && use_spaces {
-                   region.max() - tab_size
+                   region.start - tab_size
                } else {
                    // TODO: implement complex emoji logic
-                    self.text.prev_codepoint_offset(region.end).unwrap_or(region.end)
+                    self.text.prev_codepoint_offset(region.end)
+                        .unwrap_or(region.end)
                }
             };
 

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -479,12 +479,13 @@ impl Editor {
                 let (_, c) = self.view.offset_to_line_col(&self.text,
                                                           region.start);
                 let use_spaces = self.config.items.translate_tabs_to_spaces;
+                let use_tab_stops = self.config.items.use_tab_stops;
                 let tab_size = self.config.items.tab_size;
                 let tab_size = if c % tab_size == 0 { tab_size } else { c % tab_size };
                 let preceded_by_spaces = self.text.len() > 0 &&
                     (region.start.saturating_sub(tab_size)..region.start)
                     .all(|i| self.text.byte_at(i) == b' ');
-               if preceded_by_spaces && use_spaces {
+               if preceded_by_spaces && use_spaces && use_tab_stops {
                    region.start - tab_size
                } else {
                    // TODO: implement complex emoji logic

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -481,9 +481,9 @@ impl Editor {
                 let use_spaces = self.config.items.translate_tabs_to_spaces;
                 let tab_size = self.config.items.tab_size;
                 let tab_size = if c % tab_size == 0 { tab_size } else { c % tab_size };
-                let preceded_by_spaces = (1..tab_size + 1)
-                    .map(|i| region.start.saturating_sub(i))
-                    .all(|i| self.text.len() > 0 && self.text.byte_at(i) == b' ');
+                let preceded_by_spaces = self.text.len() > 0 &&
+                    (region.start.saturating_sub(tab_size)..region.start)
+                    .all(|i| self.text.byte_at(i) == b' ');
                if preceded_by_spaces && use_spaces {
                    region.start - tab_size
                } else {


### PR DESCRIPTION
With this patch backspace will delete `tab_size` contiguous spaces, if possible.

@raphlinus: I'm earnestly curious to know how you would've implemented this; my implementation feels okay but I have a nagging feeling there's a cleaner one out there?