### PR TITLE
Fix crash when line break iterator is end of string

### DIFF
--- a/rust/core-lib/src/linewrap.rs
+++ b/rust/core-lib/src/linewrap.rs
@@ -38,8 +38,7 @@ impl<'a> LineBreakCursor<'a> {
     fn new(text: &'a Rope, pos: usize) -> LineBreakCursor<'a> {
         let inner = Cursor::new(text, pos);
         let lb_iter = match inner.get_leaf() {
-            Some((s, offset)) if !s.is_empty() =>
-                LineBreakLeafIter::new(s.as_str(), offset),
+            Some((s, offset)) => LineBreakLeafIter::new(s.as_str(), offset),
             _ => LineBreakLeafIter::default()
         };
         LineBreakCursor {
@@ -358,6 +357,7 @@ pub fn rewrap_width(breaks: &mut Breaks, text: &Rope,
         start = cursor.prev::<LinesMetric>().unwrap_or(0);
     }
 
+    eprintln!("text len = {}, start = {}, end = {}", text.len(), start, end);
     let new_breaks = compute_rewrap_width(text, width_cache, /* style_spans, */
                                           client, max_width, breaks,
                                           start, end);

--- a/rust/core-lib/src/linewrap.rs
+++ b/rust/core-lib/src/linewrap.rs
@@ -343,7 +343,8 @@ pub fn rewrap_width(breaks: &mut Breaks, text: &Rope,
     // First, remove any breaks in edited section.
     let mut builder = BreakBuilder::new();
     builder.add_no_break(newsize);
-    breaks.edit(iv, builder.build());
+    let edit_iv = Interval::new_open_closed(iv.start(), iv.end());
+    breaks.edit(edit_iv, builder.build());
     // At this point, breaks is aligned with text.
 
     let mut start = iv.start();
@@ -357,7 +358,6 @@ pub fn rewrap_width(breaks: &mut Breaks, text: &Rope,
         start = cursor.prev::<LinesMetric>().unwrap_or(0);
     }
 
-    eprintln!("text len = {}, start = {}, end = {}", text.len(), start, end);
     let new_breaks = compute_rewrap_width(text, width_cache, /* style_spans, */
                                           client, max_width, breaks,
                                           start, end);

--- a/rust/unicode/src/lib.rs
+++ b/rust/unicode/src/lib.rs
@@ -144,9 +144,13 @@ impl Default for LineBreakLeafIter {
 
 impl LineBreakLeafIter {
     /// Create a new line break iterator suitable for leaves in a rope.
-    /// Precondition: ix references a codepoint in s (implies s is not empty).
+    /// Precondition: ix is at a code point boundary within s.
     pub fn new(s: &str, ix: usize) -> LineBreakLeafIter {
-        let (lb, len) = linebreak_property_str(s, ix);
+        let (lb, len) = if ix == s.len() {
+            (0, 0)
+        } else {
+            linebreak_property_str(s, ix)
+        };
         LineBreakLeafIter {
             ix: ix + len,
             state: lb,


### PR DESCRIPTION
Fixes #625 but is work in progress because the resulting break state
is not correct, even though there's no crash.