### PR TITLE
Prepare doc comments for pulldown migration

### DIFF
--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -142,7 +142,7 @@ pub enum CoreNotification {
     /// (this should be changed to more accurately reflect the behaviour
     /// of the edit commands).
     ///
-    ///For the available commands, see [`PluginNotification`].
+    /// For the available commands, see [`PluginNotification`].
     ///
     /// [`PluginNotification`]: enum.PluginNotification.html
     ///
@@ -213,6 +213,7 @@ pub enum CoreNotification {
 /// # Examples
 ///
 /// The `new_view` command:
+///
 /// ```
 /// # extern crate xi_core_lib as xi_core;
 /// extern crate serde_json;

--- a/rust/rpc/src/lib.rs
+++ b/rust/rpc/src/lib.rs
@@ -62,15 +62,15 @@ pub struct RawPeer<W: Write + 'static>(Arc<RpcState<W>>);
 /// channel. It is intended to be used behind a pointer, a trait object.
 pub trait Peer: Send + 'static {
     /// Used to implement `clone` in an object-safe way.
-    /// For an explanation on this approach, see this thread:
-    /// https://users.rust-lang.org/t/solved-is-it-possible-to-clone-a-boxed-trait-object/1714/6
+    /// For an explanation on this approach, see
+    /// [this thread](https://users.rust-lang.org/t/solved-is-it-possible-to-clone-a-boxed-trait-object/1714/6).
     fn box_clone(&self) -> Box<Peer>;
     /// Sends a notification (asynchronous RPC) to the peer.
     fn send_rpc_notification(&self, method: &str, params: &Value);
     /// Sends a request asynchronously, and the supplied callback will
     /// be called when the response arrives.
     ///
-    /// `Callback` is an alias for FnOnce(Result<Value, Error>); it must
+    /// `Callback` is an alias for `FnOnce(Result<Value, Error>)`; it must
     /// be boxed because trait objects cannot use generic paramaters.
     fn send_rpc_request_async(&self, method: &str, params: &Value,
                               f: Box<Callback>);

--- a/rust/trace/src/lib.rs
+++ b/rust/trace/src/lib.rs
@@ -631,8 +631,9 @@ pub fn trace<S, C>(name: S, categories: C)
 /// ```
 ///
 /// With `json_payload` feature:
-/// ```
-/// xi_trace::trace_payload("something happened", &["rpc", "response"], json!({"key": "value"}));
+///
+/// ```rust,ignore
+/// xi_trace::trace_payload("my event", &["rpc", "response"], json!({"key": "value"}));
 /// ```
 #[inline]
 pub fn trace_payload<S, C, P>(name: S, categories: C, payload: P)
@@ -757,6 +758,7 @@ pub fn samples_len() -> usize {
 
 /// Returns all the samples collected so far.  There is no guarantee that the
 /// samples are ordered chronologically for several reasons:
+///
 /// 1. Samples that span sections of code may be inserted on end instead of
 /// beginning.
 /// 2. Performance optimizations might have per-thread buffers.  Keeping all

--- a/rust/unicode/src/lib.rs
+++ b/rust/unicode/src/lib.rs
@@ -157,8 +157,8 @@ impl LineBreakLeafIter {
     /// indication may go away, this may not be useful in actual application.
     /// If end of leaf is found, return leaf's len. This does not indicate
     /// a break, as that requires at least one more codepoint of context.
-    /// If it is a break, then subsequent next call will return an offset of
-    /// 0. EOT is always a break, so in the EOT case it's up to the caller
+    /// If it is a break, then subsequent next call will return an offset of 0.
+    /// EOT is always a break, so in the EOT case it's up to the caller
     /// to figure that out.
     ///
     /// For consistent results, always supply same `s` until end of leaf is


### PR DESCRIPTION
This was motivated by CI failure on nightly; a code example that wasn't being correctly identified under hoedown was being identified and run when parsed with pulldown.