### PR TITLE
Fix broken links as per LinkChecker output.

### DIFF
--- a/docs/docs/crdt-details.md
+++ b/docs/docs/crdt-details.md
@@ -92,7 +92,7 @@ An example of a `O(log n)` operation is deleting an interval of a `Rope`, which 
 
 Obviously `Rope`s will be slower and take more memory than small `Strings` but they have an asymptotic advantage when working with large documents.
 
-For a deeper look at `Rope`s see the [Rope Science](rope_science/intro.md) series.
+For a deeper look at `Rope`s see the [Rope Science](rope_science_00.md) series.
 
 ### Subset
 

--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -47,7 +47,7 @@ versions.
 This document is not always perfectly up to date. For a comprehensive list of
 supported commands, the canonical resource is the source specifically [rust/core-lib/src/rpc.rs](https://github.com/google/xi-editor/blob/master/rust/core-lib/src/rpc.rs).
 
-- The update protocol is explained in more detail in [doc/update.md](https://github.com/google/xi-editor/blob/master/doc/update.md).
+- The update protocol is explained in more detail in [Xi view update protocol](#Xi-view-update-protocol).
 - The config system is explained in more detail in [doc/config.md](https://github.com/google/xi-editor/blob/master/doc/config.md).
 
 
@@ -250,7 +250,7 @@ or a request.
 
 #### update
 **Note**: This document is not entirely up to date: some changes to
-the protocol are described in [this document](https://github.com/google/xi-editor/blob/master/doc/update.md).
+the protocol are described in [this document](frontend-protocol.md#Xi-view-update-protocol).
 
 ```
 update {"tab": "1", "update": {

--- a/docs/docs/rope_science_09.md
+++ b/docs/docs/rope_science_09.md
@@ -6,7 +6,7 @@ is_site_nav_category2: true
 site_nav_category: docs
 ---
 
-(originally written 7 May 2016, now at [doc/crdt.md](../crdt.md))
+(originally written 7 May 2016, now at [crdt.md](crdt.md))
 
 I'll publish this shortly as a doc in the xi repo, but figured it might be useful to get a draft up here first. I'm prototyping the relevant diff calculations hinted in the second section, not sure how useful it would be to describe the data structures and algorithms in detail. Feels like working code is the most important thing :)
 

--- a/docs/docs/rope_science_12.md
+++ b/docs/docs/rope_science_12.md
@@ -110,7 +110,7 @@ details of representation are not terribly important. In xi, we ended up with a
 sequence of `invalidate`, `skip`, `copy`, `ins`, and `update` operations (this last
 is for updating only styles and cursors when the text is otherwise unchanged). The
 `ins` operation is the same as diff, while deletion is represented as two `copy`
-operations with a `skip` in the middle. See [update.md](../update.md) for detailed
+operations with a `skip` in the middle. See [update.md](update.md) for detailed
 documentation on the update method.
 
 ## The render plan

--- a/docs/docs/rope_science_12.md
+++ b/docs/docs/rope_science_12.md
@@ -110,7 +110,7 @@ details of representation are not terribly important. In xi, we ended up with a
 sequence of `invalidate`, `skip`, `copy`, `ins`, and `update` operations (this last
 is for updating only styles and cursors when the text is otherwise unchanged). The
 `ins` operation is the same as diff, while deletion is represented as two `copy`
-operations with a `skip` in the middle. See [update.md](update.md) for detailed
+operations with a `skip` in the middle. See [Xi view update protocol](frontend-protocol.md#Xi-view-update-protocol) for detailed
 documentation on the update method.
 
 ## The render plan


### PR DESCRIPTION
Fixes #550.

```
URL        `rope_science/intro.md'
Name       `Rope Science'
Parent URL https://google.github.io/xi-editor/docs/crdt-details.html, line 596, col 78
Real URL   https://google.github.io/xi-editor/docs/rope_science/intro.md
Check time 3.344 seconds
Size       5KB
Result     Error: 404 Not Found
 5 threads active,     0 links queued,  129 links in 134 URLs checked, runtime 16 seconds

URL        `../crdt.md'
Name       `doc/crdt.md'
Parent URL https://google.github.io/xi-editor/docs/rope_science_09.html, line 502, col 51
Real URL   https://google.github.io/xi-editor/crdt.md
Check time 3.801 seconds
Size       5KB
Result     Error: 404 Not Found

URL        `../update.md'
Name       `update.md'
Parent URL https://google.github.io/xi-editor/docs/rope_science_12.html, line 604, col 82
Real URL   https://google.github.io/xi-editor/update.md
Check time 3.828 seconds
Size       5KB
Result     Error: 404 Not Found
```
NOTE: I updated the update.md link, but then realized I don't know where it is. Any pointers?