### PR TITLE
Remove do_click and migrate to do_gesture

### DIFF
--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -177,11 +177,21 @@ column, and flag as in `click`.
 
 `gesture {"line": 42, "col": 31, "ty": "toggle_sel"}`
 
-Note: both `click` and `drag` functionality will be migrated to
-additional `ty` options for `gesture`. For now, "toggle_sel" is the
-only supported option, and has the semantics of toggling one cursor
-in the selection (the usual mapping of Command-click in macOS
-front-ends).
+**Note:** both `click` and `drag` functionality will be migrated to
+additional `ty` options for `gesture`.
+
+Currently, the following gestures are supported:
+
+```
+toggle_sel
+point_select
+range_select
+line_select
+word_select
+multi_line_select
+multi_word_select
+```
+
 
 The following edit methods take no parameters, and have similar
 meanings as NSView actions. The pure movement and selection

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -881,7 +881,7 @@ impl Editor {
     fn do_gesture(&mut self, line: u64, col: u64, ty: GestureType) {
         let offset = self.view.line_col_to_offset(&self.text, line as usize, col as usize);
         match ty {
-            GestureType::Click => {
+            GestureType::PointSelect => {
                 self.view.set_selection(&self.text, SelRegion::caret(offset));
                 self.view.start_drag(offset, offset, offset);
             },
@@ -1113,6 +1113,20 @@ impl Editor {
             RequestLines(LineRange { first, last }) => self.do_request_lines(first, last),
             Yank => self.yank(),
             Transpose => self.do_transpose(),
+            Click(MouseAction {line, column, flags, click_count} ) => {
+                // Deprecated (kept for client compatibility): should be removed in favor of do_gesture
+                println!("Usage of click is deprecated and should be replaced by gestures");
+
+                if (flags & FLAG_SELECT) != 0 {
+                    self.do_gesture(line, column, GestureType::RangeSelect)
+                } else if click_count == Some(2) {
+                    self.do_gesture(line, column, GestureType::WordSelect)
+                } else if click_count == Some(3) {
+                    self.do_gesture(line, column, GestureType::LineSelect)
+                } else {
+                    self.do_gesture(line, column, GestureType::PointSelect)
+                }
+            }
             Drag (MouseAction {line, column, flags, ..}) => {
                 self.do_drag(line, column, flags);
             }

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -873,7 +873,7 @@ impl Editor {
     fn do_request_lines(&mut self, first: i64, last: i64) {
         self.view.request_lines(&self.text, &self.doc_ctx, self.styles.get_merged(), first as usize, last as usize);
     }
-    
+
     fn do_drag(&mut self, line: u64, col: u64, _flags: u64) {
         self.view.do_drag(&self.text, line, col, Affinity::default());
     }
@@ -1115,7 +1115,7 @@ impl Editor {
             Transpose => self.do_transpose(),
             Click(MouseAction {line, column, flags, click_count} ) => {
                 // Deprecated (kept for client compatibility): should be removed in favor of do_gesture
-                println!("Usage of click is deprecated and should be replaced by gestures");
+                eprintln!("Usage of click is deprecated and should be replaced by gestures");
 
                 if (flags & FLAG_SELECT) != 0 {
                     self.do_gesture(line, column, GestureType::RangeSelect)

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -288,7 +288,7 @@ pub struct EditCommand<T> {
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum GestureType {
-    Click,
+    PointSelect,
     ToggleSel,
     RangeSelect,
     LineSelect,
@@ -376,6 +376,7 @@ pub enum EditNotification {
     RequestLines(LineRange),
     Yank,
     Transpose,
+    Click(MouseAction),
     Drag(MouseAction),
     Gesture { line: u64, col: u64, ty: GestureType},
     Undo,

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -288,7 +288,11 @@ pub struct EditCommand<T> {
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum GestureType {
+    Click,
     ToggleSel,
+    RangeSelect,
+    LineSelect,
+    WordSelect,
     MultiLineSelect,
     MultiWordSelect,
 }
@@ -372,7 +376,6 @@ pub enum EditNotification {
     RequestLines(LineRange),
     Yank,
     Transpose,
-    Click(MouseAction),
     Drag(MouseAction),
     Gesture { line: u64, col: u64, ty: GestureType},
     Undo,

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -220,6 +220,26 @@ impl View {
         self.set_selection_raw(text, selection);
     }
 
+    /// Selects a specific range (eg. when the user performs SHIFT + click).
+    pub fn select_range(&mut self, text: &Rope, offset: usize) {
+      if !self.is_point_in_selection(offset) {
+        let sel = {
+          let (last, rest) = self.sel_regions().split_last().unwrap();
+          let mut sel = Selection::new();
+          for &region in rest {
+            sel.add_region(region);
+          }
+          // TODO: small nit, merged region should be backward if end < start.
+          // This could be done by explicitly overriding, or by tweaking the
+          // merge logic.
+          sel.add_region(SelRegion::new(last.start, offset));
+          sel
+        };
+        self.set_selection(text, sel);
+        self.start_drag(offset, offset, offset);
+      }
+    }
+
     /// Selects the given region and supports multi selection.
     fn select_region(&mut self, text: &Rope, offset: usize, region: SelRegion, multi_select: bool) {
         let mut selection = match multi_select {

--- a/rust/core-lib/tests/rpc.rs
+++ b/rust/core-lib/tests/rpc.rs
@@ -265,9 +265,12 @@ const TEXT_EDIT_RPCS: &str = r#"{"method":"edit","params":{"view_id":"view-id-1"
 const OTHER_EDIT_RPCS: &str = r#"{"method":"edit","params":{"view_id":"view-id-1","method":"scroll","params":[0,1]}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"goto_line","params":{"line":1}}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"request_lines","params":[0,1]}}
-{"method":"edit","params":{"view_id":"view-id-1","method":"click","params":[6,0,0,1]}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"drag","params":[17,15,0]}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"gesture","params":{"line": 1, "col": 2, "ty": "toggle_sel"}}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"gesture","params":{"line": 1, "col": 2, "ty": "click"}}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"gesture","params":{"line": 1, "col": 2, "ty": "range_select"}}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"gesture","params":{"line": 1, "col": 2, "ty": "line_select"}}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"gesture","params":{"line": 1, "col": 2, "ty": "word_select"}}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"gesture","params":{"line": 1, "col": 2, "ty": "multi_line_select"}}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"gesture","params":{"line": 1, "col": 2, "ty": "multi_word_select"}}}
 {"id":4,"method":"edit","params":{"view_id":"view-id-1","method":"find","params":{"case_sensitive":false,"chars":"m"}}}

--- a/rust/core-lib/tests/rpc.rs
+++ b/rust/core-lib/tests/rpc.rs
@@ -267,7 +267,7 @@ const OTHER_EDIT_RPCS: &str = r#"{"method":"edit","params":{"view_id":"view-id-1
 {"method":"edit","params":{"view_id":"view-id-1","method":"request_lines","params":[0,1]}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"drag","params":[17,15,0]}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"gesture","params":{"line": 1, "col": 2, "ty": "toggle_sel"}}}
-{"method":"edit","params":{"view_id":"view-id-1","method":"gesture","params":{"line": 1, "col": 2, "ty": "click"}}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"gesture","params":{"line": 1, "col": 2, "ty": "point_select"}}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"gesture","params":{"line": 1, "col": 2, "ty": "range_select"}}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"gesture","params":{"line": 1, "col": 2, "ty": "line_select"}}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"gesture","params":{"line": 1, "col": 2, "ty": "word_select"}}}


### PR DESCRIPTION
This addresses https://github.com/google/xi-editor/issues/591. I moved all the click gestures to `do_gesture` and removed `do_click`. I am not entirely sure if the way I did it is the best one.
This also fixes the issue in https://github.com/google/xi-editor/pull/604/files 