### PR TITLE
rust global plugin lib [WIP]

### DIFF
--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -1024,6 +1024,19 @@ impl From<String> for ViewIdentifier {
     }
 }
 
+// these two only exist so that we can use ViewIdentifiers as idle tokens
+impl From<usize> for ViewIdentifier {
+    fn from(src: usize) -> ViewIdentifier {
+        ViewIdentifier(src)
+    }
+}
+
+impl From<ViewIdentifier> for usize {
+    fn from(src: ViewIdentifier) -> usize {
+        src.0
+    }
+}
+
 impl fmt::Display for ViewIdentifier {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "view-id-{}", self.0)

--- a/rust/plugin-lib/src/global/dispatch.rs
+++ b/rust/plugin-lib/src/global/dispatch.rs
@@ -1,0 +1,199 @@
+// Copyright 2018 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use serde_json::{self, Value};
+
+use xi_core::{ViewIdentifier, PluginPid, ConfigTable};
+use xi_core::plugin_rpc::{PluginBufferInfo, PluginUpdate, HostRequest, HostNotification};
+use xi_rpc::{RpcCtx, RemoteError, Handler as RpcHandler};
+
+use global::{Plugin, View, Cache};
+
+/// Convenience for unwrapping a view, when handling RPC notifications.
+macro_rules! bail {
+    ($opt:expr, $method:expr, $pid:expr, $view:expr) => ( match $opt {
+        Some(t) => t,
+        None => {
+            eprintln!("{:?} missing {:?} for {:?}", $pid, $view, $method);
+            return
+        }
+    })
+}
+
+/// Convenience for unwrapping a view when handling RPC requests.
+/// Prints an error if the view is missing, and returns an appropriate error.
+macro_rules! bail_err {
+    ($opt:expr, $method:expr, $pid:expr, $view:expr) => ( match $opt {
+        Some(t) => t,
+        None => {
+            eprintln!("{:?} missing {:?} for {:?}", $pid, $view, $method);
+            return Err(RemoteError::custom(404, "missing view", None))
+        }
+    })
+}
+
+/// Handles raw RPCs from core, updating state and forwarding calls
+/// to the plugin,
+pub struct Dispatcher<'a, P: 'a + Plugin> {
+    //TODO: when we add multi-view, this should be an Arc+Mutex/Rc+RefCell
+    views: HashMap<ViewIdentifier, View<P::Cache>>,
+    pid: Option<PluginPid>,
+    plugin: &'a mut P,
+}
+
+impl<'a, P: 'a + Plugin> Dispatcher<'a, P> {
+    pub (crate) fn new(plugin: &'a mut P) -> Self {
+        Dispatcher {
+            views: HashMap::new(),
+            pid: None,
+            plugin: plugin,
+        }
+    }
+
+    fn do_initialize(&mut self, ctx: &RpcCtx,
+                     plugin_id: PluginPid,
+                     buffers: Vec<PluginBufferInfo>)
+    {
+        assert!(self.pid.is_none(), "initialize rpc received with existing pid");
+        self.pid = Some(plugin_id);
+        self.do_new_buffer(ctx, buffers);
+
+    }
+
+    fn do_did_save(&mut self, view_id: ViewIdentifier, path: PathBuf) {
+        let v = bail!(self.views.get_mut(&view_id), "did_save", self.pid, view_id);
+        self.plugin.did_save(v, &path);
+        v.path = Some(path);
+    }
+
+    fn do_config_changed(&mut self, view_id: ViewIdentifier, changes: ConfigTable) {
+        let v = bail!(self.views.get_mut(&view_id), "config_changed", self.pid, view_id);
+        self.plugin.config_changed(v, &changes);
+        for (key, value) in changes.iter() {
+            v.config_table.insert(key.to_owned(), value.to_owned());
+        }
+        let conf = serde_json::from_value(Value::Object(v.config_table.clone()));
+        v.config = conf.unwrap();
+    }
+
+    fn do_new_buffer(&mut self, ctx: &RpcCtx, buffers: Vec<PluginBufferInfo>) {
+        let plugin_id = self.pid.unwrap();
+        buffers.into_iter()
+            .map(|info| View::new(ctx.get_peer().clone(), plugin_id, info))
+            .for_each(|view| {
+                let mut view = view;
+                self.plugin.new_view(&mut view);
+                self.views.insert(view.view_id, view);
+            });
+
+    }
+
+    fn do_close(&mut self, view_id: ViewIdentifier) {
+        {
+            let v = bail!(self.views.get(&view_id), "close", self.pid, view_id);
+            self.plugin.did_close(v);
+        }
+        self.views.remove(&view_id);
+    }
+
+    fn do_shutdown(&mut self) {
+        eprintln!("rust plugin lib does not shutdown");
+        //TODO: handle shutdown
+
+    }
+
+    fn do_tracing_config(&mut self, enabled: bool) {
+        use xi_trace;
+
+        if enabled {
+            eprintln!("Enabling tracing in {:?}", self.pid);
+            xi_trace::enable_tracing();
+        } else {
+            eprintln!("Disabling tracing in {:?}",  self.pid);
+            xi_trace::disable_tracing();
+        }
+    }
+
+    fn do_update(&mut self, update: PluginUpdate) -> Result<Value, RemoteError> {
+        let PluginUpdate {
+            view_id, delta, new_len, new_line_count, rev, edit_type, author,
+        } = update;
+        let v = bail_err!(self.views.get_mut(&view_id), "update",
+                          self.pid, view_id);
+        //TODO: probably view should just have an update method
+        v.cache.update(delta.as_ref(), new_len, new_line_count, rev);
+        v.rev = rev;
+        Ok(self.plugin.update(v, delta.as_ref(), edit_type, author)
+            .map(|edit| serde_json::to_value(edit).unwrap())
+            .unwrap_or(Value::from(1)))
+    }
+
+    fn do_collect_trace(&self) -> Result<Value, RemoteError> {
+        use xi_trace;
+        use xi_trace_dump::*;
+
+        let samples = xi_trace::samples_cloned_unsorted();
+        chrome_trace::to_value(&samples, chrome_trace::OutputFormat::JsonArray)
+            .map_err(|e| RemoteError::custom(500, format!("{:?}", e), None))
+    }
+}
+
+impl<'a, P: Plugin> RpcHandler for Dispatcher<'a, P> {
+    type Notification = HostNotification;
+    type Request = HostRequest;
+
+    fn handle_notification(&mut self, ctx: &RpcCtx, rpc: Self::Notification) {
+        use self::HostNotification::*;
+        match rpc {
+            Initialize { plugin_id, buffer_info } =>
+                self.do_initialize(ctx, plugin_id, buffer_info),
+            DidSave { view_id, path } =>
+                self.do_did_save(view_id, path),
+            ConfigChanged { view_id, changes } =>
+                self.do_config_changed(view_id, changes),
+            NewBuffer { buffer_info } =>
+                self.do_new_buffer(ctx, buffer_info),
+            DidClose { view_id } =>
+                self.do_close(view_id),
+            //TODO: figure out shutdown
+            Shutdown ( .. ) =>
+                self.do_shutdown(),
+            TracingConfig { enabled } =>
+                self.do_tracing_config(enabled),
+            Ping ( .. ) => (),
+        }
+    }
+
+    fn handle_request(&mut self, _ctx: &RpcCtx, rpc: Self::Request)
+                      -> Result<Value, RemoteError> {
+        use self::HostRequest::*;
+        match rpc {
+            Update(params) =>
+                self.do_update(params),
+            CollectTrace ( .. ) =>
+                self.do_collect_trace(),
+        }
+    }
+
+    fn idle(&mut self, _ctx: &RpcCtx, token: usize) {
+        let view_id: ViewIdentifier = token.into();
+        let v = bail!(self.views.get_mut(&view_id), "idle", self.pid, view_id);
+        self.plugin.idle(v);
+    }
+}
+
+

--- a/rust/plugin-lib/src/global/mod.rs
+++ b/rust/plugin-lib/src/global/mod.rs
@@ -1,0 +1,17 @@
+mod view;
+
+use std::collections::HashMap;
+
+use xi_core::{ViewIdentifier, PluginPid, plugin_rpc};
+use xi_rpc::{self, RpcLoop, RpcCtx, RemoteError, ReadError, Handler as RpcHandler};
+use self::view::{Plugin, View};
+
+/// Handles raw RPCs from core, updating documents and bridging calls
+/// to the plugin,
+pub struct Dispatcher<'a, P: 'a + Plugin> {
+    //TODO: when we add multi-view, this should be an Arc+Mutex/Rc+RefCell
+    views: HashMap<ViewIdentifier, View<P::Cache>>,
+    pid: PluginPid,
+    plugin: &'a mut P,
+}
+

--- a/rust/plugin-lib/src/global/mod.rs
+++ b/rust/plugin-lib/src/global/mod.rs
@@ -1,17 +1,185 @@
+// Copyright 2018 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 mod view;
 
 use std::collections::HashMap;
+use std::io;
+use std::path::PathBuf;
 
-use xi_core::{ViewIdentifier, PluginPid, plugin_rpc};
+use serde_json::{self, Value};
+
+use xi_core::{ViewIdentifier, PluginPid, ConfigTable};
+use xi_core::plugin_rpc::{PluginBufferInfo, PluginUpdate, HostRequest, HostNotification};
 use xi_rpc::{self, RpcLoop, RpcCtx, RemoteError, ReadError, Handler as RpcHandler};
-use self::view::{Plugin, View};
+use self::view::{Plugin, View, Cache};
+
+macro_rules! bail {
+    ($opt:expr, $method:expr, $pid:expr, $view:expr) => ( match $opt {
+        Some(t) => t,
+        None => {
+            eprintln!("{:?} missing {:?} for {:?}", $pid, $view, $method);
+            return
+        }
+    })
+}
+
+macro_rules! bail_err {
+    ($opt:expr, $method:expr, $pid:expr, $view:expr, $err:expr) => ( match $opt {
+        Some(t) => t,
+        None => {
+            eprintln!("{:?} missing {:?} for {:?}", $pid, $view, $method);
+            return Err($err)
+        }
+    })
+}
 
 /// Handles raw RPCs from core, updating documents and bridging calls
 /// to the plugin,
 pub struct Dispatcher<'a, P: 'a + Plugin> {
     //TODO: when we add multi-view, this should be an Arc+Mutex/Rc+RefCell
     views: HashMap<ViewIdentifier, View<P::Cache>>,
-    pid: PluginPid,
+    pid: Option<PluginPid>,
     plugin: &'a mut P,
 }
 
+impl<'a, P: 'a + Plugin> Dispatcher<'a, P> {
+    pub fn new(plugin: &'a mut P) -> Self {
+        Dispatcher {
+            views: HashMap::new(),
+            pid: None,
+            plugin: plugin,
+        }
+    }
+
+    fn do_initialize(&mut self, ctx: &RpcCtx,
+                     plugin_id: PluginPid,
+                     buffers: Vec<PluginBufferInfo>)
+    {
+        assert!(self.pid.is_none(), "initialize rpc received with existing pid");
+        self.pid = Some(plugin_id);
+        self.do_new_buffer(ctx, buffers);
+
+    }
+
+    fn do_did_save(&mut self, view_id: ViewIdentifier, path: PathBuf) {
+        let v = bail!(self.views.get_mut(&view_id), "did_save", self.pid, view_id);
+        self.plugin.did_save(v, &path);
+        v.path = Some(path);
+    }
+
+    fn do_config_changed(&mut self, view_id: ViewIdentifier, changes: ConfigTable) {
+        let v = bail!(self.views.get_mut(&view_id), "config_changed", self.pid, view_id);
+        self.plugin.config_changed(v, &changes);
+    }
+
+    fn do_new_buffer(&mut self, ctx: &RpcCtx, buffers: Vec<PluginBufferInfo>) {
+        let plugin_id = self.pid.unwrap();
+        buffers.into_iter()
+            .map(|info| View::new(ctx.get_peer().clone(), plugin_id, info))
+            .for_each(|view| {
+                let mut view = view;
+                self.plugin.new_view(&mut view);
+                self.views.insert(view.view_id, view);
+            });
+
+    }
+
+    fn do_close(&mut self, view_id: ViewIdentifier) {
+        {
+            let v = bail!(self.views.get(&view_id), "close", self.pid, view_id);
+            self.plugin.did_close(v);
+        }
+        self.views.remove(&view_id);
+    }
+
+    fn do_update(&mut self, update: PluginUpdate) -> Result<Value, RemoteError> {
+        let PluginUpdate {
+            view_id, delta, new_len, new_line_count, rev, edit_type, author,
+        } = update;
+        let v = bail_err!(self.views.get_mut(&view_id), "update",
+                          self.pid, view_id,
+                          RemoteError::custom(404, "missing view", None));
+        v.cache.update(delta.as_ref(), new_len, new_line_count, rev);
+        self.plugin.update(v, delta.as_ref())
+    }
+
+    fn do_shutdown(&mut self) {
+        //TODO: handle shutdown
+
+    }
+
+    fn do_tracing_config(&mut self, enabled: bool) {
+        use xi_trace;
+
+        if enabled {
+            eprintln!("Enabling tracing in {:?}", self.pid);
+            xi_trace::enable_tracing();
+        } else {
+            eprintln!("Disabling tracing in {:?}",  self.pid);
+            xi_trace::disable_tracing();
+        }
+    }
+}
+
+impl<'a, P: Plugin> RpcHandler for Dispatcher<'a, P> {
+    type Notification = HostNotification;
+    type Request = HostRequest;
+
+    fn handle_notification(&mut self, ctx: &RpcCtx, rpc: Self::Notification) {
+        use self::HostNotification::*;
+        match rpc {
+            Initialize { plugin_id, buffer_info } =>
+                self.do_initialize(ctx, plugin_id, buffer_info),
+            DidSave { view_id, path } =>
+                self.do_did_save(view_id, path),
+            ConfigChanged { view_id, changes } =>
+                self.do_config_changed(view_id, changes),
+            NewBuffer { buffer_info } =>
+                self.do_new_buffer(ctx, buffer_info),
+            DidClose { view_id } =>
+                self.do_close(view_id),
+            //TODO: figure out shutdown
+            Shutdown ( .. ) =>
+                self.do_shutdown(),
+            TracingConfig { enabled } =>
+                self.do_tracing_config(enabled),
+            Ping ( .. ) => (),
+        }
+    }
+
+    fn handle_request(&mut self, ctx: &RpcCtx, rpc: Self::Request)
+                      -> Result<Value, RemoteError> {
+        use self::HostRequest::*;
+        match rpc {
+            Update(params) =>
+                self.do_update(params),
+            CollectTrace ( .. ) =>
+                Err(RemoteError::custom(100, "method not supported", None)),
+        }
+    }
+
+    fn idle(&mut self, ctx: &RpcCtx, token: usize) {
+        self.plugin.idle();
+    }
+}
+
+pub fn mainloop<P: Plugin>(plugin: &mut P) -> Result<(), ReadError> {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut rpc_looper = RpcLoop::new(stdout);
+    let mut dispatcher = Dispatcher::new(plugin);
+
+    rpc_looper.mainloop(|| stdin.lock(), &mut dispatcher)
+}

--- a/rust/plugin-lib/src/global/mod.rs
+++ b/rust/plugin-lib/src/global/mod.rs
@@ -170,8 +170,10 @@ impl<'a, P: Plugin> RpcHandler for Dispatcher<'a, P> {
         }
     }
 
-    fn idle(&mut self, ctx: &RpcCtx, token: usize) {
-        self.plugin.idle();
+    fn idle(&mut self, _ctx: &RpcCtx, token: usize) {
+        let view_id: ViewIdentifier = token.into();
+        let v = bail!(self.views.get_mut(&view_id), "idle", self.pid, view_id);
+        self.plugin.idle(v);
     }
 }
 

--- a/rust/plugin-lib/src/global/view.rs
+++ b/rust/plugin-lib/src/global/view.rs
@@ -1,20 +1,37 @@
-use std::path::{Path, PathBuf};
-use serde_json::Value;
+// Copyright 2018 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-use xi_core::{ViewIdentifier, PluginPid, BufferConfig, ConfigTable, plugin_rpc};
-use xi_rpc::RpcPeer;
-use xi_rope::rope::{RopeDelta, LinesMetric};
+use std::path::{Path, PathBuf};
+use serde_json::{self, Value};
+use serde::Deserialize;
+
+use xi_core::{ViewIdentifier, PluginPid, BufferConfig, ConfigTable};
+use xi_core::plugin_rpc::{TextUnit, GetDataResponse, ScopeSpan, PluginBufferInfo};
+
+use xi_rpc::{RpcPeer, RemoteError};
+use xi_rope::rope::RopeDelta;
 
 use plugin_base::{Error, DataSource};
 
 pub struct View<C> {
-    cache: C,
+    pub (crate) cache: C,
     peer: RpcPeer,
-    path: Option<PathBuf>,
+    pub (crate) path: Option<PathBuf>,
     config: BufferConfig,
     config_table: ConfigTable,
     plugin_id: PluginPid,
-    view_id: ViewIdentifier,
+    pub (crate) view_id: ViewIdentifier,
 }
 
 struct FetchCtx {
@@ -24,12 +41,32 @@ struct FetchCtx {
 }
 
 impl<C: Cache> View<C> {
-    fn get_path(&self) -> Option<&Path> {
-        unimplemented!()
+    pub (crate) fn new(peer: RpcPeer, plugin_id: PluginPid,
+                       info: PluginBufferInfo) -> Self {
+        let PluginBufferInfo {
+            views, rev, path, config, buf_size, nb_lines, ..
+        } = info;
+
+        assert_eq!(views.len(), 1, "assuming single view");
+        let view_id = views.first().unwrap().to_owned();
+        let path = path.map(PathBuf::from);
+        View {
+            cache: C::new(buf_size, rev, nb_lines),
+            peer: peer,
+            config_table: config.clone(),
+            config: serde_json::from_value(Value::Object(config)).unwrap(),
+            path: path,
+            plugin_id: plugin_id,
+            view_id: view_id,
+        }
     }
 
-    fn get_config(&self) -> &BufferConfig {
-        unimplemented!()
+    pub fn get_path(&self) -> Option<&PathBuf> {
+        self.path.as_ref()
+    }
+
+    pub fn get_config(&self) -> &BufferConfig {
+        &self.config
     }
 
     pub fn add_scopes(&self, scopes: &Vec<Vec<String>>) {
@@ -37,7 +74,7 @@ impl<C: Cache> View<C> {
     }
 
     pub fn update_spans(&self, start: usize, len: usize,
-                        spans: &[plugin_rpc::ScopeSpan]) {
+                        spans: &[ScopeSpan]) {
 
     }
 
@@ -58,10 +95,11 @@ impl<C: Cache> View<C> {
 
 /// A cache of a document's contents
 pub trait Cache {
-    fn new(buf_size: usize, rev: u64) -> Self;
+    fn new(buf_size: usize, rev: u64, num_lines: usize) -> Self;
     fn get_line<DS>(&self, source: &DS, line_num: usize) -> Result<&str, Error>;
     /// Updates the cache by applying this delta'.
-    fn update(&mut self, delta: &RopeDelta, buf_size: usize, rev: u64);
+    fn update(&mut self, delta: Option<&RopeDelta>, buf_size: usize,
+              num_lines: usize, rev: u64);
     /// Flushes any state held by this cache.
     fn clear(&mut self);
 }
@@ -69,50 +107,31 @@ pub trait Cache {
 pub trait Plugin {
     type Cache: Cache;
 
-    fn initialize(&mut self) {
-
-    }
-
-    fn update(&mut self, view: &View<Self::Cache>, delta: RopeDelta, rev: usize) {
-
-    }
-
-    fn did_save(&mut self, view: &View<Self::Cache>) {
-
-    }
-
-    fn did_close(&mut self, view: &View<Self::Cache>) {
-
-    }
-
-    fn new_view(&mut self, view: &View<Self::Cache>) {
-
-    }
+    fn update(&mut self, view: &mut View<Self::Cache>, delta: Option<&RopeDelta>)
+        -> Result<Value, RemoteError>;
+    fn did_save(&mut self, view: &mut View<Self::Cache>, new_path: &Path);
+    fn did_close(&self, view: &View<Self::Cache>);
+    fn new_view(&mut self, view: &mut View<Self::Cache>);
 
     /// `view.config` contains the pre-change config
-    fn config_changed(&mut self, view: &View<Self::Cache>, changes: &ConfigTable) {
-
-    }
-
-    fn idle(&mut self) {
-
-    }
+    fn config_changed(&mut self, view: &mut View<Self::Cache>, changes: &ConfigTable);
+    fn idle(&mut self) { }
 }
 
 impl DataSource for FetchCtx {
-    fn get_data(&self, offset: usize, max_size: usize, rev: u64) -> Result<String, Error> {
+    fn get_data(&self, start: usize, unit: TextUnit, max_size: usize, rev: u64)
+        -> Result<GetDataResponse, Error> {
         let params = json!({
             "plugin_id": self.plugin_id,
             "view_id": self.view_id,
-            "offset": offset,
+            "start": start,
+            "unit": unit,
             "max_size": max_size,
             "rev": rev,
         });
-        let result = self.peer.send_rpc_request("get_data", &params);
-        match result {
-            Ok(Value::String(s)) => Ok(s),
-            Ok(_) => Err(Error::WrongReturnType),
-            Err(err) => Err(Error::RpcError(err)),
-        }
+        let result = self.peer.send_rpc_request("get_data", &params)
+            .map_err(|e| Error::RpcError(e))?;
+        GetDataResponse::deserialize(result)
+            .map_err(|_| Error::WrongReturnType)
     }
 }

--- a/rust/plugin-lib/src/global/view.rs
+++ b/rust/plugin-lib/src/global/view.rs
@@ -90,6 +90,11 @@ impl<C: Cache> View<C> {
         };
         self.cache.get_line(&ctx, line_num)
     }
+
+    pub fn schedule_idle(&self) {
+        let token: usize = self.view_id.into();
+        self.peer.schedule_idle(token);
+    }
 }
 
 

--- a/rust/plugin-lib/src/global/view.rs
+++ b/rust/plugin-lib/src/global/view.rs
@@ -1,0 +1,118 @@
+use std::path::{Path, PathBuf};
+use serde_json::Value;
+
+use xi_core::{ViewIdentifier, PluginPid, BufferConfig, ConfigTable, plugin_rpc};
+use xi_rpc::RpcPeer;
+use xi_rope::rope::{RopeDelta, LinesMetric};
+
+use plugin_base::{Error, DataSource};
+
+pub struct View<C> {
+    cache: C,
+    peer: RpcPeer,
+    path: Option<PathBuf>,
+    config: BufferConfig,
+    config_table: ConfigTable,
+    plugin_id: PluginPid,
+    view_id: ViewIdentifier,
+}
+
+struct FetchCtx {
+    plugin_id: PluginPid,
+    view_id: ViewIdentifier,
+    peer: RpcPeer,
+}
+
+impl<C: Cache> View<C> {
+    fn get_path(&self) -> Option<&Path> {
+        unimplemented!()
+    }
+
+    fn get_config(&self) -> &BufferConfig {
+        unimplemented!()
+    }
+
+    pub fn add_scopes(&self, scopes: &Vec<Vec<String>>) {
+
+    }
+
+    pub fn update_spans(&self, start: usize, len: usize,
+                        spans: &[plugin_rpc::ScopeSpan]) {
+
+    }
+
+    pub fn do_edit(&self) {
+
+    }
+
+    pub fn get_line(&self, line_num: usize) -> Result<&str, Error> {
+        let ctx = FetchCtx {
+            view_id: self.view_id,
+            plugin_id: self.plugin_id,
+            peer: self.peer.clone(),
+        };
+        self.cache.get_line(&ctx, line_num)
+    }
+}
+
+
+/// A cache of a document's contents
+pub trait Cache {
+    fn new(buf_size: usize, rev: u64) -> Self;
+    fn get_line<DS>(&self, source: &DS, line_num: usize) -> Result<&str, Error>;
+    /// Updates the cache by applying this delta'.
+    fn update(&mut self, delta: &RopeDelta, buf_size: usize, rev: u64);
+    /// Flushes any state held by this cache.
+    fn clear(&mut self);
+}
+
+pub trait Plugin {
+    type Cache: Cache;
+
+    fn initialize(&mut self) {
+
+    }
+
+    fn update(&mut self, view: &View<Self::Cache>, delta: RopeDelta, rev: usize) {
+
+    }
+
+    fn did_save(&mut self, view: &View<Self::Cache>) {
+
+    }
+
+    fn did_close(&mut self, view: &View<Self::Cache>) {
+
+    }
+
+    fn new_view(&mut self, view: &View<Self::Cache>) {
+
+    }
+
+    /// `view.config` contains the pre-change config
+    fn config_changed(&mut self, view: &View<Self::Cache>, changes: &ConfigTable) {
+
+    }
+
+    fn idle(&mut self) {
+
+    }
+}
+
+impl DataSource for FetchCtx {
+    fn get_data(&self, offset: usize, max_size: usize, rev: u64) -> Result<String, Error> {
+        let params = json!({
+            "plugin_id": self.plugin_id,
+            "view_id": self.view_id,
+            "offset": offset,
+            "max_size": max_size,
+            "rev": rev,
+        });
+        let result = self.peer.send_rpc_request("get_data", &params);
+        match result {
+            Ok(Value::String(s)) => Ok(s),
+            Ok(_) => Err(Error::WrongReturnType),
+            Err(err) => Err(Error::RpcError(err)),
+        }
+    }
+}

--- a/rust/plugin-lib/src/lib.rs
+++ b/rust/plugin-lib/src/lib.rs
@@ -29,4 +29,4 @@ extern crate memchr;
 pub mod plugin_base;
 pub mod state_cache;
 pub mod base_cache;
-mod global;
+pub mod global;

--- a/rust/plugin-lib/src/lib.rs
+++ b/rust/plugin-lib/src/lib.rs
@@ -29,3 +29,4 @@ extern crate memchr;
 pub mod plugin_base;
 pub mod state_cache;
 pub mod base_cache;
+mod global;


### PR DESCRIPTION
This is based off of #568, which should be resolved first.

This isn't quite usable at the moment, but I wanted to PR in case there was feedback on the overall approach.

This introduces essentially a new plugin lib, rooted in `plugin-lib/src/global`. This new lib allows for a single plugin to manage events in multiple views.

Todos:
- [ ] break `StateCache` out into a stand alone component (without breaking existing lib)
- [ ] implement the new `Cache` trait for `StateCache` and `ChunkCache`
- [ ] implement outstanding features from current lib (`request_is_pending`, maybe a bit more)
- [ ] implement syntect on top of new API

I think (famous last words) most of the tricky stuff is out of the way, so I hope to have the rest of this work done by the weekend.

- closes #472 
- progress on #558 