### PR TITLE
Cleanup core init and ConfigManager

### DIFF
--- a/rust/core-lib/src/core.rs
+++ b/rust/core-lib/src/core.rs
@@ -104,12 +104,12 @@ impl Handler for XiCore {
         // wait for client_started before setting up inner
         if let &ClientStarted { ref config_dir, ref client_extras_dir } = &rpc {
             assert!(self.is_waiting(), "client_started can only be sent once");
-            let state = CoreState::new(ctx.get_peer());
+            let state = CoreState::new(ctx.get_peer(), config_dir.clone(),
+                                      client_extras_dir.clone());
             let state = Arc::new(Mutex::new(state));
             *self = XiCore::Running(state);
             let weak_self = self.weak_self().unwrap();
-            self.inner().finish_setup(weak_self, config_dir.clone(),
-                                      client_extras_dir.clone());
+            self.inner().finish_setup(weak_self);
         }
 
         self.inner().client_notification(rpc);
@@ -185,7 +185,7 @@ pub fn dummy_weak_core() -> WeakXiCore {
     use xi_rpc::test_utils::DummyPeer;
     use xi_rpc::Peer;
     let peer = Box::new(DummyPeer);
-    let state = CoreState::new(&peer.box_clone());
+    let state = CoreState::new(&peer.box_clone(), None, None);
     let core = Arc::new(Mutex::new(state));
     WeakXiCore(Arc::downgrade(&core))
 }

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -433,7 +433,7 @@ mod tests {
         fn new<S: AsRef<str>>(s: S) -> Self {
             let view_id = ViewId(1);
             let buffer_id = BufferId(2);
-            let config_manager = ConfigManager::default();
+            let config_manager = ConfigManager::new(None, None);
             let view = RefCell::new(View::new(view_id, buffer_id));
             let editor = RefCell::new(
                 Editor::with_text(s, config_manager.default_buffer_config()));


### PR DESCRIPTION
A long time ago we had a constraint where we didn't know config dirs
when creating CoreState (then Tabs), and so we had to do that setup
afterwards.

That constraint has gone away, but the code hadn't caught up. This gets
us most of the way there.

In addition, it includes a bit of API simplification in `ConfigManager`.
These changes are in anticipation of some upcoming work that will make
plugins responsible for defining new languages/syntaxes.