### PR TITLE
Added status bar rpcs to send to front end

### DIFF
--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -380,13 +380,13 @@ Adds a status item, which will be displayed on the frontend's status bar. The al
 
 #### update_status_item
 
-`update_status_item { key: "my_key", value: "hello"}
+`update_status_item { key: "my_key", value: "hello"}`
 
 Update a status item with the specified key with the new value.
 
 #### remove_status_item
 
-`remove_status_item { key: "my_key" }
+`remove_status_item { key: "my_key" }`
 
 Removes a status item from the front end.
 

--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -12,7 +12,9 @@ site_nav_category: docs
     - [Backend](#from-front-end-to-back-end)
         - [Edit Commands](#edit-namespace)
         - [Plugin Commands](#plugin-namespace)
+
     - [Frontend](#from-back-end-to-front-end)
+        - [Status Bar Commands](#status-bar-commands)
 
 ----
 
@@ -367,6 +369,27 @@ this writing, the following is valid json for a `Command` object:
         ]
     }
 ```
+
+### Status Bar Commands
+
+#### add_status_item
+
+`add_status_item { key: "my_key", value: "hello", alignment: "left" }`
+
+Adds a status item, which will be displayed on the frontend's status bar. The alignment key dictates whether this item appears on the left side or the right side of the bar. This alignment can only be set when the item is added.
+
+#### update_status_item
+
+`update_status_item { key: "my_key", value: "hello"}
+
+Update a status item with the specified key with the new value.
+
+#### remove_status_item
+
+`remove_status_item { key: "my_key" }
+
+Removes a status item from the front end.
+
 
 ## Other future extensions
 

--- a/rust/core-lib/src/client.rs
+++ b/rust/core-lib/src/client.rs
@@ -135,9 +135,30 @@ impl Client {
            .expect("failed to deserialize width response"))
     }
 
-
     pub fn alert<S: AsRef<str>>(&self, msg: S) {
         self.0.send_rpc_notification("alert", &json!({ "msg": msg.as_ref() }));
+    }
+
+    pub fn add_status_item(&self, view_id: ViewId, key: &str, value: &str, alignment: &str) {
+        self.0.send_rpc_notification("add_status_item", &json!(
+            {   "view_id": view_id,
+                "key": key,
+                "value": value,
+                "alignment": alignment
+            }));
+    }
+
+    pub fn update_status_item(&self, view_id: ViewId, key: &str, value: &str) {
+        self.0.send_rpc_notification("update_status_item", &json!(
+            {   "view_id": view_id,
+                "key": key,
+                "value": value,
+            }));
+    }
+
+    pub fn remove_status_item(&self, view_id: ViewId, key: &str) {
+        self.0.send_rpc_notification("remove_status_item", &json!(
+            {   "view_id": view_id, "key": key }));
     }
 
     pub fn schedule_idle(&self, token: usize) {

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -162,9 +162,12 @@ impl<'a> EventContext<'a> {
             Edit { edit } => self.with_editor(
                 |ed, _, _| ed.apply_plugin_edit(edit)),
             Alert { msg } => self.client.alert(&msg),
-            AddStatusItem { key, value, alignment }  => self.client.add_status_item(viewID, &key, &value, &alignment),
-            UpdateStatusItem { key, value } => self.client.update_status_item(viewID, &key, &value),
-            RemoveStatusItem { key } => self.client.remove_status_item(viewID, &key)
+            AddStatusItem { key, value, alignment }  =>
+            self.client.add_status_item(viewID, &key, &value, &alignment),
+            UpdateStatusItem { key, value }
+            => self.client.update_status_item(viewID, &key, &value),
+            RemoveStatusItem { key }
+            => self.client.remove_status_item(viewID, &key)
         };
         self.after_edit(&plugin.to_string());
         self.render_if_needed();

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -149,7 +149,7 @@ impl<'a> EventContext<'a> {
     pub(crate) fn do_plugin_cmd(&mut self, plugin: PluginId,
                                  cmd: PluginNotification) {
         use self::PluginNotification::*;
-
+        let viewID = self.view.borrow().view_id;
         match cmd {
             AddScopes { scopes } => {
                 let mut ed = self.editor.borrow_mut();
@@ -162,6 +162,9 @@ impl<'a> EventContext<'a> {
             Edit { edit } => self.with_editor(
                 |ed, _, _| ed.apply_plugin_edit(edit)),
             Alert { msg } => self.client.alert(&msg),
+            AddStatusItem { key, value, alignment }  => self.client.add_status_item(viewID, &key, &value, &alignment),
+            UpdateStatusItem { key, value } => self.client.update_status_item(viewID, &key, &value),
+            RemoveStatusItem { key } => self.client.remove_status_item(viewID, &key)
         };
         self.after_edit(&plugin.to_string());
         self.render_if_needed();

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -149,7 +149,6 @@ impl<'a> EventContext<'a> {
     pub(crate) fn do_plugin_cmd(&mut self, plugin: PluginId,
                                  cmd: PluginNotification) {
         use self::PluginNotification::*;
-        let viewID = self.view.borrow().view_id;
         match cmd {
             AddScopes { scopes } => {
                 let mut ed = self.editor.borrow_mut();
@@ -162,12 +161,11 @@ impl<'a> EventContext<'a> {
             Edit { edit } => self.with_editor(
                 |ed, _, _| ed.apply_plugin_edit(edit)),
             Alert { msg } => self.client.alert(&msg),
-            AddStatusItem { key, value, alignment }  =>
-            self.client.add_status_item(viewID, &key, &value, &alignment),
-            UpdateStatusItem { key, value }
-            => self.client.update_status_item(viewID, &key, &value),
-            RemoveStatusItem { key }
-            => self.client.remove_status_item(viewID, &key)
+            AddStatusItem { key, value, alignment }  => self.client.add_status_item(
+                                                        self.view_id, &key, &value, &alignment),
+            UpdateStatusItem { key, value } => self.client.update_status_item(
+                                                        self.view_id, &key, &value),
+            RemoveStatusItem { key } => self.client.remove_status_item(self.view_id, &key)
         };
         self.after_edit(&plugin.to_string());
         self.render_if_needed();

--- a/rust/core-lib/src/plugins/rpc.rs
+++ b/rust/core-lib/src/plugins/rpc.rs
@@ -181,6 +181,9 @@ pub enum PluginNotification {
     UpdateSpans { start: usize, len: usize, spans: Vec<ScopeSpan>, rev: u64 },
     Edit { edit: PluginEdit },
     Alert { msg: String },
+    AddStatusItem { key: String, value: String, alignment: String },
+    UpdateStatusItem { key: String, value: String  },
+    RemoveStatusItem { key: String }
 }
 
 /// Common wrapper for plugin-originating RPCs.

--- a/rust/plugin-lib/src/view.rs
+++ b/rust/plugin-lib/src/view.rs
@@ -175,6 +175,36 @@ impl<C: Cache> View<C> {
         self.peer.request_is_pending()
     }
 
+    pub fn add_status_item(&self, key: &str, value: &str, alignment: &str) {
+        let params = json!({
+            "plugin_id": self.plugin_id,
+            "view_id": self.view_id,
+            "key": key,
+            "value": value,
+            "alignment": alignment
+        });
+        self.peer.send_rpc_notification("add_status_item", &params);
+    }
+
+    pub fn update_status_item(&self, key: &str, value: &str) {
+        let params = json!({
+            "plugin_id": self.plugin_id,
+            "view_id": self.view_id,
+            "key": key,
+            "value": value
+        });
+        self.peer.send_rpc_notification("update_status_item", &params);
+    }
+
+    pub fn remove_status_item(&self, key: &str) {
+        let params = json!({
+            "plugin_id": self.plugin_id,
+            "view_id": self.view_id,
+            "key": key
+        });
+        self.peer.send_rpc_notification("remove_status_item", &params);
+    }
+
 }
 
 /// A simple wrapper type that acts as a `DataSource`.

--- a/rust/sample-plugin/src/main.rs
+++ b/rust/sample-plugin/src/main.rs
@@ -33,7 +33,7 @@ use xi_plugin_lib::{Plugin, ChunkCache, View, mainloop, Error};
 /// intended to demonstrate how to edit a document; when the plugin is active,
 /// and the user inserts an exclamation mark, the plugin will capitalize the
 /// preceding word.
-struct SamplePlugin;
+struct SamplePlugin(usize);
 
 //NOTE: implementing the `Plugin` trait is the sole requirement of a plugin.
 // For more documentation, see `rust/plugin-lib` in this repo.
@@ -42,10 +42,12 @@ impl Plugin for SamplePlugin {
 
     fn new_view(&mut self, view: &mut View<Self::Cache>) {
         eprintln!("new view {}", view.get_id());
+        view.add_status_item("my_key", &format!("hello {}", self.0), "left");
     }
 
     fn did_close(&mut self, view: &View<Self::Cache>) {
         eprintln!("close view {}", view.get_id());
+        view.remove_status_item("my_key");
     }
 
     fn did_save(&mut self, view: &mut View<Self::Cache>, _old: Option<&Path>) {
@@ -60,7 +62,6 @@ impl Plugin for SamplePlugin {
 
         //NOTE: example simple conditional edit. If this delta is
         //an insert of a single '!', we capitalize the preceding word.
-
         if let Some(delta) = delta {
             let (iv, _) = delta.summary();
             let text: String = delta.as_simple_insert()
@@ -69,6 +70,16 @@ impl Plugin for SamplePlugin {
             if text == "!" {
                 let _ = self.capitalize_word(view, iv.end());
             }
+        }
+        self.0 += 1;
+        view.update_status_item("my_key", &format!("hello {}", self.0));
+        if self.0 == 50 {
+            view.add_status_item("my_key_2", &format!("hi there {}", self.0), "left");
+            view.add_status_item("my_key_3", &format!("howdy {}", self.0), "right");
+        }
+        if self.0 == 100 {
+            view.remove_status_item("my_key");
+            view.add_status_item("my_key_4", &format!("hiya {}", self.0), "left");
         }
     }
 }
@@ -108,6 +119,6 @@ impl SamplePlugin {
 }
 
 fn main() {
-    let mut plugin = SamplePlugin;
+    let mut plugin = SamplePlugin(0);
     mainloop(&mut plugin).unwrap();
 }

--- a/rust/sample-plugin/src/main.rs
+++ b/rust/sample-plugin/src/main.rs
@@ -33,7 +33,7 @@ use xi_plugin_lib::{Plugin, ChunkCache, View, mainloop, Error};
 /// intended to demonstrate how to edit a document; when the plugin is active,
 /// and the user inserts an exclamation mark, the plugin will capitalize the
 /// preceding word.
-struct SamplePlugin(usize);
+struct SamplePlugin;
 
 //NOTE: implementing the `Plugin` trait is the sole requirement of a plugin.
 // For more documentation, see `rust/plugin-lib` in this repo.
@@ -42,12 +42,10 @@ impl Plugin for SamplePlugin {
 
     fn new_view(&mut self, view: &mut View<Self::Cache>) {
         eprintln!("new view {}", view.get_id());
-        view.add_status_item("my_key", &format!("hello {}", self.0), "left");
     }
 
     fn did_close(&mut self, view: &View<Self::Cache>) {
         eprintln!("close view {}", view.get_id());
-        view.remove_status_item("my_key");
     }
 
     fn did_save(&mut self, view: &mut View<Self::Cache>, _old: Option<&Path>) {
@@ -70,19 +68,6 @@ impl Plugin for SamplePlugin {
             if text == "!" {
                 let _ = self.capitalize_word(view, iv.end());
             }
-        }
-        self.0 += 1;
-        view.update_status_item("my_key", &format!("hello {}", self.0));
-        if self.0 == 50 {
-            view.add_status_item("my_key_2", &format!("hi there {}", self.0), "left");
-            view.add_status_item("my_key_3", &format!("howdy {}", self.0), "right");
-        }
-        if self.0 == 100 {
-            view.remove_status_item("my_key_2");
-            view.add_status_item("my_key_4", &format!("hiya {}", self.0), "left");
-        }
-        if self.0 == 200 {
-            view.remove_status_item("my_key_3");
         }
     }
 }
@@ -122,6 +107,6 @@ impl SamplePlugin {
 }
 
 fn main() {
-    let mut plugin = SamplePlugin(0);
+    let mut plugin = SamplePlugin;
     mainloop(&mut plugin).unwrap();
 }

--- a/rust/sample-plugin/src/main.rs
+++ b/rust/sample-plugin/src/main.rs
@@ -78,8 +78,11 @@ impl Plugin for SamplePlugin {
             view.add_status_item("my_key_3", &format!("howdy {}", self.0), "right");
         }
         if self.0 == 100 {
-            view.remove_status_item("my_key");
+            view.remove_status_item("my_key_2");
             view.add_status_item("my_key_4", &format!("hiya {}", self.0), "left");
+        }
+        if self.0 == 200 {
+            view.remove_status_item("my_key_3");
         }
     }
 }


### PR DESCRIPTION
This PR is a companion PR to xi-mac's [#183](https://github.com/google/xi-mac/pull/183). This PR adds necessary RPC items and commands to support status bar items, along with a sample plugin that  makes use of these features. 