### PR TITLE
Fix issue where plugins are not launched at startup

### DIFF
--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -244,6 +244,14 @@ impl ConfigManager {
         if exists { config_file } else { None }
     }
 
+    pub fn get_plugin_paths(&self) -> Vec<PathBuf> {
+        let config_dir = self.config_dir.as_ref().map(|p| p.join("plugins"));
+        [self.extras_dir.as_ref(), config_dir.as_ref()].iter()
+            .flat_map(|p| p.map(|p| p.to_owned()))
+                .filter(|p| p.exists())
+                .collect()
+    }
+
     /// Sets the config for the given domain, removing any existing config.
     pub fn set_user_config<P>(&mut self, domain: ConfigDomain,
                               new_config: Table, path: P)

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -176,6 +176,10 @@ impl CoreState {
             self.load_file_based_config(&path);
         }
 
+        //FIXME: quickfix pending #672
+        let plugin_paths = self.config_manager.get_plugin_paths();
+        self.plugins = PluginCatalog::from_paths(plugin_paths);
+
         let theme_names = self.style_map.borrow().get_theme_names();
         self.peer.available_themes(theme_names);
 


### PR DESCRIPTION
This is a regression in c62284e that is addressed in #672, but in the meantime it is
interfering with other work.