### PR TITLE
Keep find result selected on close

### DIFF
--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -193,16 +193,19 @@ impl View {
     }
 
     fn do_cancel(&mut self, text: &Rope) {
-        self.collapse_selections(text);
-        for mut find in self.find.iter_mut() {
-            find.unset();
+        // if we have active find highlights, we don't collapse selections
+        if self.find.is_empty() {
+            self.collapse_selections(text);
+        } else {
+            self.unset_find();
         }
     }
 
-    pub fn unset_find(&mut self) {
+    pub(crate) fn unset_find(&mut self) {
         for mut find in self.find.iter_mut() {
             find.unset();
         }
+        self.find.clear();
     }
 
     fn goto_line(&mut self, text: &Rope, line: u64) {


### PR DESCRIPTION
This fixes an issue where the find result wasn't selected after closing the find view.

Questions:
- is `cancel_operation` the correct RPC to be sending when the user dismisses the find view? Maybe we want a new RPC specific to this case?
- is it correct to call `clear()` when unsetting find? 

@scholtzan let me know if this change makes sense to you, or if you have a better idea.