### PR TITLE
added #[must_use] to SampleGuard

### DIFF
--- a/rust/trace/src/lib.rs
+++ b/rust/trace/src/lib.rs
@@ -541,6 +541,7 @@ impl Hash for Sample {
     }
 }
 
+#[must_use]
 pub struct SampleGuard<'a> {
     sample: Option<Sample>,
     trace: Option<&'a Trace>,


### PR DESCRIPTION
Pretty small change, I just put the #[must_use] annotation above the SampleGuard struct in rust/trace/src/lib.rs