### PR TITLE
Allow new_view into non-existent file (fix #627)

### DIFF
--- a/rust/core-lib/src/file.rs
+++ b/rust/core-lib/src/file.rs
@@ -110,11 +110,11 @@ impl FileManager {
     pub fn open(&mut self, path: &Path, id: BufferId)
         -> Result<Rope, FileError>
     {
-        let (rope, info) = if path.exists() {
-            try_load_file(path)?
-        } else {
-            new_for_path(path)
-        };
+        if !path.exists() {
+            let _ = File::create(path)?;
+        }
+
+        let (rope, info) = try_load_file(path)?;
 
         self.open_files.insert(path.to_owned(), id);
         if self.file_info.insert(id, info).is_none() {
@@ -179,18 +179,6 @@ impl FileManager {
         }
         Ok(())
     }
-}
-
-/// We allow 'opening' paths that don't exist
-fn new_for_path<P: AsRef<Path>>(path: P) -> (Rope, FileInfo) {
-    let info = FileInfo {
-        encoding: CharacterEncoding::Utf8,
-        mod_time: None,
-        path: path.as_ref().to_owned(),
-        has_changed: false,
-    };
-
-    ("".into(), info)
 }
 
 fn try_load_file<P>(path: P) -> Result<(Rope, FileInfo), FileError>

--- a/rust/core-lib/src/watcher.rs
+++ b/rust/core-lib/src/watcher.rs
@@ -142,8 +142,11 @@ impl FileWatcher {
                   filter: Option<Box<PathFilter>>)
     {
         let path = match path.canonicalize() {
-            Ok(ref p) if p.exists() => p.to_owned(),
-            _ => return,
+            Ok(ref p) => p.to_owned(),
+            Err(e) => {
+                eprintln!("error watching {:?}: {:?}", path, e);
+                return
+            }
         };
 
         let mut state = self.state.lock().unwrap();

--- a/rust/syntect-plugin/src/main.rs
+++ b/rust/syntect-plugin/src/main.rs
@@ -212,7 +212,9 @@ impl<'a> Syntect<'a> {
     fn guess_syntax(&'a self, path: Option<&Path>) -> &'a SyntaxDefinition {
         let _t = trace_block("Syntect::guess_syntax", &["syntect"]);
         match path {
-            Some(path) => self.syntax_set.find_syntax_for_file(path).unwrap()
+            Some(path) => self.syntax_set.find_syntax_for_file(path)
+                .ok()
+                .unwrap_or(None)
                 .unwrap_or_else(|| self.syntax_set.find_syntax_plain_text()),
             None => self.syntax_set.find_syntax_plain_text(),
         }


### PR DESCRIPTION
cc @eyelash 

This does have one issue, which is that we cannot monitor non-existent files for changes; with this patch, if the file we're pointed to is written by another process after we open the view, a subsequent write by us will overwrite the file without warning.

We currently trust the client to know what it wants when it asks us to save, so I'm not sure what the best approach is here. 😕 