### PR TITLE
Send rpc notification to plugins on config_changed

### DIFF
--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -325,6 +325,8 @@ impl<'a> EventContext<'a> {
                     view.set_dirty(&ed.get_buffer());
                 }
                 self.client.config_changed(view.view_id, &changes);
+                self.plugins.iter()
+                    .for_each(|plug| plug.config_changed(view.view_id, &changes));
             }
         }
         self.render()

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -30,6 +30,7 @@ use xi_rpc::{self, RpcPeer, RpcLoop};
 use xi_trace;
 
 use WeakXiCore;
+use config::Table;
 use tabs::ViewId;
 
 use self::rpc::{PluginUpdate, PluginBufferInfo};
@@ -117,7 +118,13 @@ where F: FnOnce(Result<Value, xi_rpc::Error>) + Send + 'static
     }
 
     pub fn collect_trace(&self) -> Result<Value, xi_rpc::Error> {
-        self.peer.send_rpc_request("collect_trace", &json!({}))
+       self.peer.send_rpc_request("collect_trace", &json!({}))
+    }
+
+    pub fn config_changed(&self, view_id: ViewId, changes: &Table) {
+        self.peer.send_rpc_notification("config_changed", 
+                                        &json!({"view_id": view_id, 
+                                                "changes": changes}))
     }
 }
 

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -118,7 +118,7 @@ where F: FnOnce(Result<Value, xi_rpc::Error>) + Send + 'static
     }
 
     pub fn collect_trace(&self) -> Result<Value, xi_rpc::Error> {
-       self.peer.send_rpc_request("collect_trace", &json!({}))
+        self.peer.send_rpc_request("collect_trace", &json!({}))
     }
 
     pub fn config_changed(&self, view_id: ViewId, changes: &Table) {


### PR DESCRIPTION
This was done with help from @cmyr during a session, where we found that plugins weren't getting sent an RPC notification when the config changes. This PR fixes that.