### PR TITLE
Tracing in core

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -560,6 +560,7 @@ dependencies = [
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xi-trace 0.1.0",
 ]
 
 [[package]]

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -84,9 +84,8 @@ impl PluginRef {
     /// NOTE: Only added temporarily for tracing infrastructure to simplify
     /// the initial implementation & perf doesn't matter.
     /// Otherwise should communicate asynchronously with plugins.
-    pub fn request_trace_rpc_sync(&self, method: &str, params: &Value)
-        -> Result<Value, xi_rpc::Error> {
-        self.0.lock().unwrap().peer.send_rpc_request(method, params)
+    pub fn request_traces(&self) -> Result<Value, xi_rpc::Error> {
+        self.0.lock().unwrap().peer.send_rpc_request("collect_trace", &json!({}))
     }
 
     /// Initialize the plugin.

--- a/rust/rpc/Cargo.toml
+++ b/rust/rpc/Cargo.toml
@@ -11,3 +11,5 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 crossbeam = "0.3.2"
+
+xi-trace = { path = "../trace", version = "0.1.0" }

--- a/rust/rpc/src/parse.rs
+++ b/rust/rpc/src/parse.rs
@@ -18,6 +18,7 @@ use std::io::BufRead;
 
 use serde_json::{self, Value, Error as JsonError};
 use serde::de::DeserializeOwned;
+use xi_trace;
 
 use error::{RemoteError, ReadError};
 
@@ -79,6 +80,7 @@ impl MessageReader {
     /// This should not be called directly unless you are writing tests.
     #[doc(hidden)]
     pub fn parse(&self, s: &str) -> Result<RpcObject, ReadError> {
+        let _trace = xi_trace::trace_block("parse", &["rpc"]);
         let val = serde_json::from_str::<Value>(&s)?;
         if !val.is_object() {
             Err(ReadError::NotObject)
@@ -127,7 +129,7 @@ impl RpcObject {
         }
         let result = self.0.as_object_mut()
             .and_then(|obj| obj.remove("result"));
-        //let id = id.map(Value::from).unwrap_or(Value::Null);
+
         match result {
             Some(r) => Ok(Ok(r)),
             None => {

--- a/rust/syntect-plugin/Cargo.lock
+++ b/rust/syntect-plugin/Cargo.lock
@@ -711,6 +711,7 @@ dependencies = [
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xi-trace 0.1.0",
 ]
 
 [[package]]

--- a/rust/syntect-plugin/Cargo.lock
+++ b/rust/syntect-plugin/Cargo.lock
@@ -725,6 +725,8 @@ dependencies = [
  "xi-core-lib 0.2.0",
  "xi-plugin-lib 0.1.0",
  "xi-rope 0.2.0",
+ "xi-trace 0.1.0",
+ "xi-trace-dump 0.1.0",
 ]
 
 [[package]]

--- a/rust/syntect-plugin/Cargo.toml
+++ b/rust/syntect-plugin/Cargo.toml
@@ -24,3 +24,9 @@ path = "../core-lib"
 
 [dependencies.xi-rope]
 path = "../rope"
+
+[dependencies.xi-trace]
+path = "../trace"
+
+[dependencies.xi-trace-dump]
+path = "../trace-dump"


### PR DESCRIPTION
This PR adds basic support for chrome tracing to xi-rpc, xi-core, and xi-plugin-lib. This produces traces like this, which is the trace of this PR message:
![screen shot 2018-03-27 at 7 08 37 pm](https://user-images.githubusercontent.com/3330916/37999780-713827c6-31f2-11e8-8692-05c38b5c30ea.png)

This will have some conflicts with #569 and #573, but it's probably worth merging now and then patching up those PRs, so that we can compare traces.

closes #471
supersedes #526 

cc @vlovich