### PR TITLE
Deserialize chrome JSON trace into data structure

### DIFF
--- a/rust/trace-dump/Cargo.toml
+++ b/rust/trace-dump/Cargo.toml
@@ -12,6 +12,8 @@ default = ["chrome_trace_event", "ipc"]
 benchmarks = []
 chrome_trace_event = ["serde", "serde_json"]
 ipc = ["serde", "bincode"]
+dict_payload = ["xi-trace/dict_payload"]
+json_payload = ["xi-trace/json_payload"]
 
 [dependencies]
 xi-trace = { path = "../trace", version = "0.1.0" }

--- a/rust/trace-dump/src/chrome_trace.rs
+++ b/rust/trace-dump/src/chrome_trace.rs
@@ -12,12 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use xi_trace::{Sample, SampleType};
-use serde;
-use serde::ser::Serializer;
-use serde::ser::SerializeSeq;
+use xi_trace::{Sample, SampleType, StrCow, TracePayloadT};
 use serde_json;
-use std::io::{Error as IOError, Write};
+use std::io::{Error as IOError, Read, Write};
 use std::iter::Iterator;
 
 pub enum OutputFormat {
@@ -29,11 +26,45 @@ pub enum OutputFormat {
 #[derive(Debug)]
 pub enum Error {
     Io(IOError),
-    Json(serde_json::Error)
+    Json(serde_json::Error),
+    DecodingFormat(String)
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ChromeTraceArrayEntryArgs {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    xi_sample_id: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    payload: Option<TracePayloadT>,
+}
+
+/// This is the struct that represents a single entry within an array of
+/// samples.  Vec<ChromeTraceArrayEntry> would represent a single complete
+/// trace.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ChromeTraceArrayEntry {
+    name: StrCow,
+    cat: StrCow,
+    ph: StrCow,
+    #[serde(rename = "ts")]
+    ts_us: u64,
+    pid: u64,
+    tid: u64,
+    args: Option<ChromeTraceArrayEntryArgs>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+enum ChromeTraceArrayEntries {
+    Array(Vec<ChromeTraceArrayEntry>)
 }
 
 fn to_us(ns: u64) -> u64 {
     ns / 1000
+}
+
+fn to_ns(us: u64) -> u64 {
+    us * 1000
 }
 
 fn event_type(sample: &Sample, begin: bool) -> &'static str {
@@ -43,44 +74,128 @@ fn event_type(sample: &Sample, begin: bool) -> &'static str {
     }
 }
 
-fn sample_to_json(sample: &Sample, begin: bool) -> serde_json::Value {
-    json!({
-        "cat": sample.categories.join(","),
-        "name": sample.name, 
-        "ph": event_type(sample, begin),
-        "ts": to_us(if begin { sample.start_ns } else { sample.get_end_ns() }),
-        "pid": sample.pid,
-        "tid": sample.tid,
-        "args": {
-            "payload": sample.payload
-        }
-    })
+fn sample_to_entry(sample: &Sample, begin: bool) -> ChromeTraceArrayEntry {
+    ChromeTraceArrayEntry {
+        name: sample.name.clone(),
+        cat: StrCow::from(sample.categories.join(",")),
+        ph: StrCow::from(event_type(sample, begin)),
+        ts_us: to_us(if begin { sample.start_ns } else { sample.get_end_ns() }),
+        pid: sample.pid,
+        tid: sample.tid,
+        args: Some(ChromeTraceArrayEntryArgs {
+            xi_sample_id: Some(sample.sample_id),
+            payload: sample.payload.clone(),
+        })
+    }
 }
 
-fn serialize_to_json_array<'a, I, W>(samples: I, output: W)
-    -> Result<(), Error>
-    where I: IntoIterator<Item = &'a Sample>, W: Write
-{
-    let mut serializer = serde_json::ser::Serializer::new(output);
+impl<'a, A> From<A> for ChromeTraceArrayEntries where A: IntoIterator<Item = &'a Sample> {
+    fn from(samples: A) -> Self {
+        // Worst case is every sample is a duration.  if we were to use an
+        // original capacity of samples.len() then we'd inevitably encounter
+        // at least 1 duration & thus the underlying Vec would double the
+        // capacity anyway.  Alternatively, we could scan the vector to count
+        // the number of durations & add that to samples.len() for the exact
+        // final capacity.
+        let samples_iter = samples.into_iter();
+        let mut result = Vec::with_capacity(samples_iter.size_hint().0 * 2);
 
-    // Step 1: Create a serializor for the samples
-    serializer.serialize_seq(Some(1))
-        .and_then(|mut seq| {
-            // Write out each sample...
-            samples.into_iter().map(|sample: &Sample| {
-                seq.serialize_element(&sample_to_json(&sample, true))
-                    // + if it's a range write 2 samples
-                    .and_then(|_| {
-                        match sample.sample_type {
-                            SampleType::Instant => serde::export::Ok(()),
-                            SampleType::Duration => seq.serialize_element(&sample_to_json(&sample, false)),
-                        }
-                    })
-            // Reduce all the results from each individual serialization
-            }).fold(Ok(()), |acc_res, res| acc_res.and(res))
-            // Terminate the serialization
-            .and_then(|_| seq.end())
-        }).map_err(|err| Error::Json(err))
+        // Instantaneous samples have a 1:1 mapping to chrome trace event
+        // samples.  Duration samples output 2 chrome trace events (one for the
+        // start and one for the end).
+        for sample in samples_iter {
+            match sample.sample_type {
+                SampleType::Instant => result.push(sample_to_entry(&sample, true)),
+                SampleType::Duration => {
+                    result.push(sample_to_entry(&sample, true));
+                    result.push(sample_to_entry(&sample, false));
+                }
+            }
+        }
+        ChromeTraceArrayEntries::Array(result)
+    }
+}
+
+// temporary while TryFrom is still nightly.
+pub trait XiTryFrom<T>: Sized {
+    type Error;
+    fn try_from(value: T) -> Result<Self, Self::Error>;
+}
+
+fn try_from(trace_entry: ChromeTraceArrayEntry, default_sample_id: usize)
+    -> Result<Sample, Error> {
+    // Chrome trace stores the categories as comma-separated.
+    // Split it back out into a vector.
+    let categories = trace_entry.cat.split(",").map(
+        |s| s.to_string()).collect::<Vec<String>>();
+
+    let (sample_id, payload ) = trace_entry.args.map_or((default_sample_id, None), |args| {
+        (args.xi_sample_id.unwrap_or(default_sample_id), args.payload)
+    });
+
+    let ph = trace_entry.ph.as_ref();
+
+    let mut converted = match ph {
+        "i" => Ok(Sample::new_instant(trace_entry.name, categories, payload)),
+        "B" => Ok(Sample::new(trace_entry.name, categories, payload)),
+        _ => Err(Error::DecodingFormat(
+                format!("Entry has unexpected ph value {}",
+                        ph)))
+    }?;
+
+    converted.sample_id = sample_id;
+    converted.pid = trace_entry.pid;
+    converted.tid = trace_entry.tid;
+    converted.start_ns = to_ns(trace_entry.ts_us);
+    Ok(converted)
+}
+
+impl XiTryFrom<Vec<ChromeTraceArrayEntry>> for Vec<Sample> {
+    type Error = Error;
+
+    /// Converting Chrome trace event back into a Sample is a bit more work
+    /// because a Sample can represent a duration so we have to merge Chrome
+    /// trace events that indicate start/end.
+    fn try_from(trace_entries: Vec<ChromeTraceArrayEntry>) -> Result<Self, Error> {
+        let mut result = Vec::with_capacity(trace_entries.len());
+        for trace_entry in trace_entries {
+            if trace_entry.ph == "E" {
+                // Got an end of a duration measure so look back into the
+                // samples we've already converted to populate the end
+                // timestamp.
+                let mut found = false;
+                for mut existing_sample in result.iter_mut().rev() {
+                    if is_begin_sample(&existing_sample, trace_entry.pid, trace_entry.tid, &trace_entry.name) {
+                        existing_sample.set_end_ns(to_ns(trace_entry.ts_us));
+                        found = true;
+                        break;
+                    }
+                }
+                if !found {
+                    return Err(Error::DecodingFormat(
+                        format!("Entry {:?} found but no preceding start sample exists",
+                                trace_entry)));
+                }
+            } else {
+                let default_sample_id = result.len();
+                result.push(try_from(trace_entry, default_sample_id)?);
+            }
+        }
+        Ok(result)
+    }
+}
+
+impl XiTryFrom<ChromeTraceArrayEntries> for Vec<Sample> {
+    type Error = Error;
+
+    /// Converting Chrome trace event back into a Sample is a bit more work
+    /// because a Sample can represent a duration so we have to merge Chrome
+    /// trace events that indicate start/end.
+    fn try_from(entries: ChromeTraceArrayEntries) -> Result<Self, Error> {
+        match entries {
+            ChromeTraceArrayEntries::Array(samples_array) => Vec::try_from(samples_array),
+        }
+    }
 }
 
 /// This serializes the samples into the [Chrome trace event format](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&ved=0ahUKEwiJlZmDguXYAhUD4GMKHVmEDqIQFggpMAA&url=https%3A%2F%2Fdocs.google.com%2Fdocument%2Fd%2F1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU%2Fpreview&usg=AOvVaw0tBFlVbDVBikdzLqgrWK3g).
@@ -102,11 +217,42 @@ fn serialize_to_json_array<'a, I, W>(samples: I, output: W)
 /// let mut serialized = Vec::<u8>::new();
 /// chrome_trace::serialize(samples.iter(), OutputFormat::JsonArray, serialized);
 /// ```
-pub fn serialize<'a, I, W>(samples: I, format: OutputFormat, output: W)
+pub fn serialize<'a, I, W>(samples: I, _format: OutputFormat, output: W)
     -> Result<(), Error> 
     where I: IntoIterator<Item = &'a Sample>, W: Write
 {
+    let converted = ChromeTraceArrayEntries::from(samples.into_iter());
+    serde_json::to_writer(output, &converted).map_err(|e| Error::Json(e))
+}
+
+pub fn to_value(samples: &[Sample], format: OutputFormat)
+    -> Result<serde_json::Value, Error>
+{
     match format {
-        OutputFormat::JsonArray => serialize_to_json_array(samples, output)
+        OutputFormat::JsonArray => serde_json::to_value(samples).map_err(|e| Error::Json(e))
     }
+}
+
+fn is_begin_sample(sample: &Sample, pid: u64, tid: u64, name: &str) -> bool {
+    if sample.sample_type != SampleType::Duration {
+        false
+    } else if sample.pid != pid || sample.tid != tid {
+        false
+    } else if sample.name != name {
+        false
+    } else {
+        true
+    }
+}
+
+pub fn decode(samples: serde_json::Value) -> Result<Vec<Sample>, Error> {
+    let entries : ChromeTraceArrayEntries= serde_json::from_value(samples).map_err(|e| Error::Json(e))?;
+    Vec::try_from(entries)
+}
+
+pub fn deserialize<R>(input: R) -> Result<Vec<Sample>, Error>
+    where R: Read
+{
+    let entries : ChromeTraceArrayEntries = serde_json::from_reader(input).map_err(|e| Error::Json(e))?;
+    Vec::try_from(entries)
 }

--- a/rust/trace-ffi/Cargo.toml
+++ b/rust/trace-ffi/Cargo.toml
@@ -16,7 +16,7 @@ xi-trace = { path = "../trace" }
 # The FFI crate only exposes serializing to IPC so there's no need for any
 # other formats (can even reduce this further to serialization only APIs).
 xi-trace-dump = { path = "../trace-dump", default-features = false, features = ["ipc"] }
-libc = "0.2.36"
+libc = "0.2"
 
 [build-dependencies.cc]
 version = "1.0"

--- a/rust/trace/Cargo.toml
+++ b/rust/trace/Cargo.toml
@@ -16,12 +16,12 @@ json_payload = ["serde_json"]
 getpid = []
 
 [dependencies]
-time = "0.1.39"
+time = "0.1"
 lazy_static = "1.0"
 serde_json = { version = "1.0", optional = true }
 serde_derive = "1.0"
 serde = "1.0"
-libc = "0.2.36"
+libc = "0.2"
 
 [profile.bench]
 lto = true

--- a/rust/trace/src/lib.rs
+++ b/rust/trace/src/lib.rs
@@ -189,13 +189,13 @@ impl From<Vec<String>> for CategoriesT {
 }
 
 #[cfg(all(not(feature = "dict_payload"), not(feature = "json_payload")))]
-type TracePayloadT = StrCow;
+pub type TracePayloadT = StrCow;
 
 #[cfg(feature = "json_payload")]
-type TracePayloadT = serde_json::Value;
+pub type TracePayloadT = serde_json::Value;
 
 #[cfg(feature = "dict_payload")]
-type TracePayloadT = std::collections::HashMap<StrCow, StrCow>;
+pub type TracePayloadT = std::collections::HashMap<StrCow, StrCow>;
 
 /// How tracing should be configured.
 #[derive(Copy, Clone)]
@@ -257,7 +257,7 @@ pub struct Sample {
     /// A private ordering to apply to the events based on creation order.
     /// Disambiguates in case 2 samples might be created from different threads
     /// with the same start_ns for purposes of ordering.
-    pub(crate) sample_id: usize,
+    pub sample_id: usize,
     /// The name of the event to be shown.
     pub name: StrCow,
     /// List of categories the event applies to.
@@ -336,7 +336,17 @@ impl Sample {
 
 impl PartialEq for Sample {
     fn eq(&self, other: &Sample) -> bool {
-        self.pid == other.pid && self.sample_id == other.sample_id
+        if self.pid == other.pid {
+            self.sample_id == other.sample_id
+        } else {
+            self.start_ns == other.start_ns && self.end_ns == other.end_ns &&
+                self.name == other.name &&
+                self.categories == other.categories &&
+                self.pid == other.pid &&
+                self.tid == other.tid &&
+                self.sample_type == other.sample_type &&
+                self.payload == other.payload
+        }
     }
 }
 


### PR DESCRIPTION
This way xi-mac (or any other frontend) can just send the JSON trace to xi_core for dumping to disk instead of needing to use the Rust tracing framework.