### PR TITLE
Ensure core shuts down after an error

### DIFF
--- a/rust/core-lib/tests/rpc.rs
+++ b/rust/core-lib/tests/rpc.rs
@@ -93,7 +93,7 @@ fn test_malformed_json() {
     let mut state = MainState::new();
     let write = io::sink();
     let mut rpc_looper = RpcLoop::new(write);
-    // malformed json, no id: should not receive a response, and connection should close.
+    // malformed json: method should be in quotes.
     let read = make_reader(r#"{method:"client_started","params":{}}
 {"id":0,"method":"new_view","params":{}}"#);
     match rpc_looper.mainloop(|| read, &mut state).err()


### PR DESCRIPTION
Previously if an error occured in the main thread, xi-core would hang
indefinitely because it is waiting on the read thread, which doesn't
know about the error.

With this change, we keep track of crashes via an AtomicBool, which
the read thread checks before each new read operation.

Because reads are blocking, core will not exit if an error occurs
_while_ thre read thread is blocked, until the next RPC is received.
This isn't ideal, but is a limitation of blocking I/O.

Fixes #434