### PR TITLE
Some extra documentation in rope.rs

### DIFF
--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -147,12 +147,12 @@ impl NodeInfo for RopeInfo {
 #[derive(Clone, Copy)]
 pub struct BaseMetric(());
 
-/// Measured unit is utf8 code unit
-/// Base unit is utf8 code unit
+/// Measured unit is utf8 code unit.
+/// Base unit is utf8 code unit.
 /// Boundary is atomic and determined by codepoint boundary.
 /// Atomicity is implicit, putting the offset
 /// between two utf8 code units that form a code point is considered invalid.
-/// For example, take a string that starts with a 0x80 byte.
+/// For example, take a string that starts with a 0xC2 byte.
 /// Then offset=1 is invalid.
 impl Metric<RopeInfo> for BaseMetric {
     fn measure(_: &RopeInfo, len: usize) -> usize {
@@ -216,9 +216,9 @@ pub fn len_utf8_from_first_byte(b: u8) -> usize {
 #[derive(Clone, Copy)]
 pub struct LinesMetric(usize);  // number of lines
 
-/// Measured unit is newline amount
-/// Base unit is utf8 code unit(=byte) amount
-/// Boundary is trailing and determined by a newline char
+/// Measured unit is newline amount.
+/// Base unit is utf8 code unit.
+/// Boundary is trailing and determined by a newline char.
 impl Metric<RopeInfo> for LinesMetric {
     fn measure(info: &RopeInfo, _: usize) -> usize {
         info.lines

--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -149,7 +149,11 @@ pub struct BaseMetric(());
 
 /// Measured unit is utf8 code unit
 /// Base unit is utf8 code unit
-/// Boundary is are codepoint boundaries
+/// Boundary is atomic and determined by codepoint boundary.
+/// Atomicity is implicit, putting the offset
+/// between two utf8 code units that form a code point is considered invalid.
+/// For example, take a string that starts with a 0x80 byte.
+/// Then offset=1 is invalid.
 impl Metric<RopeInfo> for BaseMetric {
     fn measure(_: &RopeInfo, len: usize) -> usize {
         len

--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -216,7 +216,6 @@ pub fn len_utf8_from_first_byte(b: u8) -> usize {
 #[derive(Clone, Copy)]
 pub struct LinesMetric(usize);  // number of lines
 
-
 /// Measured unit is newline amount
 /// Base unit is utf8 code unit(=byte) amount
 /// Boundary is trailing and determined by a newline char

--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -147,6 +147,9 @@ impl NodeInfo for RopeInfo {
 #[derive(Clone, Copy)]
 pub struct BaseMetric(());
 
+/// Measured unit is utf8 code unit
+/// Base unit is utf8 code unit
+/// Boundary is are codepoint boundaries
 impl Metric<RopeInfo> for BaseMetric {
     fn measure(_: &RopeInfo, len: usize) -> usize {
         len
@@ -196,6 +199,7 @@ impl Metric<RopeInfo> for BaseMetric {
 
 /// Given the inital byte of a UTF-8 codepoint, returns the number of
 /// bytes required to represent the codepoint.
+/// RFC reference : https://tools.ietf.org/html/rfc3629#section-4
 pub fn len_utf8_from_first_byte(b: u8) -> usize {
     match b {
         b if b < 0x80 => 1,
@@ -208,6 +212,10 @@ pub fn len_utf8_from_first_byte(b: u8) -> usize {
 #[derive(Clone, Copy)]
 pub struct LinesMetric(usize);  // number of lines
 
+
+/// Measured unit is newline amount
+/// Base unit is utf8 code unit(=byte) amount
+/// Boundary is trailing and determined by a newline char
 impl Metric<RopeInfo> for LinesMetric {
     fn measure(info: &RopeInfo, _: usize) -> usize {
         info.lines


### PR DESCRIPTION
Put some more documentation around the two metrics(Line+Base) that are defined in rope.rs.
For the BaseMetric I had some difficulties explaining that it was atomic and why. My explanation felt a bit like [hand-waving](https://en.wikipedia.org/wiki/Hand-waving). Any comments would be appreciated.

Added ref to utf8 RFC for people to find out where magic bytes like 0x80 come from.