### PR TITLE
Add scroll_past_end config option

### DIFF
--- a/rust/core-lib/assets/client_example.toml
+++ b/rust/core-lib/assets/client_example.toml
@@ -19,5 +19,8 @@ font_face = "InconsolataGo"
 # In points
 font_size = 14
 
-# automatically match current indentation level on newline
+# Automatically match current indentation level on newline.
 auto_indent = true
+
+# Allow scrolling past the last line of a document.
+scroll_past_end = false

--- a/rust/core-lib/assets/defaults.toml
+++ b/rust/core-lib/assets/defaults.toml
@@ -14,3 +14,5 @@ font_size = 14
 line_ending = "\n"
 
 auto_indent = true
+
+scroll_past_end = false

--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -47,6 +47,7 @@ mod defaults {
         "font_face",
         "font_size",
         "auto_indent",
+        "scroll_past_end",
     ];
     /// config keys that are only legal at the top level
     pub const TOP_LEVEL_KEYS: &'static [&'static str] = &[
@@ -189,6 +190,7 @@ pub struct BufferItems {
     pub font_face: String,
     pub font_size: f32,
     pub auto_indent: bool,
+    pub scroll_past_end: bool,
 }
 
 pub type BufferConfig = Config<BufferItems>;


### PR DESCRIPTION
This adds a new config setting, `scrolls_past_end (bool)`.

In this patch, the default value is `false`, which matches the current behaviour.

In Sublime Text, the default value is `false` on macOS, and `true` on other platforms; Xcode does not allow scrolling past the end.

In any case, now at least it's an option?