### PR TITLE
remove page_down and page_up from docs

### DIFF
--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -211,10 +211,8 @@ move_left_and_modify_selection
 move_right
 move_right_and_modify_selection
 scroll_page_up
-page_up
 page_up_and_modify_selection
 scroll_page_down
-page_down
 page_down_and_modify_selection
 ```
 


### PR DESCRIPTION
I'm not sure if it was intentional, but the `page_down` and `page_up` edit commands have not worked for a while.  Now, serde auto-converts the variants to snake_case strings, and there is only `scroll_page_up` and `scroll_page_down`.