### PR TITLE
Simple implementation to report success/failure upon save (issue #519)

### DIFF
--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -559,9 +559,14 @@ impl Documents {
         Ok(s)
     }
 
+<<<<<<< HEAD
     fn do_save<P>(&mut self, peer: &MainPeer, view_id: ViewIdentifier, file_path: P)
         where P: AsRef<Path>
     {
+=======
+    fn do_save<P: AsRef<Path>>(&mut self, rpc_peer: &MainPeer,
+                               view_id: ViewIdentifier, file_path: P) {
+>>>>>>> Notify peer of a successfull save operation (issue519)
         //TODO: handle & report errors
         let file_path = file_path.as_ref();
         let prev_syntax = self.buffers.lock().editor_for_view(view_id)
@@ -610,6 +615,11 @@ impl Documents {
                 .unwrap().set_config(new_config);
         }
         self.plugins.document_did_save(view_id, file_path);
+        rpc_peer.send_rpc_notification(
+            "view_saved", &json!({
+                "view_id": view_id,
+                "file_path": file_path,
+            }));
     }
 
     /// Handles a plugin related command from a client


### PR DESCRIPTION
This is an early simple implementation for issue #519, which only addresses the shortcomings of error reporting during save. It does not rely on the error-reporting RFC (https://github.com/google/xi-editor/issues/543).

If we want to wait for the error reporting RFC, the first commit can probably still be merged.

I tested this by:
1. Compiling xi-mac against xi-core with the PR applied.
2. Running `build/Release/XiEditor.app/Contents/MacOS/XiEditor `with `RUST_BACKTRACE` and `XI_CLIENT_RPC_LOG` enabled.
3. Try saving a new text file to `/UNTITLED` under MacOS which fails. Correctly see that I get an alert box with the error in xi-mac.
4. Try saving a new text file to `~/UNTITLED` under MacOS which succeeds. See `unknown notification view_saved` in log output from xi-mac and file is correctly saved.