### PR TITLE
Tuning some constants

### DIFF
--- a/rust/core-lib/src/watcher.rs
+++ b/rust/core-lib/src/watcher.rs
@@ -25,6 +25,9 @@ use xi_rpc::RpcPeer;
 /// xi_rpc idle Token for watcher related idle scheduling.
 pub const WATCH_IDLE_TOKEN: usize = 1002;
 
+/// Delay for aggregating related file system events.
+pub const DEBOUNCE_WAIT_MILLIS: u64 = 50;
+
 /// Token provided to `FsWatcher`, to associate events with registrees.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EventToken(pub usize);
@@ -62,7 +65,8 @@ impl FsWatcher {
         thread::spawn(move || {
 
             let (tx, rx) = channel();
-            let mut watcher = watcher(tx, Duration::from_secs(1)).unwrap();
+            let mut watcher = watcher(tx, Duration::from_millis(DEBOUNCE_WAIT_MILLIS))
+                .unwrap();
 
             watcher.watch(&path, recursive_mode).unwrap();
 

--- a/rust/syntect-plugin/src/main.rs
+++ b/rust/syntect-plugin/src/main.rs
@@ -39,7 +39,7 @@ struct PluginState<'a> {
     syntax_name: String,
 }
 
-const LINES_PER_RPC: usize = 50;
+const LINES_PER_RPC: usize = 10;
 
 type LockedRepo = MutexGuard<'static, ScopeRepository>;
 


### PR DESCRIPTION
Decreasing the lines-per-RPC visibly improves scrolling performance on
xi-mac, especially in debug builds; and there is no apparent advantage
to having a significant debounce delay in the file watcher, which is
only used for reloading preferences.