### PR TITLE
Fix panic on backspace at start of buffer

### DIFF
--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -566,12 +566,12 @@ impl Editor {
                 let use_tab_stops = self.config.items.use_tab_stops;
                 let tab_size = self.config.items.tab_size;
                 let tab_size = if c % tab_size == 0 { tab_size } else { c % tab_size };
-                let preceded_by_spaces = self.text.len() > 0 &&
+                let preceded_by_spaces = region.start > 0 &&
                     (region.start.saturating_sub(tab_size)..region.start)
                     .all(|i| self.text.byte_at(i) == b' ');
-               if preceded_by_spaces && use_spaces && use_tab_stops {
-                   region.start - tab_size
-               } else {
+                if preceded_by_spaces && use_spaces && use_tab_stops {
+                    region.start - tab_size
+                } else {
                    // TODO: implement complex emoji logic
                     self.text.prev_codepoint_offset(region.end)
                         .unwrap_or(region.end)


### PR DESCRIPTION
It looks like there was a guard for this case, but it was overly
restrictive, only effective for empty buffers.