### PR TITLE
Clamp start of render request region

### DIFF
--- a/rust/core-lib/src/line_cache_shadow.rs
+++ b/rust/core-lib/src/line_cache_shadow.rs
@@ -240,6 +240,7 @@ impl RenderPlan {
     pub fn create(total_height: usize, first_line: usize, height: usize) -> RenderPlan {
         let mut spans = Vec::new();
         let mut last = 0;
+        let first_line = min(first_line, total_height);
         if first_line > PRESERVE_EXTENT {
             last = first_line - PRESERVE_EXTENT;
             spans.push((last, RenderTactic::Discard));


### PR DESCRIPTION
In extreme cases, it's possible for the start of a render request
to go past the actual length of the document.

Fixes #452