### PR TITLE
Cleanup plugin lib

### DIFF
--- a/rust/syntect-plugin/src/main.rs
+++ b/rust/syntect-plugin/src/main.rs
@@ -179,7 +179,7 @@ impl<'a> PluginState<'a> {
     }
 
     fn do_highlighting(&mut self, mut ctx: PluginCtx<State>) {
-        let syntax = match ctx.get_path() {
+        let syntax = match ctx.get_view().path {
             Some(ref path) => self.syntax_set.find_syntax_for_file(path).unwrap()
                 .unwrap_or_else(|| self.syntax_set.find_syntax_plain_text()),
             None => self.syntax_set.find_syntax_plain_text(),


### PR DESCRIPTION
Over time a bunch of stuff that had nothing to do with caching ended up in the `CacheState` struct. This moves all of that down into `plugin_base`.

This is related to #472; in particular it will make it easier to adapt the current state cache layer to work with global plugins.

(It was also just a useful to warm up my memory of how the plugin stuff works.)