### PR TITLE
Disable autoindent

### DIFF
--- a/rust/core-lib/assets/client_example.toml
+++ b/rust/core-lib/assets/client_example.toml
@@ -26,7 +26,8 @@ font_face = "InconsolataGo"
 font_size = 14
 
 # Automatically match current indentation level on newline.
-auto_indent = true
+# note: this is currently broken on files with > 1k lines
+auto_indent = false
 
 # Allow scrolling past the last line of a document.
 scroll_past_end = false

--- a/rust/core-lib/assets/defaults.toml
+++ b/rust/core-lib/assets/defaults.toml
@@ -17,6 +17,6 @@ font_size = 14
 
 line_ending = "\n"
 
-auto_indent = true
+auto_indent = false
 
 scroll_past_end = false


### PR DESCRIPTION
This leaves the current implementation in place, but stops running it. I think this is reasonable in this situation because it will be helpful to have some plugin capable of sending edits  while working on #466.

Maybe it would actually make more sense to just have this disabled by default? It does work and is helpful in the case where a file has < 1k lines, and anyone who finds and turns on the setting will probably know what's up if things get weird.