### PR TITLE
 Replace hard coded 'SyntaxDef's with plugin provided LanguageDefinitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ below.
 ### Building the core
 
 Xi targets 'recent stable Rust'. We recommend installing via [rustup](https://www.rustup.rs).
-The current minimum supported version is 1.25, although we expect to require 1.26 shortly.
+The current minimum supported version is 1.26.
 
 To build the xi editor from the root directory of this repo:
 

--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -25,7 +25,7 @@ use serde::de::Deserialize;
 use serde_json::{self, Value};
 use toml;
 
-use syntax::SyntaxDefinition;
+use syntax::{LanguageId, Languages};
 use tabs::{BufferId, ViewId};
 
 /// Namespace for various default settings.
@@ -49,7 +49,7 @@ mod defaults {
     {
         let mut loaded = LOADED.lock().unwrap();
         let domain = domain.into();
-        loaded.entry(domain).or_insert_with(|| { load_for_domain(domain) })
+        loaded.entry(domain.clone()).or_insert_with(|| { load_for_domain(domain) })
             .to_owned()
     }
 
@@ -84,13 +84,13 @@ mod defaults {
 pub type Table = serde_json::Map<String, Value>;
 
 /// A `ConfigDomain` describes a level or category of user settings.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all="snake_case")]
 pub enum ConfigDomain {
     /// The general user preferences
     General,
     /// The overrides for a particular syntax.
-    Syntax(SyntaxDefinition),
+    Language(LanguageId),
     /// The user overrides for a particular buffer
     UserOverride(BufferId),
     /// The system's overrides for a particular buffer. Only used internally.
@@ -100,11 +100,13 @@ pub enum ConfigDomain {
 
 /// The external RPC sends `ViewId`s, which we convert to `BufferId`s
 /// internally.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all="snake_case")]
 pub enum ConfigDomainExternal {
     General,
-    Syntax(SyntaxDefinition),
+    //TODO: remove this old name
+    Syntax(LanguageId),
+    Language(LanguageId),
     UserOverride(ViewId),
 }
 
@@ -140,6 +142,7 @@ pub struct ConfigManager {
     configs: HashMap<ConfigDomain, ConfigPair>,
     /// A map of paths to file based configs.
     sources: HashMap<PathBuf, ConfigDomain>,
+    languages: Languages,
     /// If using file-based config, this is the base config directory
     /// (perhaps `$HOME/.config/xi`, by default).
     config_dir: Option<PathBuf>,
@@ -231,6 +234,7 @@ impl ConfigManager {
         ConfigManager {
             configs: defaults,
             sources: HashMap::new(),
+            languages: Languages::default(),
             config_dir,
             extras_dir,
         }
@@ -244,6 +248,23 @@ impl ConfigManager {
         if exists { config_file } else { None }
     }
 
+    pub fn get_plugin_paths(&self) -> Vec<PathBuf> {
+        let config_dir = self.config_dir.as_ref().map(|p| p.join("plugins"));
+        [self.extras_dir.as_ref(), config_dir.as_ref()].iter()
+            .flat_map(|p| p.map(|p| p.to_owned()))
+            .filter(|p| p.exists())
+            .collect()
+    }
+
+    pub fn set_langauges(&mut self, languages: Languages) {
+        self.languages = languages;
+    }
+
+    pub fn language_for_path(&self, path: &Path) -> Option<LanguageId> {
+        self.languages.language_for_path(path)
+            .map(|lang| lang.name.clone())
+    }
+
     /// Sets the config for the given domain, removing any existing config.
     pub fn set_user_config<P>(&mut self, domain: ConfigDomain,
                               new_config: Table, path: P)
@@ -251,8 +272,8 @@ impl ConfigManager {
         where P: Into<Option<PathBuf>>,
     {
         self.check_table(&new_config)?;
-        self.configs.entry(domain)
-            .or_insert_with(|| { ConfigPair::for_domain(domain) })
+        self.configs.entry(domain.clone())
+            .or_insert_with(|| { ConfigPair::for_domain(domain.clone()) })
             .set_table(new_config);
         path.into().map(|p| self.sources.insert(p, domain));
         Ok(())
@@ -265,10 +286,26 @@ impl ConfigManager {
                           -> Result<(), ConfigError>
     {
         self.check_table(&changes)?;
-        let conf = self.configs.entry(domain)
+        let conf = self.configs.entry(domain.clone())
             .or_insert_with(|| { ConfigPair::for_domain(domain) });
         conf.update_table(changes);
         Ok(())
+    }
+
+    pub fn domain_for_path(&self, path: &Path) -> Option<ConfigDomain> {
+        if path.extension().map(|e| e != "xiconfig").unwrap_or(true) {
+            return None;
+        }
+        match path.file_stem().and_then(|s| s.to_str()) {
+            Some("preferences") => Some(ConfigDomain::General),
+            Some(name) if self.languages.language_for_name(&name).is_some() => {
+                let lang = self.languages.language_for_name(&name)
+                    .map(|lang| lang.name.clone()).unwrap();
+                Some(ConfigDomain::Language(lang))
+            }
+            //TODO: plugin configs
+            _ => None,
+        }
     }
 
     /// If `path` points to a loaded config file, unloads the associated config.
@@ -279,13 +316,11 @@ impl ConfigManager {
         }
     }
 
+    //TODO: remove this whole fn
     /// Checks whether a given file should be loaded, i.e. whether it is a
     /// config file and whether it is in an expected location.
     pub fn should_load_file<P: AsRef<Path>>(&self, path: P) -> bool {
-        let path = path.as_ref();
-
-        path.extension() == Some(OsStr::new("xiconfig")) &&
-            ConfigDomain::try_from_path(path).is_ok()
+        path.as_ref().extension() == Some(OsStr::new("xiconfig"))
     }
 
     fn check_table(&self, table: &Table) -> Result<(), ConfigError> {
@@ -303,16 +338,16 @@ impl ConfigManager {
 
     /// Generates a snapshot of the current configuration for a particular
     /// view.
-    pub fn get_buffer_config<S, I>(&self, syntax: S, id: I) -> BufferConfig
-        where S: Into<Option<SyntaxDefinition>>,
+    pub fn get_buffer_config<S, I>(&self, lang: S, id: I) -> BufferConfig
+        where S: Into<Option<LanguageId>>,
               I: Into<Option<BufferId>>
     {
-        let syntax = syntax.into();
+        let lang = lang.into();
         let id = id.into();
         let mut configs = Vec::new();
 
         configs.push(self.configs.get(&ConfigDomain::General));
-        syntax.map(|s| configs.push(self.configs.get(&s.into())));
+        lang.map(|s| configs.push(self.configs.get(&s.into())));
         id.map(|v| configs.push(self.configs.get(&ConfigDomain::SysOverride(v))));
         id.map(|v| configs.push(self.configs.get(&ConfigDomain::UserOverride(v))));
 
@@ -407,24 +442,24 @@ impl<T: PartialEq> PartialEq for Config<T> {
     }
 }
 
-impl ConfigDomain {
-    /// Given a file path, attempts to parse the file name into a `ConfigDomain`.
-    /// Returns an error if the file name does not correspond to a domain.
-    pub fn try_from_path(path: &Path) -> Result<Self, ConfigError> {
-        let file_stem = path.file_stem().unwrap().to_string_lossy();
-        if file_stem == "preferences" {
-            Ok(ConfigDomain::General)
-        } else if let Some(syntax) = SyntaxDefinition::try_from_name(&file_stem) {
-            Ok(syntax.into())
-        } else {
-            Err(ConfigError::UnknownDomain(file_stem.into_owned()))
-        }
-    }
-}
+//impl ConfigDomain {
+    ///// Given a file path, attempts to parse the file name into a `ConfigDomain`.
+    ///// Returns an error if the file name does not correspond to a domain.
+    //pub fn try_from_path(path: &Path) -> Result<Self, ConfigError> {
+        //let file_stem = path.file_stem().unwrap().to_string_lossy();
+        //if file_stem == "preferences" {
+            //Ok(ConfigDomain::General)
+        //} else if let Some(syntax) = SyntaxDefinition::try_from_name(&file_stem) {
+            //Ok(syntax.into())
+        //} else {
+            //Err(ConfigError::UnknownDomain(file_stem.into_owned()))
+        //}
+    //}
+//}
 
-impl From<SyntaxDefinition> for ConfigDomain {
-    fn from(src: SyntaxDefinition) -> ConfigDomain {
-        ConfigDomain::Syntax(src)
+impl From<LanguageId> for ConfigDomain {
+    fn from(src: LanguageId) -> ConfigDomain {
+        ConfigDomain::Language(src)
     }
 }
 
@@ -480,18 +515,15 @@ pub fn init_config_dir(dir: &Path) -> io::Result<()> {
 
 /// Attempts to load a config from a file. The config's domain is determined
 /// by the file name.
-pub fn try_load_from_file(path: &Path) -> Result<(ConfigDomain, Table), ConfigError> {
-    let domain = ConfigDomain::try_from_path(path)?;
+pub fn try_load_from_file(path: &Path) -> Result<Table, ConfigError> {
     let mut file = fs::File::open(&path)?;
     let mut contents = String::new();
     file.read_to_string(&mut contents)?;
-    let table = table_from_toml_str(&contents)
-        .map_err(|e| ConfigError::Parse(path.to_owned(), e))?;
-
-    Ok((domain, table))
+    table_from_toml_str(&contents)
+        .map_err(|e| ConfigError::Parse(path.to_owned(), e))
 }
 
-fn table_from_toml_str(s: &str) -> Result<Table, toml::de::Error> {
+pub(crate) fn table_from_toml_str(s: &str) -> Result<Table, toml::de::Error> {
     let table = toml::from_str(&s)?;
     let table = from_toml_value(table).as_object()
         .unwrap()
@@ -537,8 +569,10 @@ mod tests {
         let user_config = table_from_toml_str(r#"tab_size = 42"#).unwrap();
         let rust_config = table_from_toml_str(r#"tab_size = 31"#).unwrap();
 
+        let rust_id: LanguageId = "Rust".into();
+
         let mut manager = ConfigManager::new(None, None);
-        manager.set_user_config(ConfigDomain::Syntax(SyntaxDefinition::Rust),
+        manager.set_user_config(ConfigDomain::Language(rust_id.clone()),
                                 rust_config, None).unwrap();
 
         manager.set_user_config(ConfigDomain::General, user_config, None)
@@ -553,31 +587,26 @@ mod tests {
         let config = manager.default_buffer_config();
         assert_eq!(config.source.0.len(), 1);
         assert_eq!(config.items.tab_size, 42);
-        let config = manager.get_buffer_config(SyntaxDefinition::Rust, None);
+        let config = manager.get_buffer_config(rust_id.clone(), None);
         assert_eq!(config.items.tab_size, 31);
-        let config = manager.get_buffer_config(SyntaxDefinition::Rust, buffer_id);
+        let config = manager.get_buffer_config(rust_id.clone(), buffer_id);
         assert_eq!(config.items.tab_size, 67);
 
         // user override trumps everything
         let changes = json!({"tab_size": 85}).as_object().unwrap().to_owned();
         manager.update_user_config(ConfigDomain::UserOverride(buffer_id), changes)
             .unwrap();
-        let config = manager.get_buffer_config(SyntaxDefinition::Rust, buffer_id);
+        let config = manager.get_buffer_config(rust_id.clone(), buffer_id);
         assert_eq!(config.items.tab_size, 85);
     }
 
     #[test]
     fn test_config_domain_serde() {
-        assert!(ConfigDomain::try_from_path(Path::new("hi/python.xiconfig")).is_ok());
-        assert!(ConfigDomain::try_from_path(Path::new("hi/preferences.xiconfig")).is_ok());
-        assert!(ConfigDomain::try_from_path(Path::new("hi/rust.xiconfig")).is_ok());
-        assert!(ConfigDomain::try_from_path(Path::new("hi/unknown.xiconfig")).is_err());
-
         assert_eq!(serde_json::to_string(&ConfigDomain::General).unwrap(), "\"general\"");
         let d = ConfigDomainExternal::UserOverride(ViewId(1));
         assert_eq!(serde_json::to_string(&d).unwrap(), "{\"user_override\":\"view-id-1\"}");
-        let d = ConfigDomain::Syntax(SyntaxDefinition::Swift);
-        assert_eq!(serde_json::to_string(&d).unwrap(), "{\"syntax\":\"swift\"}");
+        let d = ConfigDomain::Language("Swift".into());
+        assert_eq!(serde_json::to_string(&d).unwrap(), "{\"language\":\"Swift\"}");
     }
 
     #[test]
@@ -619,8 +648,8 @@ translate_tabs_to_spaces = true
 
         let changes = json!({"font_face": "Roboto"})
             .as_object().unwrap().to_owned();
-        manager.update_user_config(SyntaxDefinition::Dart.into(), changes).unwrap();
-        let config = manager.get_buffer_config(SyntaxDefinition::Dart, None);
+        manager.update_user_config(LanguageId::from("Dart").into(), changes).unwrap();
+        let config = manager.get_buffer_config(LanguageId::from("Dart"), None);
         assert_eq!(config.items.font_face, "Roboto");
     }
 }

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -34,7 +34,7 @@ use plugins::PluginId;
 use plugins::rpc::{PluginEdit, ScopeSpan, TextUnit, GetDataResponse};
 use selection::{Selection, SelRegion};
 use styles::ThemeStyleMap;
-use syntax::SyntaxDefinition;
+use syntax::LanguageId;
 use view::View;
 
 #[cfg(not(feature = "ledger"))]
@@ -83,7 +83,7 @@ pub struct Editor {
     #[allow(dead_code)]
     last_synced_rev: RevId,
 
-    syntax: SyntaxDefinition,
+    syntax: LanguageId,
     layers: Layers,
     config: BufferConfig,
 }
@@ -105,7 +105,7 @@ impl Editor {
 
         Editor {
             text: buffer,
-            syntax: SyntaxDefinition::default(),
+            syntax: LanguageId::default(),
             engine,
             last_rev_id,
             pristine_rev_id: last_rev_id,
@@ -190,8 +190,8 @@ impl Editor {
         &self.config
     }
 
-    /// Returns this `Editor`'s active `SyntaxDefinition`.
-    pub fn get_syntax(&self) -> &SyntaxDefinition {
+    /// Returns this `Editor`'s active `LanguageId`.
+    pub fn get_syntax(&self) -> &LanguageId {
         &self.syntax
     }
 

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -128,6 +128,7 @@ use apps_ledger_services_public::Ledger_Proxy;
 pub use config::{BufferItems as BufferConfig, Table as ConfigTable};
 pub use core::{XiCore, WeakXiCore};
 pub use plugins::rpc as plugin_rpc;
+pub use plugins::manifest as plugin_manifest;
 pub use plugins::PluginPid;
 pub use syntax::SyntaxDefinition;
 pub use tabs::{BufferId, BufferIdentifier, ViewId, ViewIdentifier};

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -130,7 +130,7 @@ pub use core::{XiCore, WeakXiCore};
 pub use plugins::rpc as plugin_rpc;
 pub use plugins::manifest as plugin_manifest;
 pub use plugins::PluginPid;
-pub use syntax::SyntaxDefinition;
+pub use syntax::{LanguageDefinition, LanguageId};
 pub use tabs::{BufferId, BufferIdentifier, ViewId, ViewIdentifier};
 pub use tabs::test_helpers as test_helpers;
 

--- a/rust/core-lib/src/plugins/catalog.rs
+++ b/rust/core-lib/src/plugins/catalog.rs
@@ -15,7 +15,6 @@
 use std::collections::HashMap;
 use std::fs;
 use std::io::{self, Read};
-use std::mem;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -23,7 +22,7 @@ use toml;
 
 use super::{PluginName, PluginDescription};
 use config::table_from_toml_str;
-use syntax::{LanguageDefinition, Languages};
+use syntax::Languages;
 
 /// A catalog of all available plugins.
 #[derive(Debug, Clone, Default)]
@@ -43,6 +42,7 @@ pub enum PluginLoadError {
 #[allow(dead_code)]
 impl <'a>PluginCatalog {
     pub fn reload_from_paths(&mut self, paths: &[PathBuf]) {
+        eprintln!("loading plugins from {:?}", paths);
         self.items.clear();
         self.locations.clear();
         let all_manifests = find_all_manifests(paths);
@@ -50,6 +50,7 @@ impl <'a>PluginCatalog {
             match load_manifest(manifest_path) {
                 Err(e) => eprintln!("error loading plugin {:?}", e),
                 Ok(manifest) => {
+                    eprintln!("loaded {}", manifest.name);
                     let manifest = Arc::new(manifest);
                     self.items.insert(manifest.name.clone(), manifest.clone());
                     self.locations.insert(manifest_path.clone(), manifest);
@@ -65,90 +66,21 @@ impl <'a>PluginCatalog {
         Languages::new(all_langs.as_slice())
     }
 
-    ///// Loads plugins from the user's search paths
-    //pub fn from_paths(paths: Vec<PathBuf>) -> Self {
-        //let plugins = paths.iter()
-            //.flat_map(|path| {
-                //match load_plugins(path) {
-                    //Ok(plugins) => plugins,
-                    //Err(err) => {
-                        //eprintln!("error loading plugins from {:?}, error:\n{:?}",
-                                   //path, err);
-                        //Vec::new()
-                    //}
-                //}
-            //})
-            //.collect::<Vec<_>>();
-        //PluginCatalog::new(&plugins)
-    //}
-
-    //pub fn new(plugins: &[PluginDescription]) -> Self {
-        //let mut items = HashMap::with_capacity(plugins.len());
-        //for plugin in plugins {
-            //if items.contains_key(&plugin.name) {
-                //eprintln!("Duplicate plugin name.\n 1: {:?}\n 2: {:?}",
-                           //plugin, items.get(&plugin.name));
-                //continue
-            //}
-            //items.insert(plugin.name.to_owned(), plugin.to_owned());
-        //}
-        //PluginCatalog { items }
-    //}
-
     /// Returns an iterator over all plugins in the catalog, in arbitrary order.
-    pub fn iter(&'a self) -> Box<Iterator<Item=&'a PluginDescription> + 'a> {
-       Box::new(self.items.values())
+    pub fn iter(&'a self) -> impl Iterator<Item=Arc<PluginDescription>> + 'a {
+       self.items.values().cloned()
     }
 
     /// Returns an iterator over all plugin names in the catalog,
     /// in arbitrary order.
-    pub fn iter_names(&'a self) -> Box<Iterator<Item=&'a PluginName> + 'a> {
-        Box::new(self.items.keys())
+    pub fn iter_names(&'a self) -> impl Iterator<Item=&'a PluginName> {
+        self.items.keys()
     }
 
     /// Returns a reference to the named plugin if it exists in the catalog.
     pub fn get_named(&self, plugin_name: &str) -> Option<Arc<PluginDescription>> {
         self.items.get(plugin_name).map(Arc::clone)
     }
-
-    /// Returns all PluginDescriptions matching some predicate
-    pub fn filter<F>(&self, predicate: F) -> Vec<&PluginDescription>
-    where F: Fn(&PluginDescription) -> bool {
-        self.iter()
-            .filter(|item| predicate(item))
-            .collect::<Vec<_>>()
-    }
-
-    pub fn get_lang_defs(&self) -> Vec<LanguageDefinition> {
-        self.iter()
-            .flat_map(|p| p.languages.iter().cloned())
-            .collect()
-    }
-}
-
-fn load_plugins(plugin_dir: &Path)
-    -> Result<Vec<PluginDescription>, PluginLoadError> {
-    // if this is just a path to a single plugin, just return that
-    let manif_path = plugin_dir.join("manifest");
-    if manif_path.exists() {
-        let manifest = load_manifest(&manif_path)?;
-        return Ok(vec![manifest]);
-    }
-
-    let mut plugins = Vec::new();
-    for path in plugin_dir.read_dir()? {
-        let path = path?;
-        let path = path.path();
-        if !path.is_dir() { continue }
-        let manif_path = path.join("manifest.toml");
-        if !manif_path.exists() { continue }
-        match load_manifest(&manif_path) {
-            Ok(manif) => plugins.push(manif),
-            Err(err) => eprintln!("Error reading manifest {:?}, error:\n{:?}",
-                                   &manif_path, err),
-        }
-    }
-    Ok(plugins)
 }
 
 fn find_all_manifests(paths: &[PathBuf]) -> Vec<PathBuf> {
@@ -160,12 +92,15 @@ fn find_all_manifests(paths: &[PathBuf]) -> Vec<PathBuf> {
             continue;
         }
 
-        let contained_manifests = path.read_dir()
-            .map(|dir|
+         let result = path.read_dir()
+             .map(|dir|
                  dir.flat_map(|item| item.map(|p| p.path()).ok())
                  .map(|dir| dir.join("manifest.toml"))
                  .filter(|f| f.exists())
                  .for_each(|f| manifest_paths.push(f.to_owned())));
+         if let Err(e) = result {
+             eprintln!("error reading plugin path {:?}, {:?}", path, e);
+         }
     }
     manifest_paths
 }
@@ -185,7 +120,7 @@ fn load_manifest(path: &Path) -> Result<PluginDescription, PluginLoadError> {
 
     for lang in manifest.languages.iter_mut() {
         let lang_config_path = path.parent().unwrap()
-            .join(&lang.name.0)
+            .join(&lang.name.as_ref())
             .with_extension("xiconfig");
         if !lang_config_path.exists() { continue; }
         let lang_defaults = fs::read_to_string(&lang_config_path)?;

--- a/rust/core-lib/src/plugins/catalog.rs
+++ b/rust/core-lib/src/plugins/catalog.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Keeping track of available plugins.
+
 use std::collections::HashMap;
 use std::fs;
 use std::io::{self, Read};
@@ -41,8 +43,9 @@ pub enum PluginLoadError {
 
 #[allow(dead_code)]
 impl <'a>PluginCatalog {
+    /// Loads any plugins discovered in these paths, replacing any existing
+    /// plugins.
     pub fn reload_from_paths(&mut self, paths: &[PathBuf]) {
-        eprintln!("loading plugins from {:?}", paths);
         self.items.clear();
         self.locations.clear();
         let all_manifests = find_all_manifests(paths);
@@ -121,10 +124,11 @@ fn load_manifest(path: &Path) -> Result<PluginDescription, PluginLoadError> {
     for lang in manifest.languages.iter_mut() {
         let lang_config_path = path.parent().unwrap()
             .join(&lang.name.as_ref())
-            .with_extension("xiconfig");
+            .with_extension("toml");
         if !lang_config_path.exists() { continue; }
         let lang_defaults = fs::read_to_string(&lang_config_path)?;
         let lang_defaults = table_from_toml_str(&lang_defaults)?;
+        eprintln!("loaded defaults {:?}", &lang_defaults);
         lang.default_config = Some(lang_defaults);
     }
     Ok(manifest)

--- a/rust/core-lib/src/plugins/manifest.rs
+++ b/rust/core-lib/src/plugins/manifest.rs
@@ -19,12 +19,12 @@ use std::path::PathBuf;
 use serde_json::{self, Value};
 use serde::Serialize;
 
-use syntax::SyntaxDefinition;
+use syntax::{LanguageDefinition, LanguageId};
 
 /// Describes attributes and capabilities of a plugin.
 ///
 /// Note: - these will eventually be loaded from manifest files.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct PluginDescription {
     pub name: String,
@@ -39,24 +39,26 @@ pub struct PluginDescription {
     pub activations: Vec<PluginActivation>,
     #[serde(default)]
     pub commands: Vec<Command>,
+    #[serde(default)]
+    pub languages: Vec<LanguageDefinition>,
 }
 
 /// `PluginActivation`s represent events that trigger running a plugin.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PluginActivation {
     /// Always run this plugin, when available.
     Autorun,
     /// Run this plugin if the provided SyntaxDefinition is active.
     #[allow(dead_code)]
-    OnSyntax(SyntaxDefinition),
+    OnSyntax(LanguageId),
     /// Run this plugin in response to a given command.
     #[allow(dead_code)]
     OnCommand,
 }
 
 /// Describes the scope of events a plugin receives.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PluginScope {
     /// The plugin receives events from multiple buffers.

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -15,7 +15,7 @@
 //! Plugins and related functionality.
 
 pub mod rpc;
-mod manifest;
+pub mod manifest;
 mod catalog;
 
 use std::fmt;

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -23,6 +23,7 @@ use std::io::BufReader;
 use std::path::Path;
 use std::process::{Child, Command as ProcCommand, Stdio};
 use std::thread;
+use std::sync::Arc;
 
 use serde_json::Value;
 
@@ -121,7 +122,7 @@ where F: FnOnce(Result<Value, xi_rpc::Error>) + Send + 'static
     }
 }
 
-pub(crate) fn start_plugin_process(plugin_desc: PluginDescription,
+pub(crate) fn start_plugin_process(plugin_desc: Arc<PluginDescription>,
                                     id: PluginId, core: WeakXiCore) {
     thread::spawn(move || {
         eprintln!("starting plugin {}", &plugin_desc.name);

--- a/rust/core-lib/src/plugins/rpc.rs
+++ b/rust/core-lib/src/plugins/rpc.rs
@@ -23,7 +23,7 @@ use serde_json::{self, Value};
 
 use xi_rope::rope::{RopeDelta, Rope, LinesMetric};
 use super::PluginPid;
-use syntax::SyntaxDefinition;
+use syntax::LanguageId;
 use tabs::{BufferIdentifier, ViewIdentifier};
 use config::Table;
 
@@ -47,7 +47,7 @@ pub struct PluginBufferInfo {
     pub nb_lines: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
-    pub syntax: SyntaxDefinition,
+    pub syntax: LanguageId,
     pub config: Table,
 }
 
@@ -228,7 +228,7 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for PluginCommand<T>
 impl PluginBufferInfo {
     pub fn new(buffer_id: BufferIdentifier, views: &[ViewIdentifier],
                rev: u64, buf_size: usize, nb_lines: usize,
-               path: Option<PathBuf>, syntax: SyntaxDefinition,
+               path: Option<PathBuf>, syntax: LanguageId,
                config: Table) -> Self {
         //TODO: do make any current assertions about paths being valid utf-8? do we want to?
         let path = path.map(|p| p.to_str().unwrap().to_owned());
@@ -323,7 +323,7 @@ mod tests {
         };
         assert_eq!(val.rev, 1);
         assert_eq!(val.path, Some("some_path".to_owned()));
-        assert_eq!(val.syntax, SyntaxDefinition::Toml);
+        assert_eq!(val.syntax, "toml".into());
     }
 
     #[test]

--- a/rust/core-lib/src/syntax.rs
+++ b/rust/core-lib/src/syntax.rs
@@ -68,6 +68,19 @@ impl Languages {
     pub fn language_for_name(&self, name: &str) -> Option<Arc<LanguageDefinition>> {
         self.named.get(name).map(Arc::clone)
     }
+
+    /// Returns a Vec of any `LanguageDefinition`s which exist
+    /// in `self` but not `other`.
+    pub fn difference(&self, other: &Languages) -> Vec<Arc<LanguageDefinition>> {
+        self.named.iter()
+            .filter(|(k, _)| !other.named.contains_key(*k))
+            .map(|(_, v)| v.clone())
+            .collect()
+    }
+
+    pub fn iter<'a>(&'a self) -> impl Iterator<Item=&'a Arc<LanguageDefinition>> {
+        self.named.values()
+    }
 }
 
 impl AsRef<str> for LanguageId {

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -180,7 +180,7 @@ impl CoreState {
         let plugin_paths = self.config_manager.get_plugin_paths();
         self.plugins.reload_from_paths(&plugin_paths);
         let languages = self.plugins.make_languages_map();
-        self.config_manager.set_langauges(languages);
+        self.config_manager.set_languages(languages);
         let theme_names = self.style_map.borrow().get_theme_names();
         self.peer.available_themes(theme_names);
 

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -46,7 +46,6 @@ use plugin_rpc::{PluginNotification, PluginRequest};
 use rpc::{CoreNotification, CoreRequest, EditNotification, EditRequest,
           PluginNotification as CorePluginNotification};
 use styles::ThemeStyleMap;
-use syntax::SyntaxDefinition;
 use view::View;
 use width_cache::WidthCache;
 
@@ -152,7 +151,7 @@ impl CoreState {
             pending_views: Vec::new(),
             peer: Client::new(peer.clone()),
             id_counter: Counter::default(),
-            plugins: PluginCatalog::new(&[]),
+            plugins: PluginCatalog::default(),
             running_plugins: Vec::new(),
         }
     }
@@ -176,6 +175,12 @@ impl CoreState {
             self.load_file_based_config(&path);
         }
 
+        // instead of having to do this here, config should just own
+        // the plugin catalog and reload automatically
+        let plugin_paths = self.config_manager.get_plugin_paths();
+        self.plugins.reload_from_paths(&plugin_paths);
+        let languages = self.plugins.make_languages_map();
+        self.config_manager.set_langauges(languages);
         let theme_names = self.style_map.borrow().get_theme_names();
         self.peer.available_themes(theme_names);
 
@@ -190,9 +195,11 @@ impl CoreState {
     /// Attempt to load a config file.
     fn load_file_based_config(&mut self, path: &Path) {
         let _t = trace_block("CoreState::load_config_file", &["core"]);
-        match config::try_load_from_file(&path) {
-            Ok((d, t)) => self.set_config(d, t, Some(path.to_owned())),
-            Err(e) => self.peer.alert(e.to_string()),
+        if let Some(domain) = self.config_manager.domain_for_path(path) {
+            match config::try_load_from_file(&path) {
+                Ok(table) => self.set_config(domain, table, Some(path.to_owned())),
+                Err(e) => self.peer.alert(e.to_string()),
+            }
         }
     }
 
@@ -362,7 +369,7 @@ impl CoreState {
         -> Result<Editor, RemoteError>
     {
         let rope = self.file_manager.open(path, buffer_id)?;
-        let syntax = SyntaxDefinition::new(path.to_str());
+        let syntax = self.config_manager.language_for_path(path);
         let config = self.config_manager.get_buffer_config(syntax, buffer_id);
         let editor = Editor::with_text(rope, config);
         Ok(editor)
@@ -388,9 +395,10 @@ impl CoreState {
             return;
         }
 
-        // hacky, syntax defs per-se are going away soon
-        let syntax = SyntaxDefinition::new(path.to_str());
+        let syntax = self.config_manager.language_for_path(path);
         let config = self.config_manager.get_buffer_config(syntax, buffer_id);
+        //TODO: rework how config changes are handled if a path changes.
+        //tldr; do the save first, then reload the config.
 
         let mut event_ctx = self.make_context(view_id).unwrap();
         event_ctx.after_save(path, config);
@@ -440,7 +448,8 @@ impl CoreState {
         // the client sends ViewId but we need BufferId so we do a dance
         let domain: ConfigDomain = match domain {
             ConfigDomainExternal::General => ConfigDomain::General,
-            ConfigDomainExternal::Syntax(s) => ConfigDomain::Syntax(s),
+            ConfigDomainExternal::Syntax(id) => ConfigDomain::Language(id),
+            ConfigDomainExternal::Language(id) => ConfigDomain::Language(id),
             ConfigDomainExternal::UserOverride(view_id) => {
                  match self.views.get(&view_id) {
                      Some(v) => ConfigDomain::UserOverride(v.borrow().buffer_id),
@@ -587,10 +596,10 @@ impl CoreState {
     fn handle_config_fs_event(&mut self, event: DebouncedEvent) {
         use self::DebouncedEvent::*;
         match event {
-            Create(ref path) | Write(ref path) => {
-                self.load_file_based_config(path)
-            }
-            Remove(ref path) => self.config_manager.remove_source(path),
+            Create(ref path) | Write(ref path) =>
+                self.load_file_based_config(path),
+            Remove(ref path) =>
+                self.config_manager.remove_source(path),
             Rename(ref old, ref new) => {
                 self.config_manager.remove_source(old);
                 let should_load = self.config_manager.should_load_file(new);

--- a/rust/syntect-plugin/Cargo.lock
+++ b/rust/syntect-plugin/Cargo.lock
@@ -721,6 +721,7 @@ dependencies = [
  "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntect 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "xi-core-lib 0.2.0",
  "xi-plugin-lib 0.1.0",
  "xi-rope 0.2.0",

--- a/rust/syntect-plugin/Cargo.toml
+++ b/rust/syntect-plugin/Cargo.toml
@@ -10,6 +10,9 @@ description = "A syntax highlighting plugin based on syntect."
 serde = "1.0"
 serde_derive = "1.0"
 
+[dev-dependencies]
+toml = "0.4"
+
 [dependencies.syntect]
 version = "2.0"
 default-features = false

--- a/rust/syntect-plugin/Makefile
+++ b/rust/syntect-plugin/Makefile
@@ -4,12 +4,27 @@ XDG_CONFIG_HOME ?= $(HOME)/.config
 XI_CONFIG_DIR ?= $(XDG_CONFIG_HOME)/xi
 XI_PLUGIN_DIR ?= $(XI_CONFIG_DIR)/plugins
 
-target/release/xi-syntect-plugin:
+lang_configs = assets/*.toml
+
+out/syntect: $(lang_configs) out/gen_manifest.toml target/release/xi-syntect-plugin
+	mkdir -p out/syntect/bin
+	cp $(lang_configs) out/syntect
+	install target/release/xi-syntect-plugin out/syntect/bin
+	cp out/gen_manifest.toml out/syntect/manifest.toml
+
+out/gen_manifest.toml: Cargo.toml Cargo.lock
+	cargo run --release --example make_manifest
+
+target/release/xi-syntect-plugin: src/*.rs Cargo.toml Cargo.lock
 	cargo build --release
 
-install: manifest.toml target/release/xi-syntect-plugin
-	install -d $(XI_PLUGIN_DIR)/syntect/bin
-	install manifest.toml $(XI_PLUGIN_DIR)/syntect
-	install target/release/xi-syntect-plugin $(XI_PLUGIN_DIR)/syntect/bin
+install: out/syntect
+	mkdir -p $(XI_PLUGIN_DIR)
+	cp -r out/syntect $(XI_PLUGIN_DIR)/syntect
+
+clean:
+	rm out/gen_manifest.toml
+	rmdir out
+	cargo clean
 
 .PHONY: install

--- a/rust/syntect-plugin/assets/Makefile.toml
+++ b/rust/syntect-plugin/assets/Makefile.toml
@@ -1,0 +1,2 @@
+# make requires tabs
+translate_tabs_to_spaces = false

--- a/rust/syntect-plugin/assets/YAML.toml
+++ b/rust/syntect-plugin/assets/YAML.toml
@@ -1,0 +1,3 @@
+# YAML mandates that tabs aren't used for indentation
+translate_tabs_to_spaces = true
+tab_size = 2

--- a/rust/syntect-plugin/examples/make_manifest.rs
+++ b/rust/syntect-plugin/examples/make_manifest.rs
@@ -1,0 +1,61 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A simple tool that generates the syntect plugin's manifest.
+
+extern crate syntect;
+extern crate toml;
+extern crate  xi_core_lib as xi_core;
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::fs::File;
+
+use xi_core::plugin_manifest::*;
+use xi_core::LanguageDefinition;
+use syntect::parsing::{SyntaxSet, SyntaxDefinition};
+
+
+fn main() {
+    let syntax_set = SyntaxSet::load_defaults_newlines();
+    let lang_defs = syntax_set.syntaxes().iter()
+        .filter(|syntax| !syntax.file_extensions.is_empty())
+        .map(lang_from_syn)
+        .collect::<Vec<_>>();
+
+    let mani = PluginDescription {
+        name: "syntect".into(),
+        version: "0.1".into(),
+        scope: PluginScope::Global,
+        exec_path: PathBuf::from("./bin/xi-syntect-plugin"),
+        activations: vec![PluginActivation::Autorun],
+        commands: vec![],
+        languages: lang_defs,
+    };
+
+	let toml_str = toml::to_string(&mani).unwrap();
+	let mut f = File::create("xi_manifest.toml").unwrap();
+    f.write_all(toml_str.as_ref()).unwrap();
+}
+
+fn lang_from_syn<'a>(src: &'a SyntaxDefinition) -> LanguageDefinition {
+    LanguageDefinition {
+        name: src.name.clone(),
+        extensions: src.file_extensions.clone(),
+        first_line_match: src.first_line_match.clone(),
+        scope: src.scope.to_string(),
+        default_config: None,
+    }
+}
+

--- a/rust/syntect-plugin/manifest.toml
+++ b/rust/syntect-plugin/manifest.toml
@@ -1,5 +1,5 @@
 name = "syntect"
 version = "0.1"
+scope = "global"
 exec_path = "./bin/xi-syntect-plugin"
 activations = ["autorun"]
-scope = "global"


### PR DESCRIPTION
All current language support is now provided by the syntect plugin; the syntect plugin's manifest is generated by a small program (`syntect-plugin/examples/make_manifest.rs`) that  parses them out of syntect itself.

This should 'just work' when syntect is installed via the Makefile; for xi-mac I'll have a patch shortly that handles this in its build script.

I've tried to keep this PR fairly minimal; there's some cleanup possible, but I'll keep that for follow-on work.

Also: this bumps our minimum supported rustc to 1.26. I could've avoided that, but I think we'll want to get there pretty soon anyway, so why not now.

cc @eyelash: let me know if this actually works for xi-gtk?
cc @betterclever: you might want to give this a quick look, it's plugin related

progress on #645 