### PR TITLE
Small serde cleanup

### DIFF
--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -475,8 +475,7 @@ impl Serialize for MouseAction
         struct Helper(u64, u64, u64, Option<u64>);
 
         let as_tup = Helper(self.line, self.column, self.flags, self.click_count);
-        let v = serde_json::to_value(&as_tup).map_err(ser::Error::custom)?;
-        v.serialize(serializer)
+        as_tup.serialize(serializer)
     }
 }
 
@@ -497,8 +496,7 @@ impl Serialize for LineRange
         where S: Serializer
     {
         let as_tup = (self.first, self.last);
-        let v = serde_json::to_value(&as_tup).map_err(ser::Error::custom)?;
-        v.serialize(serializer)
+        as_tup.serialize(serializer)
     }
 }
 

--- a/rust/core-lib/src/styles.rs
+++ b/rust/core-lib/src/styles.rs
@@ -128,7 +128,7 @@ impl Style {
     /// Note: this should only be used when sending the `def_style` RPC.
     pub fn to_json(&self, id: usize) -> Value {
         let mut as_val = serde_json::to_value(self).expect("failed to encode style");
-        as_val["id"] = serde_json::to_value(id).unwrap();
+        as_val["id"] = id.into();
         as_val
     }
 

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -25,7 +25,7 @@ use std::time::SystemTime;
 
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
-use serde_json::value::Value;
+use serde_json::Value;
 #[cfg(feature = "notify")]
 use notify::DebouncedEvent;
 

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -15,7 +15,7 @@
 use std::cmp::{min,max};
 use std::mem;
 
-use serde_json::value::Value;
+use serde_json::Value;
 
 use xi_rope::rope::{Rope, LinesMetric, RopeInfo};
 use xi_rope::delta::{Delta, DeltaRegion};


### PR DESCRIPTION
Minor things I noticed as I was skimming the Serde-related code.

- `as_tup` can be serialized to the serializer directly, does not need to be converted to a Value first.
- Conversion from usize to Value is infallible.
- Value is typically accessed as serde_json::Value.