### PR TITLE
refactor(rope): use memrchr for reverse byte lookup

### DIFF
--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -238,7 +238,7 @@ impl Metric<RopeInfo> for LinesMetric {
     }
 
     fn prev(s: &String, offset: usize) -> Option<usize> {
-        memrchr(b'\n', s.as_bytes()[..offset])
+        memrchr(b'\n', &s.as_bytes()[..offset])
             .map(|pos| pos + 1)
     }
 
@@ -267,7 +267,7 @@ fn find_leaf_split_for_merge(s: &str) -> usize {
 // Try to split at newline boundary (leaning left), if not, then split at codepoint
 fn find_leaf_split(s: &str, minsplit: usize) -> usize {
     let mut splitpoint = min(MAX_LEAF, s.len() - MIN_LEAF);
-    match memrchr(b'\n', s.as_bytes()[minsplit - 1..splitpoint]) {
+    match memrchr(b'\n', &s.as_bytes()[minsplit - 1..splitpoint]) {
         Some(pos) => minsplit + pos,
         None => {
             while !s.is_char_boundary(splitpoint) {

--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -28,7 +28,7 @@ use delta::{Delta, DeltaElement};
 use interval::Interval;
 
 use bytecount;
-use memchr::memchr;
+use memchr::{memrchr, memchr};
 use serde::ser::{Serialize, Serializer, SerializeStruct, SerializeTupleVariant};
 use serde::de::{Deserialize, Deserializer};
 
@@ -238,7 +238,7 @@ impl Metric<RopeInfo> for LinesMetric {
     }
 
     fn prev(s: &String, offset: usize) -> Option<usize> {
-        s.as_bytes()[..offset].iter().rposition(|&c| c == b'\n')
+        memrchr(b'\n', s.as_bytes()[..offset])
             .map(|pos| pos + 1)
     }
 
@@ -267,7 +267,7 @@ fn find_leaf_split_for_merge(s: &str) -> usize {
 // Try to split at newline boundary (leaning left), if not, then split at codepoint
 fn find_leaf_split(s: &str, minsplit: usize) -> usize {
     let mut splitpoint = min(MAX_LEAF, s.len() - MIN_LEAF);
-    match s.as_bytes()[minsplit - 1..splitpoint].iter().rposition(|&c| c == b'\n') {
+    match memrchr(b'\n', s.as_bytes()[minsplit - 1..splitpoint]) {
         Some(pos) => minsplit + pos,
         None => {
             while !s.is_char_boundary(splitpoint) {


### PR DESCRIPTION
The crate [memchr](https://docs.rs/memchr/2.0.1/memchr/) offers byte lookup in both directions. Until now only `memchr` was used, which is the lookup in positive direction. I replaced all `as_bytes().iter().rposition` calls with memrchr.