### PR TITLE
Improve ergonomics around SelRegion and Selection

### DIFF
--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -347,8 +347,7 @@ impl Editor {
     /// Sets the selection to a single region, and scrolls the end of that
     /// region into view.
     fn set_sel_single_region(&mut self, region: SelRegion) {
-        let mut sel = Selection::new();
-        sel.add_region(region);
+        let sel = Selection::new_simple(region);
         self.scroll_to = self.view.set_selection(&self.text, sel);
     }
 

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -347,8 +347,7 @@ impl Editor {
     /// Sets the selection to a single region, and scrolls the end of that
     /// region into view.
     fn set_sel_single_region(&mut self, region: SelRegion) {
-        let sel = Selection::new_simple(region);
-        self.scroll_to = self.view.set_selection(&self.text, sel);
+        self.scroll_to = self.view.set_selection(&self.text, region.into());
     }
 
     /// Applies a delta to the text, and updates undo state.

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -621,12 +621,12 @@ impl Editor {
         // Another possibility would be to make the delta builder be able to handle
         // overlapping deletions (using union semantics).
         let mut deletions = Selection::new();
-        for r in self.view.sel_regions() {
+        for &r in self.view.sel_regions() {
             if r.is_caret() {
                 let new_region = region_movement(movement, r, &self.view, &self.text, true);
                 deletions.add_region(new_region);
             } else {
-                deletions.add_region(r.clone());
+                deletions.add_region(r);
             }
         }
         if save {
@@ -784,8 +784,8 @@ impl Editor {
 
     fn add_selection_by_movement(&mut self, movement: Movement) {
         let mut sel = Selection::new();
-        for region in self.view.sel_regions() {
-            sel.add_region(region.clone());
+        for &region in self.view.sel_regions() {
+            sel.add_region(region);
             let new_region = region_movement(movement, region, &self.view, &self.text, false);
             sel.add_region(new_region);
         }
@@ -848,8 +848,8 @@ impl Editor {
                 let sel = {
                     let (last, rest) = self.view.sel_regions().split_last().unwrap();
                     let mut sel = Selection::new();
-                    for region in rest {
-                        sel.add_region(region.clone());
+                    for &region in rest {
+                        sel.add_region(region);
                     }
                     // TODO: small nit, merged region should be backward if end < start.
                     // This could be done by explicitly overriding, or by tweaking the
@@ -937,7 +937,7 @@ impl Editor {
         }
     }
 
-    fn sel_region_to_interval_and_rope(&self, region: &SelRegion) -> (Interval, Rope) {
+    fn sel_region_to_interval_and_rope(&self, region: SelRegion) -> (Interval, Rope) {
         let as_interval = Interval::new_closed_open(region.min(), region.max());
         let interval_rope = Rope::from(self.text.slice_to_string(
             as_interval.start(), as_interval.end()));
@@ -949,9 +949,9 @@ impl Editor {
         let mut last = 0;
         let mut optional_previous_selection : Option<(Interval, Rope)> =
             last_selection_region(self.view.sel_regions()).map(
-                |ref region| self.sel_region_to_interval_and_rope(region));
+                |&region| self.sel_region_to_interval_and_rope(region));
 
-        for region in self.view.sel_regions() {
+        for &region in self.view.sel_regions() {
             if region.is_caret() {
                 let middle = region.end;
                 let start = self.text.prev_grapheme_offset(middle).unwrap_or(0);
@@ -967,7 +967,7 @@ impl Editor {
                     }
                 }
             } else if let Some(previous_selection) = optional_previous_selection {
-                let current_interval = self.sel_region_to_interval_and_rope(&region);
+                let current_interval = self.sel_region_to_interval_and_rope(region);
                 builder.replace(current_interval.0, previous_selection.1);
                 optional_previous_selection = Some(current_interval);
             }

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -251,12 +251,7 @@ impl Editor {
 
         if let Some(prev_sel) = prev_sel {
             let offset = prev_sel.start.min(new_len);
-            let new_sel = SelRegion {
-                start: offset,
-                end: offset,
-                horiz: None,
-                affinity: Affinity::default(),
-            };
+            let new_sel = SelRegion::caret(offset);
             self.set_sel_single_region(new_sel);
         }
 
@@ -346,12 +341,7 @@ impl Editor {
 
     // TODO: add affinity.
     fn set_cursor(&mut self, offset: usize) {
-        self.set_sel_single_region(SelRegion {
-            start: offset,
-            end: offset,
-            horiz: None,
-            affinity: Affinity::default(),
-        });
+        self.set_sel_single_region(SelRegion::caret(offset));
     }
 
     /// Sets the selection to a single region, and scrolls the end of that
@@ -854,12 +844,7 @@ impl Editor {
                     // TODO: small nit, merged region should be backward if end < start.
                     // This could be done by explicitly overriding, or by tweaking the
                     // merge logic.
-                    sel.add_region(SelRegion {
-                        start: last.start,
-                        end: offset,
-                        horiz: None,
-                        affinity: Affinity::default(),
-                    });
+                    sel.add_region(SelRegion::new(last.start, offset));
                     sel
                 };
                 self.view.start_drag(offset, offset, offset);

--- a/rust/core-lib/src/movement.rs
+++ b/rust/core-lib/src/movement.rs
@@ -16,7 +16,7 @@
 
 use std::cmp::max;
 
-use selection::{Affinity, HorizPos, Selection, SelRegion};
+use selection::{HorizPos, Selection, SelRegion};
 use view::View;
 use word_boundaries::WordCursor;
 use xi_rope::rope::{LinesMetric, Rope};
@@ -205,12 +205,10 @@ pub fn region_movement(m: Movement, r: SelRegion, view: &View, text: &Rope, modi
         Movement::StartOfDocument => (0, None),
         Movement::EndOfDocument => (text.len(), None),
     };
-    SelRegion {
-        start: if modify { r.start } else { offset },
-        end: offset,
-        horiz: horiz,
-        affinity: Affinity::default(),
-    }
+    SelRegion::new(
+        if modify { r.start } else { offset },
+        offset,
+    ).with_horiz(horiz)
 }
 
 /// Compute a new selection by applying a movement to an existing selection.

--- a/rust/core-lib/src/movement.rs
+++ b/rust/core-lib/src/movement.rs
@@ -61,7 +61,7 @@ pub enum Movement {
 ///
 /// Note: in non-exceptional cases, this function preserves the `horiz`
 /// field of the selection region.
-fn vertical_motion(r: &SelRegion, view: &View, text: &Rope, line_delta: isize,
+fn vertical_motion(r: SelRegion, view: &View, text: &Rope, line_delta: isize,
     modify: bool) -> (usize, Option<HorizPos>)
 {
     // The active point of the selection
@@ -107,7 +107,7 @@ fn scroll_height(view: &View) -> isize {
 }
 
 /// Compute the result of movement on one selection region.
-pub fn region_movement(m: Movement, r: &SelRegion, view: &View, text: &Rope, modify: bool)
+pub fn region_movement(m: Movement, r: SelRegion, view: &View, text: &Rope, modify: bool)
     -> SelRegion
 {
     let (offset, horiz) = match m {
@@ -224,7 +224,7 @@ pub fn selection_movement(m: Movement, s: &Selection, view: &View, text: &Rope,
     modify: bool) -> Selection
 {
     let mut result = Selection::new();
-    for r in s.iter() {
+    for &r in s.iter() {
         let new_region = region_movement(m, r, view, text, modify);
         result.add_region(new_region);
     }

--- a/rust/core-lib/src/selection.rs
+++ b/rust/core-lib/src/selection.rs
@@ -199,12 +199,10 @@ impl Selection {
                 }
             };
 
-            let new_region =  SelRegion {
-                start: transformer.transform(region.start, start_after),
-                end: transformer.transform(region.end, end_after),
-                horiz: None,
-                affinity: region.affinity,
-            };
+            let new_region = SelRegion::new(
+                transformer.transform(region.start, start_after),
+                transformer.transform(region.end, end_after),
+            ).with_affinity(region.affinity);
             result.add_region(new_region);
         }
         result
@@ -265,6 +263,42 @@ pub struct SelRegion {
 }
 
 impl SelRegion {
+    /// Returns a new region.
+    pub fn new(start: usize, end: usize) -> Self {
+        Self {
+            start,
+            end,
+            horiz: None,
+            affinity: Affinity::default(),
+        }
+    }
+
+    /// Returns a new caret region (`start == end`).
+    pub fn caret(pos: usize) -> Self {
+        Self {
+            start: pos,
+            end: pos,
+            horiz: None,
+            affinity: Affinity::default(),
+        }
+    }
+
+    /// Returns a region with the given horizontal position.
+    pub fn with_horiz(self, horiz: Option<HorizPos>) -> Self {
+        Self {
+            horiz,
+            ..self
+        }
+    }
+
+    /// Returns a region with the given affinity.
+    pub fn with_affinity(self, affinity: Affinity) -> Self {
+        Self {
+            affinity,
+            ..self
+        }
+    }
+
     /// Gets the earliest offset within the region, ie the minimum of both edges.
     pub fn min(self) -> usize {
         min(self.start, self.end)
@@ -301,29 +335,19 @@ impl SelRegion {
         } else {
             (new_max, new_min)
         };
-        SelRegion {
-            start: start,
-            end: end,
-            // Could try to preserve horiz/affinity from one of the
-            // sources, but very likely not worth it.
-            horiz: None,
-            affinity: Affinity::default(),
-        }
+        // Could try to preserve horiz/affinity from one of the
+        // sources, but very likely not worth it.
+        SelRegion::new(start, end)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{Affinity, Selection, SelRegion};
+    use super::{Selection, SelRegion};
     use std::ops::Deref;
 
     fn r(start: usize, end: usize) -> SelRegion {
-        SelRegion {
-            start: start,
-            end: end,
-            horiz: None,
-            affinity: Affinity::default(),
-        }
+        SelRegion::new(start, end)
     }
 
     #[test]

--- a/rust/core-lib/src/selection.rs
+++ b/rust/core-lib/src/selection.rs
@@ -69,7 +69,7 @@ impl Selection {
     /// touching at the edges does not cause a merge. A caret merges with
     /// a non-caret if it is in the interior or on either edge. Two carets
     /// merge if they are the same offset.
-    /// 
+    ///
     /// Performance note: should be O(1) if the new region strictly comes
     /// after all the others in the selection, otherwise O(n).
     pub fn add_region(&mut self, region: SelRegion) {
@@ -81,15 +81,15 @@ impl Selection {
         let mut region = region;
         let mut end_ix = ix;
         if self.regions[ix].min() <= region.min() {
-            if self.regions[ix].should_merge(&region) {
-                region = self.regions[ix].merge_with(&region);
+            if self.regions[ix].should_merge(region) {
+                region = self.regions[ix].merge_with(region);
             } else {
                 ix += 1;
             }
             end_ix += 1;
         }
-        while end_ix < self.regions.len() && region.should_merge(&self.regions[end_ix]) {
-            region = region.merge_with(&self.regions[end_ix]);
+        while end_ix < self.regions.len() && region.should_merge(self.regions[end_ix]) {
+            region = region.merge_with(self.regions[end_ix]);
             end_ix += 1;
         }
         if ix == end_ix {
@@ -223,7 +223,7 @@ impl Deref for Selection {
 }
 
 /// The "affinity" of a cursor which is sitting exactly on a line break.
-/// 
+///
 /// We say "cursor" here rather than "caret" because (depending on presentation)
 /// the front-end may draw a cursor even when the region is not a caret.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -248,7 +248,7 @@ impl Default for Affinity {
 /// term "caret" (sometimes also "cursor", more loosely) to refer to a selection
 /// region with an empty interior. A "non-caret region" is one with a non-empty
 /// interior (i.e. `start != end`).
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct SelRegion {
     /// The inactive edge of a selection, as a byte offset. When
     /// equal to end, the selection range acts as a caret.
@@ -266,33 +266,33 @@ pub struct SelRegion {
 
 impl SelRegion {
     /// Gets the earliest offset within the region, ie the minimum of both edges.
-    pub fn min(&self) -> usize {
+    pub fn min(self) -> usize {
         min(self.start, self.end)
     }
 
     /// Gets the latest offset within the region, ie the maximum of both edges.
-    pub fn max(&self) -> usize {
+    pub fn max(self) -> usize {
         max(self.start, self.end)
     }
 
     /// Determines whether the region is a caret (ie has an empty interior).
-    pub fn is_caret(&self) -> bool {
+    pub fn is_caret(self) -> bool {
         self.start == self.end
     }
 
     /// Determines whether the region's affinity is upstream.
-    pub fn is_upstream(&self) -> bool {
+    pub fn is_upstream(self) -> bool {
         self.affinity == Affinity::Upstream
     }
 
     // Indicate whether this region should merge with the next.
     // Assumption: regions are sorted (self.min() <= other.min())
-    fn should_merge(&self, other: &SelRegion) -> bool {
+    fn should_merge(self, other: SelRegion) -> bool {
         other.min() < self.max() ||
             ((self.is_caret() || other.is_caret()) && other.min() == self.max())
     }
 
-    fn merge_with(&self, other: &SelRegion) -> SelRegion {
+    fn merge_with(self, other: SelRegion) -> SelRegion {
         let is_forward = self.end > self.start || other.end > other.start;
         let new_min = min(self.min(), other.min());
         let new_max = max(self.max(), other.max());

--- a/rust/core-lib/src/selection.rs
+++ b/rust/core-lib/src/selection.rs
@@ -40,6 +40,13 @@ impl Selection {
         Selection::default()
     }
 
+    /// Creates a selection with a single region.
+    pub fn new_simple(region: SelRegion) -> Selection {
+        Selection {
+            regions: vec![region]
+        }
+    }
+
     /// Clear the selection.
     pub fn clear(&mut self) {
         self.regions.clear();
@@ -359,16 +366,14 @@ mod tests {
 
     #[test]
     fn simple_region() {
-        let mut s = Selection::new();
-        s.add_region(r(3, 5));
+        let s = Selection::new_simple(r(3, 5));
         assert!(!s.is_empty());
         assert_eq!(s.deref(), &[r(3, 5)]);
     }
 
     #[test]
     fn delete_range() {
-        let mut s = Selection::new();
-        s.add_region(r(3, 5));
+        let mut s = Selection::new_simple(r(3, 5));
         s.delete_range(1, 2, true);
         assert_eq!(s.deref(), &[r(3, 5)]);
         s.delete_range(1, 3, false);
@@ -376,15 +381,13 @@ mod tests {
         s.delete_range(1, 3, true);
         assert_eq!(s.deref(), &[]);
 
-        let mut s = Selection::new();
-        s.add_region(r(3, 5));
+        let mut s = Selection::new_simple(r(3, 5));
         s.delete_range(5, 6, false);
         assert_eq!(s.deref(), &[r(3, 5)]);
         s.delete_range(5, 6, true);
         assert_eq!(s.deref(), &[]);
 
-        let mut s = Selection::new();
-        s.add_region(r(3, 5));
+        let mut s = Selection::new_simple(r(3, 5));
         s.delete_range(2, 4, false);
         assert_eq!(s.deref(), &[]);
         assert_eq!(s.deref(), &[]);
@@ -398,8 +401,7 @@ mod tests {
 
     #[test]
     fn simple_regions_in_range() {
-        let mut s = Selection::new();
-        s.add_region(r(3, 5));
+        let s = Selection::new_simple(r(3, 5));
         assert_eq!(s.regions_in_range(0, 1), &[]);
         assert_eq!(s.regions_in_range(0, 2), &[]);
         assert_eq!(s.regions_in_range(0, 3), &[r(3, 5)]);
@@ -410,8 +412,7 @@ mod tests {
 
     #[test]
     fn caret_regions_in_range() {
-        let mut s = Selection::new();
-        s.add_region(r(4, 4));
+        let s = Selection::new_simple(r(4, 4));
         assert_eq!(s.regions_in_range(0, 1), &[]);
         assert_eq!(s.regions_in_range(0, 2), &[]);
         assert_eq!(s.regions_in_range(0, 3), &[]);

--- a/rust/core-lib/src/selection.rs
+++ b/rust/core-lib/src/selection.rs
@@ -348,6 +348,12 @@ impl SelRegion {
     }
 }
 
+impl From<SelRegion> for Selection {
+    fn from(region: SelRegion) -> Self {
+        Self::new_simple(region)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{Selection, SelRegion};
@@ -367,6 +373,13 @@ mod tests {
     #[test]
     fn simple_region() {
         let s = Selection::new_simple(r(3, 5));
+        assert!(!s.is_empty());
+        assert_eq!(s.deref(), &[r(3, 5)]);
+    }
+
+    #[test]
+    fn from_selregion() {
+        let s: Selection = r(3, 5).into();
         assert!(!s.is_empty());
         assert_eq!(s.deref(), &[r(3, 5)]);
     }

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -90,7 +90,7 @@ impl View {
     pub fn new(view_id: ViewIdentifier) -> View {
         View {
             view_id: view_id.to_owned(),
-            selection: Selection::new_simple(SelRegion::caret(0)),
+            selection: SelRegion::caret(0).into(),
             drag_state: None,
             first_line: 0,
             height: 10,
@@ -222,7 +222,7 @@ impl View {
     ///
     /// Note: unlike movement based selection, this does not scroll.
     pub fn select_all(&mut self, text: &Rope) {
-        let selection = Selection::new_simple(SelRegion::new(0, text.len()));
+        let selection = SelRegion::new(0, text.len()).into();
         self.set_selection_raw(text, selection);
     }
 
@@ -852,8 +852,7 @@ impl View {
         }
 
         if let Some(occurrence) = next_occurrence {
-            let selection = Selection::new_simple(occurrence);
-            self.set_selection(text, selection)
+            self.set_selection(text, occurrence.into())
         } else {
             None
         }

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -89,12 +89,7 @@ struct DragState {
 impl View {
     pub fn new(view_id: ViewIdentifier) -> View {
         let mut selection = Selection::new();
-        selection.add_region(SelRegion {
-            start: 0,
-            end: 0,
-            horiz: None,
-            affinity: Affinity::default(),
-        });
+        selection.add_region(SelRegion::caret(0));
         View {
             view_id: view_id.to_owned(),
             selection: selection,
@@ -150,12 +145,7 @@ impl View {
             min: offset,
             max: offset,
         });
-        let region = SelRegion {
-            start: offset,
-            end: offset,
-            horiz: None,
-            affinity: Affinity::default(),
-        };
+        let region = SelRegion::caret(offset);
         selection.add_region(region);
         self.set_selection_raw(text, selection);
     }
@@ -235,12 +225,7 @@ impl View {
     /// Note: unlike movement based selection, this does not scroll.
     pub fn select_all(&mut self, text: &Rope) {
         let mut selection = Selection::new();
-        selection.add_region(SelRegion {
-            start: 0,
-            end: text.len(),
-            horiz: None,
-            affinity: Default::default(),
-        });
+        selection.add_region(SelRegion::new(0, text.len()));
         self.set_selection_raw(text, selection);
     }
 
@@ -251,12 +236,7 @@ impl View {
             word_cursor.select_word()
         };
 
-        let region = SelRegion {
-            start: start,
-            end: end,
-            horiz: None,
-            affinity: Affinity::default(),
-        };
+        let region = SelRegion::new(start, end);
 
         let mut selection = match multi_select {
             true => self.selection.clone(),
@@ -273,12 +253,7 @@ impl View {
     pub fn select_line(&mut self, text: &Rope, offset: usize, line: usize, multi_select: bool) {
         let start = self.line_col_to_offset(text, line, 0);
         let end = self.line_col_to_offset(text, line + 1, 0);
-        let region = SelRegion {
-            start: start,
-            end: end,
-            horiz: None,
-            affinity: Affinity::default(),
-        };
+        let region = SelRegion::new(start, end);
 
         let mut selection = match multi_select {
             true => self.selection.clone(),
@@ -309,7 +284,11 @@ impl View {
                 (drag_state.min, max(offset, drag_state.max))
             };
             let horiz = None;
-            sel.add_region(SelRegion { start, end, horiz, affinity });
+            sel.add_region(
+                SelRegion::new(start, end)
+                    .with_horiz(horiz)
+                    .with_affinity(affinity)
+            );
             sel
         });
         new_sel.and_then(|new_sel| self.set_selection(text, new_sel))
@@ -747,12 +726,7 @@ impl View {
                     Some(start) => {
                         let end = start + len;
 
-                        let region = SelRegion {
-                            start: start,
-                            end: end,
-                            horiz: None,
-                            affinity: Affinity::default(),
-                        };
+                        let region = SelRegion::new(start, end);
                         let prev_len = occurrences.len();
                         let (_, e) = occurrences.add_range_distinct(region);
                         // in case of ambiguous search results (e.g. search "aba" in "ababa"),

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -163,7 +163,8 @@ impl View {
 
     /// Set the selection to a new value. Return value is the offset of a
     /// point that should be scrolled into view.
-    pub fn set_selection(&mut self, text: &Rope, sel: Selection) -> Option<usize> {
+    pub fn set_selection<S: Into<Selection>>(&mut self, text: &Rope, sel: S) -> Option<usize> {
+        let sel = sel.into();
         self.set_selection_raw(text, sel);
         // We somewhat arbitrarily choose the last region for setting the old-style
         // selection state, and for scrolling it into view if needed. This choice can
@@ -852,7 +853,7 @@ impl View {
         }
 
         if let Some(occurrence) = next_occurrence {
-            self.set_selection(text, occurrence.into())
+            self.set_selection(text, occurrence)
         } else {
             None
         }

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -226,6 +226,19 @@ impl View {
         self.set_selection_raw(text, selection);
     }
 
+    /// Selects the given region and supports multi selection.
+    fn select_region(&mut self, text: &Rope, offset: usize, region: SelRegion, multi_select: bool) {
+        let mut selection = match multi_select {
+            true => self.selection.clone(),
+            false => Selection::new(),
+        };
+
+        selection.add_region(region);
+        self.set_selection(text, selection);
+
+        self.start_drag(offset, region.start, region.end);
+    }
+
     /// Selects an entire word and supports multi selection.
     pub fn select_word(&mut self, text: &Rope, offset: usize, multi_select: bool) {
         let (start, end) = {
@@ -233,34 +246,15 @@ impl View {
             word_cursor.select_word()
         };
 
-        let region = SelRegion::new(start, end);
-
-        let mut selection = match multi_select {
-            true => self.selection.clone(),
-            false => Selection::new(),
-        };
-
-        selection.add_region(region);
-        self.set_selection(text, selection);
-
-        self.start_drag(offset, start, end);
+        self.select_region(text, offset, SelRegion::new(start, end), multi_select);
     }
 
     /// Selects an entire line and supports multi selection.
     pub fn select_line(&mut self, text: &Rope, offset: usize, line: usize, multi_select: bool) {
         let start = self.line_col_to_offset(text, line, 0);
         let end = self.line_col_to_offset(text, line + 1, 0);
-        let region = SelRegion::new(start, end);
 
-        let mut selection = match multi_select {
-            true => self.selection.clone(),
-            false => Selection::new(),
-        };
-
-        selection.add_region(region);
-        self.set_selection(text, selection);
-
-        self.start_drag(offset, start, end);
+        self.select_region(text, offset, SelRegion::new(start, end), multi_select);
     }
 
     /// Starts a drag operation.

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -88,11 +88,9 @@ struct DragState {
 
 impl View {
     pub fn new(view_id: ViewIdentifier) -> View {
-        let mut selection = Selection::new();
-        selection.add_region(SelRegion::caret(0));
         View {
             view_id: view_id.to_owned(),
-            selection: selection,
+            selection: Selection::new_simple(SelRegion::caret(0)),
             drag_state: None,
             first_line: 0,
             height: 10,
@@ -224,8 +222,7 @@ impl View {
     ///
     /// Note: unlike movement based selection, this does not scroll.
     pub fn select_all(&mut self, text: &Rope) {
-        let mut selection = Selection::new();
-        selection.add_region(SelRegion::new(0, text.len()));
+        let selection = Selection::new_simple(SelRegion::new(0, text.len()));
         self.set_selection_raw(text, selection);
     }
 
@@ -861,8 +858,7 @@ impl View {
         }
 
         if let Some(occurrence) = next_occurrence {
-            let mut selection = Selection::new();
-            selection.add_region(occurrence);
+            let selection = Selection::new_simple(occurrence);
             self.set_selection(text, selection)
         } else {
             None


### PR DESCRIPTION
Resolves #589.

First of all, `Copy` is derived for `SelRegion` and thus everything that accepts a `SelRegion` by reference is changed to accept it by value.

Two constructors are added to `SelRegion`: `new(start, end)` and `caret(position)` for creating non-caret and caret regions respectively. They initialize `horiz` and `affinity` to their default values. This covers how regions are created in most cases.

Two builder-like methods are added: `SelRegion::with_horiz(self, horiz)` and `SelRegion::with_affinity(self, affinity)`. Together with the constructors, they can be used as follows:
```rust
let region = SelRegion::new(start, end).with_horiz(horiz).with_affinity(affinity);
```

A new constructor is added to `Selection`: `new_simple(region)`, which makes a `Selection` consisting of a single region. Also `impl From<SelRegion> for Selection` is added for the same purpose to allow for shorter code.

Various code was changed to make use of these additions where it made sense. In particular, all uses of `let _ = SelRegion { ... };` were changed to use the constructors.

Finally, the common part of `View::select_word()` and `View::select_line()` was extracted into `View::select_region()`.

Please comment if any of these changes are undesired or need, well, changes so I can adjust or remove them accordingly.