### PR TITLE
    Actually set new selection when toggled

### DIFF
--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -139,6 +139,7 @@ impl View {
             selection.delete_range(offset, offset, true);
             if !selection.is_empty() {
                 self.drag_state = None;
+                self.set_selection_raw(text, selection);
                 return;
             }
         }


### PR DESCRIPTION
The minimal invalidation logic required explicit setting of the
selection, rather than updating it in place, so it could compute the
delta for rendering. One case, toggling an existing selection off,
wasn't updated.

Fixes #590