### PR TITLE
add xi-qt to the list of front-ends

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ and might work on other Flutter targets.
 
 * [kod](https://github.com/linde12/kod), a terminal frontend written in Golang.
 
+* [xi-qt](https://github.com/sw5cc/xi-qt), a Qt front-end.
+
 The following are currently inactive, based on earlier versions of the front-end
 protocol, but perhaps could be revitalized:
 


### PR DESCRIPTION
Hi,
The xi-editor is awesome. Greatly inspired by the [talk](https://www.recurse.com/events/localhost-raph-levien), I'll try my best to make a contribution to the project. 
I would like to add xi-qt to the list of front-ends. It's very simple now, but it will be improved over time. Thanks.