### PR TITLE
Cleanup: less file-centric config

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -540,7 +540,6 @@ dependencies = [
 name = "xi-core-lib"
 version = "0.2.0"
 dependencies = [
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rust/core-lib/Cargo.toml
+++ b/rust/core-lib/Cargo.toml
@@ -12,7 +12,6 @@ serde_json = "1.0"
 serde_derive = "1.0"
 time = "0.1"
 toml = "0.4"
-lazy_static = "1.0"
 notify = { optional = true, version = "4.0" }
 
 xi-trace = { path = "../trace", version = "0.1.0" }

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -195,6 +195,11 @@ impl Editor {
         &self.syntax
     }
 
+    //TODO: temporary, this should be tracked in config manager
+    pub(crate) fn set_syntax(&mut self, language: LanguageId) {
+        self.syntax = language;
+    }
+
     // each outstanding plugin edit represents a rev_in_flight.
     pub fn increment_revs_in_flight(&mut self) {
         self.revs_in_flight += 1;

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -36,8 +36,6 @@ extern crate serde;
 extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;
-#[macro_use]
-extern crate lazy_static;
 extern crate time;
 extern crate syntect;
 extern crate toml;

--- a/rust/core-lib/src/syntax.rs
+++ b/rust/core-lib/src/syntax.rs
@@ -101,3 +101,19 @@ impl<'a> From<&'a str> for LanguageId {
         LanguageId(Arc::new(src.into()))
     }
 }
+
+// for testing
+#[cfg(test)]
+impl LanguageDefinition {
+    pub(crate) fn simple(name: &str, exts: &[&str],
+                         scope: &str, config: Option<Table>) -> Self
+    {
+        LanguageDefinition {
+            name: name.into(),
+            extensions: exts.iter().map(|s| (*s).into()).collect(),
+            first_line_match: None,
+            scope: scope.into(),
+            default_config: config,
+        }
+    }
+}

--- a/rust/syntect-plugin/Cargo.lock
+++ b/rust/syntect-plugin/Cargo.lock
@@ -659,7 +659,6 @@ dependencies = [
 name = "xi-core-lib"
 version = "0.2.0"
 dependencies = [
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Based off of #672.

This removes any knowledge of file paths from the `ConfigManager`, makes the loading of default configs more explicit, and simplifies the codepaths responsible for changing a config table.

This is still in a bit of an in-between state; the next step is to move ownership of configs and language definitions out of the buffer and into the ConfigManager; the buffer will get a config passed in during edit calls, which is something we'd like anyway for testing.

Progress on #645 