### PR TITLE
Tracing infrastructure

### DIFF
--- a/rust/trace/Cargo.toml
+++ b/rust/trace/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "xi-trace"
+version = "0.1.0"
+license = "Apache-2.0"
+authors = ["Vitali Lovich <vlovich@google.com>"]
+categories = ["development-tools::profiling"]
+repository = "https://github.com/google/xi-editor"
+description = "Library-based distributed tracing API to meet the needs of xi-core, frontends and plugins"
+
+[features]
+benchmarks = []
+collections_range = []
+default = []
+dict_payload = []
+json_payload = ["serde_json"]
+getpid = []
+
+[dependencies]
+time = "0.1.39"
+lazy_static = "1.0"
+serde_json = { version = "1.0", optional = true }
+libc = "0.2.36"
+
+[profile.bench]
+lto = true

--- a/rust/trace/src/fixed_lifo_deque.rs
+++ b/rust/trace/src/fixed_lifo_deque.rs
@@ -1,0 +1,412 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp;
+use std::cmp::Ordering;
+#[cfg(feature = "collections_range")]
+use std::collections::range::RangeArgument;
+#[cfg(feature = "collections_range")]
+use std::collections::vec_deque::Drain;
+use std::collections::vec_deque::{IntoIter, Iter, IterMut, VecDeque};
+use std::hash::{Hash, Hasher};
+use std::ops::{Index, IndexMut};
+
+/// Provides fixed size ring buffer that overwrites elements in FIFO order on
+/// insertion when full.  API provided is similar to VecDeque & uses a VecDeque
+/// internally. One distinction is that only append-like insertion is allowed.
+/// This means that insert & push_front are not allowed.  The reasoning is that
+/// there is ambiguity on how such functions should operate since it would be
+/// pretty impossible to maintain a FIFO ordering.
+///
+/// All operations that would cause growth beyond the limit drop the appropriate
+/// number of elements from the front.  For example, on a full buffer push_front
+/// replaces the first element.
+///
+/// The removal of elements on operation that would cause excess beyond the
+/// limit happens first to make sure the space is available in the underlying
+/// VecDeque, thus guaranteeing O(1) operations always.
+#[derive(Clone, Debug)]
+pub struct FixedLifoDeque<T> {
+    storage: VecDeque<T>,
+    limit: usize,
+}
+
+impl<T> FixedLifoDeque<T> {
+    /// Constructs a ring buffer that will reject all insertions as no-ops.
+    /// This also construct the underlying VecDeque with_capacity(0) which
+    /// in the current stdlib implementation allocates 2 Ts.
+    #[inline]
+    pub fn new() -> Self {
+        FixedLifoDeque::with_limit(0)
+    }
+
+    /// Constructs a fixed size ring buffer with the given number of elements.
+    /// Attempts to insert more than this number of elements will cause excess
+    /// elements to first be evicted in FIFO order (i.e. from the front).
+    pub fn with_limit(n: usize) -> Self {
+        FixedLifoDeque {
+            storage: VecDeque::with_capacity(n),
+            limit: n
+        }
+    }
+
+    /// This sets a new limit on the container.  Excess elements are dropped in
+    /// FIFO order.  The new capacity is reset to the requested limit which will
+    /// likely result in re-allocation + copies/clones even if the limit
+    /// shrinks.
+    pub fn reset_limit(&mut self, n: usize) {
+        if n < self.limit {
+            let overflow = self.limit - n;
+            self.drop_excess_for_inserting(overflow);
+        }
+        self.limit = n;
+        self.storage.reserve_exact(n);
+        self.storage.shrink_to_fit();
+        debug_assert!(self.storage.len() <= self.limit);
+    }
+
+    /// Returns the current limit this ring buffer is configured with.
+    #[inline]
+    pub fn limit(&self) -> usize {
+        self.limit
+    }
+
+    #[inline]
+    pub fn get(&self, index: usize) -> Option<&T> {
+        self.storage.get(index)
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut T> {
+        self.storage.get_mut(index)
+    }
+
+    #[inline]
+    pub fn swap(&mut self, i: usize, j: usize) {
+        self.storage.swap(i, j);
+    }
+
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.limit
+    }
+
+    #[inline]
+    pub fn iter(&self) -> Iter<T> {
+        self.storage.iter()
+    }
+
+    #[inline]
+    pub fn iter_mut(&mut self) -> IterMut<T> {
+        self.storage.iter_mut()
+    }
+
+    /// Returns a tuple of 2 slices that represents the ring buffer. [0] is the
+    /// beginning of the buffer to the physical end of the array or the last
+    /// element (whichever comes first).  [1] is the continuation of [0] if the
+    /// ring buffer has wrapped the contiguous storage.
+    #[inline]
+    pub fn as_slices(&self) -> (&[T], &[T]) {
+        self.storage.as_slices()
+    }
+
+    #[inline]
+    pub fn as_mut_slices(&mut self) -> (&mut [T], &mut [T]) {
+        self.storage.as_mut_slices()
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.storage.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.storage.is_empty()
+    }
+
+    #[inline]
+    #[cfg(feature = "collections_range")]
+    pub fn drain<R>(&mut self, range: R) -> Drain<T>
+        where R : RangeArgument<usize>
+    {
+        self.storage.drain(range)
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        self.storage.clear();
+    }
+
+    #[inline]
+    pub fn contains(&self, x: &T) -> bool
+        where T: PartialEq<T>
+    {
+        self.storage.contains(x)
+    }
+
+    #[inline]
+    pub fn front(&self) -> Option<&T> {
+        self.storage.front()
+    }
+
+    #[inline]
+    pub fn front_mut(&mut self) -> Option<&mut T> {
+        self.storage.front_mut()
+    }
+
+    #[inline]
+    pub fn back(&self) -> Option<&T> {
+        self.storage.back()
+    }
+
+    #[inline]
+    pub fn back_mut(&mut self) -> Option<&mut T> {
+        self.storage.back_mut()
+    }
+
+    #[inline]
+    fn drop_excess_for_inserting(&mut self, n_to_be_inserted: usize) {
+        if self.storage.len() + n_to_be_inserted > self.limit {
+            let overflow = self.storage.len().min(self.storage.len() + n_to_be_inserted - self.limit);
+            self.storage.drain(..overflow);
+        }
+    }
+
+    /// Always an O(1) operation.  Memory is never reclaimed.
+    #[inline]
+    pub fn pop_front(&mut self) -> Option<T> {
+        self.storage.pop_front()
+    }
+
+    /// Always an O(1) operation.  If the number of elements is at the limit,
+    /// the element at the front is overwritten.
+    ///
+    /// Post condition: The number of elements is <= limit
+    pub fn push_back(&mut self, value: T) {
+        self.drop_excess_for_inserting(1);
+        self.storage.push_back(value);
+        // For when limit == 0
+        self.drop_excess_for_inserting(0);
+    }
+
+    /// Always an O(1) operation.  Memory is never reclaimed.
+    #[inline]
+    pub fn pop_back(&mut self) -> Option<T> {
+        self.storage.pop_back()
+    }
+
+    #[inline]
+    pub fn swap_remove_back(&mut self, index: usize) -> Option<T> {
+        self.storage.swap_remove_back(index)
+    }
+
+    #[inline]
+    pub fn swap_remove_front(&mut self, index: usize) -> Option<T> {
+        self.storage.swap_remove_front(index)
+    }
+
+    /// Always an O(1) operation.
+    #[inline]
+    pub fn remove(&mut self, index: usize) -> Option<T> {
+        self.storage.remove(index)
+    }
+
+    pub fn split_off(&mut self, at: usize) -> FixedLifoDeque<T> {
+        FixedLifoDeque {
+            storage: self.storage.split_off(at),
+            limit: self.limit
+        }
+    }
+
+    /// Always an O(m) operation where m is the length of `other'.
+    pub fn append(&mut self, other: &mut VecDeque<T>) {
+        self.drop_excess_for_inserting(other.len());
+        self.storage.append(other);
+        // For when limit == 0
+        self.drop_excess_for_inserting(0);
+    }
+
+    #[inline]
+    pub fn retain<F>(&mut self, f: F)
+        where F: FnMut(&T) -> bool
+    {
+        self.storage.retain(f);
+    }
+}
+
+impl<T: Clone> FixedLifoDeque<T> {
+    /// Resizes a fixed queue.  This doesn't change the limit so the resize is
+    /// capped to the limit.  Additionally, resizing drops the elements from the
+    /// front unlike with a regular VecDeque.
+    pub fn resize(&mut self, new_len: usize, value: T) {
+        if new_len < self.len() {
+            let to_drop = self.len() - new_len;
+            self.storage.drain(..to_drop);
+        } else {
+            self.storage.resize(cmp::min(self.limit, new_len), value);
+        }
+    }
+}
+
+impl<A: PartialEq> PartialEq for FixedLifoDeque<A> {
+    #[inline]
+    fn eq(&self, other: &FixedLifoDeque<A>) -> bool {
+        return self.storage == other.storage;
+    }
+}
+
+impl<A: Eq> Eq for FixedLifoDeque<A> {}
+
+impl<A: PartialOrd> PartialOrd for FixedLifoDeque<A> {
+    #[inline]
+    fn partial_cmp(&self, other: &FixedLifoDeque<A>) -> Option<Ordering> {
+        self.storage.partial_cmp(&other.storage)
+    }
+}
+
+impl<A: Ord> Ord for FixedLifoDeque<A> {
+    #[inline]
+    fn cmp(&self, other: &FixedLifoDeque<A>) -> Ordering {
+        self.storage.cmp(&other.storage)
+    }
+}
+
+impl<A: Hash> Hash for FixedLifoDeque<A> {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.storage.hash(state);
+    }
+}
+
+impl<A> Index<usize> for FixedLifoDeque<A> {
+    type Output = A;
+
+    #[inline]
+    fn index(&self, index: usize) -> &A {
+        &self.storage[index]
+    }
+}
+
+impl<A> IndexMut<usize> for FixedLifoDeque<A> {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut A {
+        &mut self.storage[index]
+    }
+}
+
+impl<T> IntoIterator for FixedLifoDeque<T> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+
+    /// Consumes the list into a front-to-back iterator yielding elements by
+    /// value.
+    #[inline]
+    fn into_iter(self) -> IntoIter<T> {
+        self.storage.into_iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a FixedLifoDeque<T> {
+    type Item = &'a T;
+    type IntoIter = Iter<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> Iter<'a, T> {
+        self.storage.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut FixedLifoDeque<T> {
+    type Item = &'a mut T;
+    type IntoIter = IterMut<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> IterMut<'a, T> {
+        self.storage.iter_mut()
+    }
+}
+
+impl<A> Extend<A> for FixedLifoDeque<A> {
+    fn extend<T: IntoIterator<Item = A>>(&mut self, iter: T) {
+        for elt in iter {
+            self.push_back(elt);
+        }
+    }
+}
+
+impl<'a, T: 'a + Copy> Extend<&'a T> for FixedLifoDeque<T> {
+    fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
+        self.extend(iter.into_iter().cloned());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(feature = "benchmarks")]
+    use test::Bencher;
+
+    #[test]
+    fn test_basic_insertions() {
+        let mut tester = FixedLifoDeque::with_limit(3);
+        assert_eq!(tester.len(), 0);
+        assert_eq!(tester.capacity(), 3);
+        assert_eq!(tester.front(), None);
+        assert_eq!(tester.back(), None);
+
+        tester.push_back(1);
+        assert_eq!(tester.len(), 1);
+        assert_eq!(tester.front(), Some(1).as_ref());
+        assert_eq!(tester.back(), Some(1).as_ref());
+
+        tester.push_back(2);
+        assert_eq!(tester.len(), 2);
+        assert_eq!(tester.front(), Some(1).as_ref());
+        assert_eq!(tester.back(), Some(2).as_ref());
+
+        tester.push_back(3);
+        tester.push_back(4);
+        assert_eq!(tester.len(), 3);
+        assert_eq!(tester.front(), Some(2).as_ref());
+        assert_eq!(tester.back(), Some(4).as_ref());
+        assert_eq!(tester[0], 2);
+        assert_eq!(tester[1], 3);
+        assert_eq!(tester[2], 4);
+    }
+
+    #[cfg(feature = "benchmarks")]
+    #[bench]
+    fn bench_push_back(b: &mut Bencher) {
+        let mut q = FixedLifoDeque::with_limit(10);
+        b.iter(|| q.push_back(5));
+    }
+
+    #[cfg(feature = "benchmarks")]
+    #[bench]
+    fn bench_deletion_from_empty(b: &mut Bencher) {
+        let mut q = FixedLifoDeque::<u32>::with_limit(10000);
+        b.iter(|| q.pop_front());
+    }
+
+    #[cfg(feature = "benchmarks")]
+    #[bench]
+    fn bench_deletion_from_non_empty(b: &mut Bencher) {
+        let mut q = FixedLifoDeque::with_limit(1000000);
+        for i in 0..q.limit() {
+            q.push_back(i);
+        }
+        b.iter(|| q.pop_front());
+    }
+}

--- a/rust/trace/src/lib.rs
+++ b/rust/trace/src/lib.rs
@@ -1,0 +1,693 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg_attr(feature = "benchmarks", feature(test))]
+#![cfg_attr(feature = "collections_range", feature(collections_range))]
+
+#[macro_use]
+extern crate lazy_static;
+extern crate time;
+
+extern crate libc;
+
+#[cfg(all(test, feature = "benchmarks"))]
+extern crate test;
+
+#[cfg(feature = "json_payload")]
+#[macro_use]
+extern crate serde_json;
+
+mod fixed_lifo_deque;
+mod sys_pid;
+mod sys_tid;
+
+use std::borrow::Cow;
+use std::cmp;
+
+use std::mem::size_of;
+use std::hash::{Hash, Hasher};
+use std::sync::atomic::{AtomicBool, AtomicUsize, ATOMIC_USIZE_INIT, Ordering as AtomicOrdering};
+use std::sync::Mutex;
+use fixed_lifo_deque::FixedLifoDeque;
+
+pub type StrCow = Cow<'static, str>;
+pub type CategoriesT = &'static[&'static str];
+
+#[cfg(all(not(feature = "dict_payload"), not(feature = "json_payload")))]
+type TracePayloadT = StrCow;
+
+#[cfg(feature = "json_payload")]
+type TracePayloadT = serde_json::Value;
+
+#[cfg(feature = "dict_payload")]
+type TracePayloadT = std::collections::HashMap<StrCow, StrCow>;
+
+#[derive(Copy, Clone)]
+pub struct Config {
+    /* Returns the maximum number of bytes that should be used for storing trace data */
+    sample_limit_count: usize
+}
+
+impl Config {
+    fn with_limit_bytes(size: usize) -> Self {
+        Self::with_limit_count(size / size_of::<Sample>())
+    }
+
+    fn with_limit_count(limit: usize) -> Self {
+        Self {
+            sample_limit_count: limit
+        }
+    }
+
+    fn default() -> Self {
+        // 1 MB
+        Self::with_limit_bytes(1 * 1024 * 1024)
+    }
+
+    pub fn max_size_in_bytes(&self) -> usize {
+        self.sample_limit_count * size_of::<Sample>()
+    }
+
+    pub fn max_samples(&self) -> usize {
+        self.sample_limit_count
+    }
+}
+
+static SAMPLE_COUNTER: AtomicUsize = ATOMIC_USIZE_INIT;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SampleType {
+    Instant,
+    Duration,
+}
+
+#[derive(Clone, Debug)]
+pub struct Sample {
+    /// A private ordering to apply to the events based on creation order.
+    /// Disambiguates in case 2 samples might be created from different threads
+    /// with the same start_ns for purposes of ordering.
+    sample_id: usize,
+    /// The name of the event to be shown.
+    pub name: StrCow,
+    /// List of categories the event applies to.
+    pub categories: CategoriesT,
+    /// An arbitrary payload to associate with the sample.
+    pub payload: Option<TracePayloadT>,
+    /// When was the sample started.
+    pub start_ns: u64,
+    /// When the sample completed.  Equivalent to start_ns for instantaneous
+    /// samples.
+    pub end_ns: u64,
+    /// Whether the sample was record via trace/trace_payload or
+    /// trace_block/trace_closure.
+    pub sample_type: SampleType,
+    /// The thread the sample was captured on.
+    pub tid: u64,
+    /// The process the sample was captured in.
+    pub pid: u64,
+}
+
+impl Sample {
+    fn new<S>(name: S, categories: CategoriesT, payload: Option<TracePayloadT>)
+        -> Self
+        where S: Into<StrCow>
+    {
+        Self {
+            sample_id: SAMPLE_COUNTER.fetch_add(1, AtomicOrdering::Relaxed),
+            name: name.into(),
+            categories: categories,
+            start_ns: time::precise_time_ns(),
+            payload: payload,
+            end_ns: 0,
+            sample_type: SampleType::Duration,
+            tid: sys_tid::current_tid().unwrap(),
+            pid: sys_pid::current_pid(),
+        }
+    }
+
+    fn new_instant<S>(name: S, categories: CategoriesT,
+                      payload: Option<TracePayloadT>) -> Self
+        where S: Into<StrCow>
+    {
+        let now = time::precise_time_ns();
+        Self {
+            sample_id: SAMPLE_COUNTER.fetch_add(1, AtomicOrdering::Relaxed),
+            name: name.into(),
+            categories: categories,
+            start_ns: now,
+            payload: payload,
+            end_ns: now,
+            sample_type: SampleType::Instant,
+            tid: sys_tid::current_tid().unwrap(),
+            pid: sys_pid::current_pid(),
+        }
+    }
+}
+
+impl PartialEq for Sample {
+    fn eq(&self, other: &Sample) -> bool {
+        self.sample_id == other.sample_id
+    }
+}
+
+impl Eq for Sample {}
+
+impl PartialOrd for Sample {
+    fn partial_cmp(&self, other: &Sample) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Sample {
+    fn cmp(&self, other: &Sample) -> cmp::Ordering {
+        self.sample_id.cmp(&other.sample_id)
+    }
+}
+
+impl Hash for Sample {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.sample_id.hash(state);
+    }
+}
+
+pub struct SampleGuard {
+    sample: Option<Sample>,
+}
+
+impl SampleGuard {
+    #[inline]
+    fn new_disabled() -> Self {
+        Self {
+            sample: None
+        }
+    }
+
+    #[inline]
+    fn new<S>(name: S, categories: CategoriesT, payload: Option<TracePayloadT>)
+        -> Self
+        where S: Into<StrCow>
+    {
+        Self {
+            sample: Some(Sample::new(name, categories, payload))
+        }
+    }
+}
+
+impl Drop for SampleGuard {
+    fn drop(&mut self) {
+        if let Some(ref mut sample) = self.sample {
+            sample.end_ns = time::precise_time_ns();
+            record_sample(sample);
+        }
+    }
+}
+
+struct Trace {
+    enabled: AtomicBool,
+    samples: Mutex<FixedLifoDeque<Sample>>,
+}
+
+impl Trace {
+    fn new() -> Self {
+        Self {
+            enabled: AtomicBool::new(false),
+            samples: Mutex::new(FixedLifoDeque::new())
+        }
+    }
+}
+
+lazy_static! { static ref TRACE : Trace = Trace::new(); }
+
+pub fn enable_tracing() {
+    enable_tracing_with_config(&Config::default());
+}
+
+pub fn enable_tracing_with_config(config: &Config) {
+    let mut all_samples = TRACE.samples.lock().unwrap();
+    all_samples.reset_limit(config.max_samples());
+    TRACE.enabled.store(true, AtomicOrdering::Relaxed);
+}
+
+pub fn disable_tracing() {
+    let mut all_samples = TRACE.samples.lock().unwrap();
+    all_samples.reset_limit(0);
+    SAMPLE_COUNTER.store(0, AtomicOrdering::Relaxed);
+    TRACE.enabled.store(false, AtomicOrdering::Relaxed);
+}
+
+#[inline]
+fn is_enabled() -> bool {
+    TRACE.enabled.load(AtomicOrdering::Relaxed)
+}
+
+pub fn trace<S>(name: S, categories: CategoriesT)
+    where S: Into<StrCow>
+{
+    if is_enabled() {
+        record_sample(&Sample::new_instant(name, categories, None));
+    }
+}
+
+pub fn trace_payload<S, P>(name: S, categories: CategoriesT, payload: P)
+    where S: Into<StrCow>, P: Into<TracePayloadT>
+{
+    if is_enabled() {
+        record_sample(&Sample::new_instant(name, categories,
+                                           Some(payload.into())));
+    }
+}
+
+pub fn trace_block<S>(name: S, categories: CategoriesT) -> SampleGuard
+    where S: Into<StrCow>
+{
+    if !is_enabled() {
+        SampleGuard::new_disabled()
+    } else {
+        SampleGuard::new(name, categories, None)
+    }
+}
+
+pub fn trace_block_payload<S, P>(name: S, categories: CategoriesT, payload: P)
+    -> SampleGuard
+    where S: Into<StrCow>, P: Into<TracePayloadT>
+{
+    if !is_enabled() {
+        SampleGuard::new_disabled()
+    } else {
+        SampleGuard::new(name, categories, Some(payload.into()))
+    }
+}
+
+pub fn trace_closure<S, F, R>(name: S, categories: CategoriesT, closure: F) -> R
+    where S: Into<StrCow>, F: FnOnce() -> R
+{
+    let _closure_guard = trace_block(name, categories);
+    let r = closure();
+    r
+}
+
+pub fn trace_closure_payload<S, P, F, R>(name: S, categories: CategoriesT,
+                                              closure: F, payload: P) -> R
+    where S: Into<StrCow>, P: Into<TracePayloadT>,
+          F: FnOnce() -> R
+{
+    let _closure_guard = trace_block_payload(name, categories, payload);
+    let r = closure();
+    r
+}
+
+/// Returns all the samples collected so far.  There is no guarantee that the
+/// samples are ordered chronologically for several reasons:
+/// 1. Samples that span sections of code may be inserted on end instead of
+/// beginning.
+/// 2. Performance optimizations might have per-thread buffers.  Keeping all
+/// that sorted would be prohibitively expensive.
+/// 3. You may not care about them always being sorted if you're merging samples
+/// from multiple distributed sources (i.e. you want to sort the merged result
+/// rather than just this processe's samples).
+pub fn samples_cloned_unsorted() -> Vec<Sample> {
+    let all_samples = TRACE.samples.lock().unwrap();
+    let mut as_vec = Vec::with_capacity(all_samples.len());
+    as_vec.extend(all_samples.iter().cloned());
+    as_vec
+}
+
+/// Returns all the samples collected so far ordered chronologically by
+/// creation.  Roughly corresponds to start_ns but instead there's a
+/// monotonically increasing single global integer (when tracing) per creation
+/// of Sample that determines order.
+pub fn samples_cloned_sorted() -> Vec<Sample> {
+    let mut samples = samples_cloned_unsorted();
+    samples.sort_unstable();
+    samples
+}
+
+#[inline]
+fn record_sample(sample: &Sample) {
+    let mut all_samples = TRACE.samples.lock().unwrap();
+    all_samples.push_back(sample.clone());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(feature = "benchmarks")]
+    use test::Bencher;
+    #[cfg(feature = "benchmarks")]
+    use test::black_box;
+
+    lazy_static! { static ref TEST_MUTEX : Mutex<u32> = Mutex::new(0); }
+
+    #[cfg(all(not(feature = "dict_payload"), not(feature = "json_payload")))]
+    fn to_payload(value: &'static str) -> &'static str {
+        value
+    }
+
+    #[cfg(feature = "dict_payload")]
+    fn to_payload(value: &'static str) -> TracePayloadT {
+        let mut d = TracePayloadT::with_capacity(1);
+        d.insert(StrCow::from("test"), StrCow::from(value));
+        d
+    }
+
+    #[cfg(feature = "json_payload")]
+    fn to_payload(value: &'static str) -> TracePayloadT {
+        json!({"test": value})
+    }
+
+    fn get_samples_count() -> usize {
+        TRACE.samples.lock().unwrap().len()
+    }
+
+    fn get_samples_limit() -> usize {
+        TRACE.samples.lock().unwrap().limit()
+    }
+
+    #[test]
+    fn test_samples_pulse() {
+        let _test_mutex = TEST_MUTEX.lock().unwrap();
+
+        disable_tracing();
+        enable_tracing_with_config(&Config::with_limit_count(10));
+        for _i in 0..50 {
+            trace("test_samples_pulse", &["test"]);
+        }
+    }
+
+    #[test]
+    fn test_samples_block() {
+        let _test_mutex = TEST_MUTEX.lock().unwrap();
+
+        disable_tracing();
+        enable_tracing_with_config(&Config::with_limit_count(10));
+        for _i in 0..50 {
+            let _ = trace_block("test_samples_block", &["test"]);
+        }
+    }
+
+    #[test]
+    fn test_samples_closure() {
+        let _test_mutex = TEST_MUTEX.lock().unwrap();
+
+        disable_tracing();
+        enable_tracing_with_config(&Config::with_limit_count(10));
+        for _i in 0..50 {
+            trace_closure("test_samples_closure", &["test"], || {});
+        }
+    }
+
+    #[test]
+    fn test_disable_drops_all_samples() {
+        let _test_mutex = TEST_MUTEX.lock().unwrap();
+
+        disable_tracing();
+        enable_tracing_with_config(&Config::with_limit_count(10));
+        trace("1", &["test"]);
+        trace("2", &["test"]);
+        trace("3", &["test"]);
+        trace("4", &["test"]);
+        trace("5", &["test"]);
+        assert_eq!(get_samples_count(), 5);
+        assert_eq!(samples_cloned_unsorted().len(), 5);
+        disable_tracing();
+        assert_eq!(get_samples_count(), 0);
+        assert_eq!(samples_cloned_unsorted().len(), 0);
+    }
+
+    #[test]
+    fn test_get_samples() {
+        let _test_mutex = TEST_MUTEX.lock().unwrap();
+
+        disable_tracing();
+        for i in 0..100 {
+            assert_eq!(samples_cloned_unsorted().len(), 0, "i = {}", i);
+        }
+
+        enable_tracing_with_config(&Config::with_limit_count(20));
+        assert_eq!(samples_cloned_unsorted().len(), 0);
+
+        for i in 0..100 {
+            assert_eq!(samples_cloned_unsorted().len(), 0, "i = {}", i);
+        }
+
+        assert_eq!(is_enabled(), true);
+        assert_eq!(get_samples_limit(), 20);
+        assert_eq!(samples_cloned_unsorted().len(), 0);
+
+        trace_closure_payload("x", &["test"], || {},
+                              to_payload("test_get_samples"));
+        assert_eq!(samples_cloned_unsorted().len(), 1);
+
+        trace_closure_payload("y", &["test"], || {},
+                              to_payload("test_get_samples"));
+        assert_eq!(samples_cloned_unsorted().len(), 2);
+
+        trace_closure_payload("z", &["test"], || {},
+                              to_payload("test_get_samples"));
+        assert_eq!(samples_cloned_unsorted().len(), 3);
+
+        let snapshot = samples_cloned_unsorted();
+        assert_eq!(snapshot.len(), 3);
+        assert_eq!(snapshot[0].sample_id, 0);
+        assert_eq!(snapshot[0].name, "x");
+        assert_eq!(snapshot[1].sample_id, 1);
+        assert_eq!(snapshot[1].name, "y");
+        assert_eq!(snapshot[2].sample_id, 2);
+        assert_eq!(snapshot[2].name, "z");
+    }
+
+    #[test]
+    fn test_get_samples_nested_trace() {
+        let _test_mutex = TEST_MUTEX.lock().unwrap();
+
+        disable_tracing();
+        assert_eq!(get_samples_limit(), 0);
+
+        enable_tracing_with_config(&Config::with_limit_count(11));
+        assert_eq!(is_enabled(), true);
+        assert_eq!(get_samples_limit(), 11);
+
+        // current recording mechanism should see:
+        // a, b, y, z, c, x
+        // even though the actual sampling order (from timestamp of
+        // creation) is:
+        // x, a, y, b, z, c
+        // This might be an over-specified test as it will
+        // probably change as the recording internals change.
+        trace_closure_payload("x", &["test"], || {
+            trace_payload("a", &["test"], to_payload("test_get_samples_nested_trace"));
+            trace_closure_payload("y", &["test"], || {
+                trace_payload("b", &["test"], to_payload("test_get_samples_nested_trace"));
+            }, to_payload("test_get_samples_nested_trace"));
+            trace_block_payload("z", &["test"], to_payload("test_get_samples_nested_trace"));
+            trace_payload("c", &["test"], to_payload("test_get_samples_nested_trace"));
+        }, to_payload("test_get_samples_nested_trace"));
+
+        let snapshot = samples_cloned_unsorted();
+        assert_eq!(snapshot.len(), 6);
+
+        assert_eq!(snapshot[0].sample_id, 1);
+        assert_eq!(snapshot[0].name, "a");
+
+        assert_eq!(snapshot[1].sample_id, 3);
+        assert_eq!(snapshot[1].name, "b");
+
+        assert_eq!(snapshot[2].sample_id, 2);
+        assert_eq!(snapshot[2].name, "y");
+
+        assert_eq!(snapshot[3].sample_id, 4);
+        assert_eq!(snapshot[3].name, "z");
+
+        assert_eq!(snapshot[4].sample_id, 5);
+        assert_eq!(snapshot[4].name, "c");
+
+        assert_eq!(snapshot[5].sample_id, 0);
+        assert_eq!(snapshot[5].name, "x");
+    }
+
+    #[test]
+    fn test_get_sorted_samples() {
+        let _test_mutex = TEST_MUTEX.lock().unwrap();
+
+        disable_tracing();
+        enable_tracing_with_config(&Config::with_limit_count(10));
+
+        // current recording mechanism should see:
+        // a, b, y, z, c, x
+        // even though the actual sampling order (from timestamp of
+        // creation) is:
+        // x, a, y, b, z, c
+        // This might be an over-specified test as it will
+        // probably change as the recording internals change.
+        trace_closure_payload("x", &["test"], || {
+            trace_payload("a", &["test"], to_payload("test_get_sorted_samples"));
+            trace_closure_payload("y", &["test"], || {
+                trace_payload("b", &["test"], to_payload("test_get_sorted_samples"));
+            }, to_payload("test_get_sorted_samples"));
+            trace_block_payload("z", &["test"], to_payload("test_get_sorted_samples"));
+            trace("c", &["test"]);
+        }, to_payload("test_get_sorted_samples"));
+
+        let snapshot = samples_cloned_sorted();
+        assert_eq!(snapshot.len(), 6);
+
+        assert_eq!(snapshot[0].sample_id, 0);
+        assert_eq!(snapshot[0].name, "x");
+
+        assert_eq!(snapshot[1].sample_id, 1);
+        assert_eq!(snapshot[1].name, "a");
+
+        assert_eq!(snapshot[2].sample_id, 2);
+        assert_eq!(snapshot[2].name, "y");
+
+        assert_eq!(snapshot[3].sample_id, 3);
+        assert_eq!(snapshot[3].name, "b");
+
+        assert_eq!(snapshot[4].sample_id, 4);
+        assert_eq!(snapshot[4].name, "z");
+
+        assert_eq!(snapshot[5].sample_id, 5);
+        assert_eq!(snapshot[5].name, "c");
+    }
+
+    #[cfg(feature = "benchmarks")]
+    #[bench]
+    fn bench_trace_instant_disabled(b: &mut Bencher) {
+        let _test_mutex = TEST_MUTEX.lock().unwrap();
+
+        disable_tracing();
+        b.iter(|| black_box(trace("nothing", &["benchmark"])));
+    }
+
+    #[cfg(feature = "benchmarks")]
+    #[bench]
+    fn bench_trace_instant(b: &mut Bencher) {
+        let _test_mutex = TEST_MUTEX.lock().unwrap();
+
+        disable_tracing();
+        enable_tracing_with_config(&Config::with_limit_count(500));
+        b.iter(|| black_box(trace("something", &["benchmark"])));
+    }
+
+    #[cfg(feature = "benchmarks")]
+    #[bench]
+    fn bench_trace_instant_with_payload(b: &mut Bencher) {
+        let _test_mutex = TEST_MUTEX.lock().unwrap();
+
+        disable_tracing();
+        enable_tracing_with_config(&Config::with_limit_count(500));
+        b.iter(|| black_box(trace_payload(
+            "something", &["benchmark"],
+            to_payload("some description of the trace"))));
+    }
+
+    #[cfg(feature = "benchmarks")]
+    #[bench]
+    fn bench_trace_block_disabled(b: &mut Bencher) {
+        let _test_mutex = TEST_MUTEX.lock().unwrap();
+
+        disable_tracing();
+        b.iter(|| black_box(trace_block("something", &["benchmark"])));
+    }
+
+    #[cfg(feature = "benchmarks")]
+    #[bench]
+    fn bench_trace_block(b: &mut Bencher) {
+        let _test_mutex = TEST_MUTEX.lock().unwrap();
+
+        disable_tracing();
+        enable_tracing_with_config(&Config::with_limit_count(500));
+        b.iter(|| black_box(trace_block("something", &["benchmark"])));
+    }
+
+
+    #[cfg(feature = "benchmarks")]
+    #[bench]
+    fn bench_trace_block_payload(b: &mut Bencher) {
+        let _test_mutex = TEST_MUTEX.lock().unwrap();
+
+        disable_tracing();
+        enable_tracing_with_config(&Config::with_limit_count(500));
+        b.iter(|| {
+            black_box(trace_block_payload(
+                    "something", &["benchmark"],
+                    to_payload(("some payload for the block"))));
+        });
+    }
+
+    #[cfg(feature = "benchmarks")]
+    #[bench]
+    fn bench_trace_closure_disabled(b: &mut Bencher) {
+        let _test_mutex = TEST_MUTEX.lock().unwrap();
+
+        disable_tracing();
+        b.iter(|| black_box(trace_closure("something", &["benchmark"], || {})));
+    }
+
+    #[cfg(feature = "benchmarks")]
+    #[bench]
+    fn bench_trace_closure(b: &mut Bencher) {
+        let _test_mutex = TEST_MUTEX.lock().unwrap();
+
+        disable_tracing();
+        enable_tracing_with_config(&Config::with_limit_count(500));
+        b.iter(|| black_box(trace_closure("something", &["benchmark"], || {})));
+    }
+
+    #[cfg(feature = "benchmarks")]
+    #[bench]
+    fn bench_trace_closure_payload(b: &mut Bencher) {
+        let _test_mutex = TEST_MUTEX.lock().unwrap();
+
+        disable_tracing();
+        enable_tracing_with_config(&Config::with_limit_count(500));
+        b.iter(|| black_box(trace_closure_payload(
+                    "something", &["benchmark"], || {},
+                    to_payload(("some description of the closure")))));
+    }
+
+    // this is the cost contributed by the timestamp to trace()
+    #[cfg(feature = "benchmarks")]
+    #[bench]
+    fn bench_single_timestamp(b: &mut Bencher) {
+        let _test_mutex = TEST_MUTEX.lock().unwrap();
+
+        b.iter(|| black_box(time::precise_time_ns()));
+    }
+
+    // this is the cost contributed by the timestamp to
+    // trace_block()/trace_closure
+    #[cfg(feature = "benchmarks")]
+    #[bench]
+    fn bench_two_timestamps(b: &mut Bencher) {
+        let _test_mutex = TEST_MUTEX.lock().unwrap();
+
+        b.iter(|| {
+            black_box(time::precise_time_ns());
+            black_box(time::precise_time_ns());
+        });
+    }
+
+    #[cfg(feature = "benchmarks")]
+    #[bench]
+    fn bench_get_tid(b: &mut Bencher) {
+        b.iter(|| black_box(sys_tid::current_tid()));
+    }
+
+    #[cfg(feature = "benchmarks")]
+    #[bench]
+    fn bench_get_pid(b: &mut Bencher) {
+        b.iter(|| sys_pid::current_pid());
+    }
+}

--- a/rust/trace/src/sys_pid.rs
+++ b/rust/trace/src/sys_pid.rs
@@ -1,0 +1,45 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use libc;
+
+#[cfg(all(target_family = "unix", not(target_os = "fuchsia")))]
+#[inline]
+pub fn current_pid() -> u64 {
+    extern {
+        fn getpid() -> libc::pid_t;
+    }
+
+    unsafe {
+        getpid() as u64
+    }
+}
+
+#[cfg(target_os = "fuchsia")]
+pub fn current_pid() -> u64 {
+    // TODO: implement for fuchsia (does getpid work?)
+    0
+}
+
+#[cfg(target_family = "windows")]
+#[inline]
+pub fn current_pid() -> u64 {
+    extern {
+        fn GetCurrentProcessId() -> libc::c_ulong;
+    }
+
+    unsafe {
+        GetCurrentProcessId() as u64
+    }
+}

--- a/rust/trace/src/sys_tid.rs
+++ b/rust/trace/src/sys_tid.rs
@@ -1,0 +1,80 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use libc;
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[inline]
+pub fn current_tid() -> Result<u64, libc::c_int> {
+    use std::mem::uninitialized;
+
+    #[link(name = "pthread")]
+    extern {
+        fn pthread_threadid_np(thread: libc::pthread_t, thread_id: *mut libc::uint64_t) -> libc::c_int;
+    }
+
+    unsafe {
+        let mut tid: libc::uint64_t = uninitialized();
+        let err = pthread_threadid_np(0, &mut tid);
+        match err {
+            0 => Ok(tid),
+            _ => Err(err)
+        }
+    }
+}
+
+#[cfg(target_os = "fuchsia")]
+#[inline]
+pub fn current_tid() -> Result<u64, libc::c_int> {
+    // TODO: fill in for fuchsia.  This is the native C API but maybe there are
+    // rust-specific bindings already.
+    /*
+    extern {
+        fn thrd_get_zx_handle(thread: thrd_t) -> zx_handle_t;
+        fn thrd_current() -> thrd_t;
+    }
+
+    Ok(thrd_get_zx_handle(thrd_current()) as u64)
+    */
+    Ok(0)
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[inline]
+pub fn current_tid() -> Result<u64, libc::c_int> {
+    unsafe {
+        Ok(libc::syscall(libc::SYS_gettid) as u64)
+    }
+}
+
+// TODO: maybe use https://github.com/alexcrichton/cfg-if to simplify this?
+// pthread-based fallback
+#[cfg(all(target_family = "unix", not(any(target_os = "macos", target_os = "ios", target_os = "linux", target_os = "android", target_os = "fuchsia"))))]
+pub fn current_tid() -> Result<u64, libc::c_int> {
+    unsafe {
+        Ok(libc::pthread_self() as u64)
+    }
+}
+
+#[cfg(target_os = "windows")]
+#[inline]
+pub fn current_tid() -> Result<u64, libc::c_int> {
+    extern {
+        fn GetCurrentThreadId() -> libc::c_ulong;
+    }
+
+    unsafe {
+        Ok(GetCurrentThreadId() as u64)
+    }
+}


### PR DESCRIPTION
Add xi_trace module that can be used to record traces programmatically.  This simply adds an in-memory buffer to store the samples.  Serialization will be added in a follow-up pull request.

Part 1/2 for #471