### PR TITLE
Add support for serializing samples into Chrome trace event

### DIFF
--- a/rust/trace-dump/Cargo.toml
+++ b/rust/trace-dump/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "xi-trace-dump"
+version = "0.1.0"
+license = "Apache-2.0"
+authors = ["Vitali Lovich <vlovich@google.com>"]
+categories = ["development-tools::profiling"]
+repository = "https://github.com/google/xi-editor"
+description = "Library-based API to dump xi-trace data to disk"
+
+[features]
+default = ["chrome_trace_event", "ipc"]
+benchmarks = []
+chrome_trace_event = ["serde", "serde_json"]
+ipc = ["serde", "bincode"]
+
+[dependencies]
+xi-trace = { path = "../trace", version = "0.1.0" }
+bincode = { version = "0.9.2", optional = true }
+serde_json = { version = "1.0", optional = true }
+serde_derive = "1.0"
+serde = { version = "1.0", optional = true }
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/rust/trace-dump/src/chrome_trace.rs
+++ b/rust/trace-dump/src/chrome_trace.rs
@@ -1,0 +1,112 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use xi_trace::{Sample, SampleType};
+use serde;
+use serde::ser::Serializer;
+use serde::ser::SerializeSeq;
+use serde_json;
+use std::io::{Error as IOError, Write};
+use std::iter::Iterator;
+
+pub enum OutputFormat {
+    /// Output the samples as a JSON array.  Each array entry is an object
+    /// describing the sample.
+    JsonArray,
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Io(IOError),
+    Json(serde_json::Error)
+}
+
+fn to_us(ns: u64) -> u64 {
+    ns / 1000
+}
+
+fn event_type(sample: &Sample, begin: bool) -> &'static str {
+    match sample.sample_type {
+        SampleType::Instant => "i",
+        SampleType::Duration => if begin { "B" } else { "E" },
+    }
+}
+
+fn sample_to_json(sample: &Sample, begin: bool) -> serde_json::Value {
+    json!({
+        "cat": sample.categories.join(","),
+        "name": sample.name, 
+        "ph": event_type(sample, begin),
+        "ts": to_us(if begin { sample.start_ns } else { sample.get_end_ns() }),
+        "pid": sample.pid,
+        "tid": sample.tid,
+        "args": {
+            "payload": sample.payload
+        }
+    })
+}
+
+fn serialize_to_json_array<'a, I, W>(samples: I, output: W)
+    -> Result<(), Error>
+    where I: IntoIterator<Item = &'a Sample>, W: Write
+{
+    let mut serializer = serde_json::ser::Serializer::new(output);
+
+    // Step 1: Create a serializor for the samples
+    serializer.serialize_seq(Some(1))
+        .and_then(|mut seq| {
+            // Write out each sample...
+            samples.into_iter().map(|sample: &Sample| {
+                seq.serialize_element(&sample_to_json(&sample, true))
+                    // + if it's a range write 2 samples
+                    .and_then(|_| {
+                        match sample.sample_type {
+                            SampleType::Instant => serde::export::Ok(()),
+                            SampleType::Duration => seq.serialize_element(&sample_to_json(&sample, false)),
+                        }
+                    })
+            // Reduce all the results from each individual serialization
+            }).fold(Ok(()), |acc_res, res| acc_res.and(res))
+            // Terminate the serialization
+            .and_then(|_| seq.end())
+        }).map_err(|err| Error::Json(err))
+}
+
+/// This serializes the samples into the [Chrome trace event format](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&ved=0ahUKEwiJlZmDguXYAhUD4GMKHVmEDqIQFggpMAA&url=https%3A%2F%2Fdocs.google.com%2Fdocument%2Fd%2F1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU%2Fpreview&usg=AOvVaw0tBFlVbDVBikdzLqgrWK3g).
+///
+/// # Arguments
+/// `samples` - Something that can be converted into an iterator of sample
+/// references.
+/// `format` - Which trace format to save the data in.  There are four total
+/// formats described in the document.
+/// `output` - Where to write the serialized result.
+///
+/// # Returns
+/// A `Result<(), Error>` that indicates if serialization was successful or the
+/// details of any error that occured.
+///
+/// # Examples
+/// ```norun
+/// let samples = xi_trace::samples_cloned_sorted();
+/// let mut serialized = Vec::<u8>::new();
+/// chrome_trace::serialize(samples.iter(), OutputFormat::JsonArray, serialized);
+/// ```
+pub fn serialize<'a, I, W>(samples: I, format: OutputFormat, output: W)
+    -> Result<(), Error> 
+    where I: IntoIterator<Item = &'a Sample>, W: Write
+{
+    match format {
+        OutputFormat::JsonArray => serialize_to_json_array(samples, output)
+    }
+}

--- a/rust/trace-dump/src/ipc.rs
+++ b/rust/trace-dump/src/ipc.rs
@@ -1,0 +1,51 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Error as IOError;
+use std::io::{Read, Write};
+use xi_trace::*;
+
+use bincode;
+
+#[derive(Debug)]
+pub enum Error {
+    IOError(IOError),
+    BincodeError(bincode::Error)
+}
+
+pub fn serialize_to_bytes<'a>(samples: &Vec<Sample>) -> Result<Vec<u8>, Error>
+{
+    bincode::serialize(&samples, bincode::Infinite)
+        .map_err(|e| Error::BincodeError(e))
+}
+
+pub fn serialize_to_stream<'a, W>(samples: &Vec<Sample>, output: &mut W)
+    -> Result<(), Error>
+    where W: Write
+{
+    bincode::serialize_into(output, &samples, bincode::Infinite)
+        .map_err(|e| Error::BincodeError(e))
+}
+
+pub fn deserialize_from_bytes(encoded: &[u8]) -> Result<Vec<Sample>, Error> {
+    bincode::deserialize(encoded)
+        .map_err(|e| Error::BincodeError(e))
+}
+
+pub fn deserialize<R>(reader: &mut R) -> Result<Vec<Sample>, Error>
+    where R: Read
+{
+    bincode::deserialize_from(reader, bincode::Infinite)
+        .map_err(|e| Error::BincodeError(e))
+}

--- a/rust/trace-dump/src/lib.rs
+++ b/rust/trace-dump/src/lib.rs
@@ -1,0 +1,130 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg_attr(feature = "benchmarks", feature(test))]
+
+extern crate xi_trace;
+
+#[cfg(any(feature = "chrome_trace_event", feature = "ipc"))]
+extern crate serde;
+
+#[cfg(feature = "ipc")]
+extern crate bincode;
+
+#[cfg(feature = "chrome_trace_event")]
+#[macro_use]
+extern crate serde_json;
+
+#[cfg(all(test, feature = "benchmarks"))]
+extern crate test;
+
+#[cfg(feature = "chrome_trace_event")]
+pub mod chrome_trace;
+
+#[cfg(feature = "ipc")]
+pub mod ipc;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(feature = "benchmarks")]
+    use test::Bencher;
+
+    #[cfg(feature = "chrome_trace_event")]
+    #[test]
+    fn test_chrome_trace_serialization() {
+        use xi_trace::*;
+
+        let trace = Trace::enabled(Config::with_limit_count(10));
+        trace.instant("sample1", &["test", "chrome"]);
+        trace.instant_payload("sample2", &["test", "chrome"], "payload 2");
+        trace.instant_payload("sample3", &["test", "chrome"], "payload 3");
+        trace.closure_payload("sample4", &["test", "chrome"],|| (), "payload 4");
+
+        let samples = trace.samples_cloned_unsorted();
+
+        let mut serialized = Vec::<u8>::new();
+        let result = chrome_trace::serialize(
+            &samples, chrome_trace::OutputFormat::JsonArray, &mut serialized);
+        assert!(result.is_ok());
+
+        let decoded_result : Vec<serde_json::Value> = serde_json::from_slice(&serialized).unwrap();
+        assert_eq!(decoded_result.len(), 5);
+        for i in 0..3 {
+            assert_eq!(decoded_result[i]["name"].as_str().unwrap(), samples[i].name);
+            assert_eq!(decoded_result[i]["cat"].as_str().unwrap(), "test,chrome");
+            assert_eq!(decoded_result[i]["ph"].as_str().unwrap(), "i");
+            assert_eq!(decoded_result[i]["ts"], samples[i].start_ns / 1000);
+            assert_eq!(decoded_result[i]["args"]["payload"], json!(samples[i].payload));
+        }
+        assert_eq!(decoded_result[3]["ph"], "B");
+        assert_eq!(decoded_result[4]["ph"], "E");
+    }
+
+    #[cfg(feature = "ipc")]
+    #[test]
+    fn test_ipc_ser_der() {
+        use xi_trace::*;
+
+        let trace = Trace::enabled(Config::with_limit_count(10));
+        trace.instant("sample1", &["test", "chrome"]);
+        trace.instant_payload("sample2", &["test", "chrome"], "payload 2");
+        trace.instant_payload("sample3", &["test", "chrome"], "payload 3");
+        trace.closure_payload("sample4", &["test", "chrome"],|| (), "payload 4");
+
+        let samples = trace.samples_cloned_unsorted();
+
+        let serialized = ipc::serialize_to_bytes(&samples).unwrap();
+        let deserialized = ipc::deserialize_from_bytes(&serialized).unwrap();
+
+        assert_eq!(deserialized.len(), samples.len());
+        for i in 0..deserialized.len() {
+            assert_eq!(deserialized[i], samples[i])
+        }
+    }
+
+    #[cfg(all(feature = "chrome_trace_event", feature = "benchmarks"))]
+    #[bench]
+    fn bench_chrome_trace_serialization_one_element(b: &mut Bencher) {
+        use chrome_trace::*;
+
+        let mut serialized = Vec::<u8>::new();
+        let samples = [xi_trace::Sample::new_instant("trace1", &["benchmark", "test"], None)];
+        b.iter(|| {
+            serialized.clear();
+            serialize(samples.iter(), OutputFormat::JsonArray, &mut serialized).unwrap();
+        });
+    }
+
+    #[cfg(all(feature = "chrome_trace_event", feature = "benchmarks"))]
+    #[bench]
+    fn bench_chrome_trace_serialization_multiple_elements(b: &mut Bencher) {
+        use chrome_trace::*;
+        use xi_trace::*;
+
+        let mut serialized = Vec::<u8>::new();
+        let mut samples = [
+            Sample::new_instant("trace1", &["benchmark", "test"], None),
+            Sample::new_instant("trace2", &["benchmark"], None),
+            Sample::new("trace3", &["benchmark"], Some(StrCow::from("some payload"))),
+            Sample::new_instant("trace4", &["benchmark"], None)];
+        let sample_start = samples[2].start_ns;
+        samples[2].set_end_ns(sample_start);
+
+        b.iter(|| {
+            serialized.clear();
+            serialize(samples.iter(), OutputFormat::JsonArray, &mut serialized).unwrap();
+        });
+    }
+}

--- a/rust/trace/Cargo.toml
+++ b/rust/trace/Cargo.toml
@@ -19,6 +19,8 @@ getpid = []
 time = "0.1.39"
 lazy_static = "1.0"
 serde_json = { version = "1.0", optional = true }
+serde_derive = "1.0"
+serde = "1.0"
 libc = "0.2.36"
 
 [profile.bench]


### PR DESCRIPTION
Part 2/2 for #471 provides a mechanism to serialize in-memory samples to a stream.