### PR TITLE
fix(comments): remove comment about invariant

### DIFF
--- a/rust/rope/src/tree.rs
+++ b/rust/rope/src/tree.rs
@@ -142,7 +142,6 @@ pub trait Metric<N: NodeInfo> {
     /// Invariants:
     ///
     /// - `from_base_units(to_base_units(x)) == x` is True for valid `x`
-    /// - `is_boundary(to_base_units(x))` is True for all `x`
     fn to_base_units(l: &N::L, in_measured_units: usize) -> usize;
 
     /// Returns the smallest offset in measured units corresponding to an offset in base units.


### PR DESCRIPTION
It was stated that:
"`is_boundary(to_base_units(x))` is True for all `x`"

This is not the case for BaseMetric. 
For BaseMetric there can be several 'measured units'(=utf8 units) between boundaries.

This comment confused me poking around the code, so I felt like opening this trivial PR. 