### PR TITLE
Fix selection not being set for single click

### DIFF
--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -902,6 +902,7 @@ impl Editor {
             self.view.select_line(&self.text, offset, line as usize, false);
             return;
         }
+        self.view.set_selection(&self.text, SelRegion::caret(offset));
         self.view.start_drag(offset, offset, offset);
     }
 


### PR DESCRIPTION
I introduced a bug in #597 where we were no longer correctly setting the cursor on click events.