### PR TITLE
Implement delayed rendering

### DIFF
--- a/rust/core-lib/src/client.rs
+++ b/rust/core-lib/src/client.rs
@@ -14,6 +14,8 @@
 
 //! Requests and notifications from the core to front-ends.
 
+use std::time::Instant;
+
 use serde_json::{self, Value};
 use xi_rpc::{self, RpcPeer};
 
@@ -140,5 +142,9 @@ impl Client {
 
     pub fn schedule_idle(&self, token: usize) {
         self.0.schedule_idle(token)
+    }
+
+    pub fn schedule_timer(&self, timeout: Instant, token: usize) {
+        self.0.schedule_timer(timeout, token);
     }
 }

--- a/rust/core-lib/src/core.rs
+++ b/rust/core-lib/src/core.rs
@@ -151,6 +151,7 @@ impl WeakXiCore {
                                 undo_group: usize,
                                 response: Result<Value, RpcError>) {
         if let Some(core) = self.upgrade() {
+            let _t = xi_trace::trace_block("WeakXiCore::plugin_update", &["core"]);
             core.inner().plugin_update(plugin, view, undo_group, response);
         }
     }

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -261,6 +261,7 @@ impl Editor {
     /// generates a delta from a plugin's response and applies it to the buffer.
     pub fn apply_plugin_edit(&mut self, edit: PluginEdit,
                              undo_group: Option<usize>) {
+        let _t = trace_block("Editor::apply_plugin_edit", &["core"]);
         if let Some(undo_group) = undo_group {
             // non-async edits modify their associated revision
             //TODO: get priority working, so that plugin edits don't
@@ -279,7 +280,7 @@ impl Editor {
     /// buffer, and a bool indicating whether selections should be preserved.
     pub(crate) fn commit_delta(&mut self)
         -> Option<(Delta<RopeInfo>, Rope, bool)> {
-        let _t = trace_block("Editor::update_after_rev", &["core"]);
+        let _t = trace_block("Editor::commit_delta", &["core"]);
 
         if self.engine.get_head_rev_id() == self.last_rev_id {
             return None;

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -71,10 +71,13 @@ pub type PluginId = ::plugins::PluginPid;
 pub type BufferIdentifier = BufferId;
 pub type ViewIdentifier = ViewId;
 
+/// Totally arbitrary; we reserve this space for `ViewId`s
+pub(crate) const RENDER_VIEW_IDLE_MASK: usize = 1 << 25;
+
 const NEW_VIEW_IDLE_TOKEN: usize = 1001;
 
 /// xi_rpc idle Token for watcher related idle scheduling.
-pub const WATCH_IDLE_TOKEN: usize = 1002;
+pub(crate) const WATCH_IDLE_TOKEN: usize = 1002;
 
 #[cfg(feature = "notify")]
 const CONFIG_EVENT_TOKEN: WatchToken = WatchToken(1);
@@ -428,7 +431,7 @@ impl CoreState {
                 ed.theme_changed(&self.style_map.borrow());
                 view.set_dirty(ed.get_buffer());
             });
-            edit_ctx.render();
+            edit_ctx.render_if_needed();
         });
     }
 
@@ -468,7 +471,9 @@ impl CoreState {
         match token {
             NEW_VIEW_IDLE_TOKEN => self.finalize_new_views(),
             WATCH_IDLE_TOKEN => self.handle_fs_events(),
-            _ => panic!("unexpected idle token {}", token),
+            other if (other & RENDER_VIEW_IDLE_MASK) != 0 =>
+                self.handle_render_timer(other ^ RENDER_VIEW_IDLE_MASK),
+            other => panic!("unexpected idle token {}", other),
         };
     }
 
@@ -478,6 +483,13 @@ impl CoreState {
             let mut edit_ctx = self.make_context(*id).unwrap();
             edit_ctx.finish_init();
         });
+    }
+
+    fn handle_render_timer(&mut self, token: usize) {
+        let id: ViewId = token.into();
+        if let Some(mut ctx) = self.make_context(id) {
+            ctx._finish_delayed_render();
+        }
     }
 
     #[cfg(feature = "notify")]

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -52,6 +52,10 @@ pub struct View {
     pub view_id: ViewId,
     pub buffer_id: BufferId,
 
+    /// Tracks whether this view has been scheduled to render.
+    /// We attempt to reduce duplicate renders by setting a small timeout
+    /// after an edit is applied, to allow batching with any plugin updates.
+    pending_render: bool,
     /// The selection state for this view. Invariant: non-empty.
     selection: Selection,
 
@@ -119,6 +123,7 @@ impl View {
         View {
             view_id: view_id,
             buffer_id: buffer_id,
+            pending_render: false,
             selection: SelRegion::caret(0).into(),
             scroll_to: Some(0),
             drag_state: None,
@@ -133,6 +138,14 @@ impl View {
             occurrences: None,
             valid_search: IndexSet::new(),
         }
+    }
+
+    pub(crate) fn set_has_pending_render(&mut self, pending: bool) {
+        self.pending_render = pending
+    }
+
+    pub(crate) fn has_pending_render(&self) -> bool {
+        self.pending_render
     }
 
     pub(crate) fn do_edit(&mut self, text: &Rope, cmd: ViewEvent) {

--- a/rust/rpc/src/test_utils.rs
+++ b/rust/rpc/src/test_utils.rs
@@ -15,7 +15,7 @@
 //! Types and helpers used for testing.
 
 use std::sync::mpsc::{channel, Sender, Receiver};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use std::io::{self, Write, Cursor};
 
 use serde_json::{self, Value};
@@ -133,4 +133,5 @@ impl Peer for DummyPeer {
     }
     fn request_is_pending(&self) -> bool { false }
     fn schedule_idle(&self, _token: usize) {  }
+    fn schedule_timer(&self, _time: Instant, _token: usize) {  }
 }


### PR DESCRIPTION
With this patch, edit events are not rendered to the client immediately
if there are any active plugins. Instead a render is scheduled after a
brief delay (currently 2 ms) during which window any changes received
from plugins will be batched into a single render.

Progress on #437. Closes #267.


here's some pictures of traces that maybe kind of explain what's going on? 😕 

![before](https://user-images.githubusercontent.com/3330916/39076132-8afaef12-44c7-11e8-8cd9-9aecd49fedab.png)

<br>

![after](https://user-images.githubusercontent.com/3330916/39076136-8e2283e4-44c7-11e8-8998-631e6df0c68d.png)
