### PR TITLE
Refactor/configs in config manager

### DIFF
--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -573,16 +573,19 @@ impl LanguageTag {
     }
 
     fn resolve(&self) -> LanguageId {
-        self.user.as_ref().map(LanguageId::clone)
-            .unwrap_or_else(|| self.detected.clone())
+        self.user.as_ref().unwrap_or(&self.detected).clone()
     }
 
+    /// Set the detected language. Returns `true` if this changes the resolved
+    /// language.
     fn set_detected(&mut self, detected: LanguageId) -> bool {
         let before = self.resolve();
         self.detected = detected;
         before != self.resolve()
     }
 
+    /// Set the user-specified language. Returns `true` if this changes
+    /// the resolved language.
     #[allow(dead_code)]
     fn set_user(&mut self, new_lang: Option<LanguageId>) -> bool {
         let has_changed = self.user != new_lang;

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -439,7 +439,6 @@ impl Editor {
 
     fn insert_newline(&mut self, view: &View, config: &BufferItems) {
         self.this_edit_type = EditType::InsertChars;
-        //let text = self.config.items.line_ending.clone();
         self.insert(view, &config.line_ending);
     }
 

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -25,7 +25,7 @@ use xi_rope::engine::{Engine, RevId, RevToken};
 use xi_rope::spans::SpansBuilder;
 use xi_trace::trace_block;
 
-use config::{BufferConfig, Table};
+use config::BufferItems;
 use event_context::MAX_SIZE_LIMIT;
 use edit_types::BufferEvent;
 use layers::Layers;
@@ -34,7 +34,6 @@ use plugins::PluginId;
 use plugins::rpc::{PluginEdit, ScopeSpan, TextUnit, GetDataResponse};
 use selection::{Selection, SelRegion};
 use styles::ThemeStyleMap;
-use syntax::LanguageId;
 use view::View;
 
 #[cfg(not(feature = "ledger"))]
@@ -83,19 +82,17 @@ pub struct Editor {
     #[allow(dead_code)]
     last_synced_rev: RevId,
 
-    syntax: LanguageId,
     layers: Layers,
-    config: BufferConfig,
 }
 
 impl Editor {
     /// Creates a new `Editor` with a new empty buffer.
-    pub fn new(config: BufferConfig) -> Editor {
-        Self::with_text("", config)
+    pub fn new() -> Editor {
+        Self::with_text("")
     }
 
     /// Creates a new `Editor`, loading text into a new buffer.
-    pub fn with_text<T>(text: T, config: BufferConfig) -> Editor
+    pub fn with_text<T>(text: T) -> Editor
         where T: Into<Rope>,
     {
 
@@ -105,7 +102,6 @@ impl Editor {
 
         Editor {
             text: buffer,
-            syntax: LanguageId::default(),
             engine,
             last_rev_id,
             pristine_rev_id: last_rev_id,
@@ -120,7 +116,6 @@ impl Editor {
             last_edit_type: EditType::Other,
             this_edit_type: EditType::Other,
             layers: Layers::default(),
-            config,
             revs_in_flight: 0,
             sync_store: None,
             last_synced_rev: last_rev_id,
@@ -173,31 +168,6 @@ impl Editor {
         builder.replace(all_iv, text);
         self.add_delta(builder.build());
         self.set_pristine();
-    }
-
-    /// Sets the config for this buffer. If the new config differs
-    /// from the existing config, returns the modified items.
-    pub fn set_config(&mut self, conf: BufferConfig) -> Option<Table> {
-        if let Some(changes) = conf.changes_from(Some(&self.config)) {
-            self.config = conf;
-            Some(changes)
-        } else {
-            None
-        }
-    }
-
-    pub fn get_config(&self) -> &BufferConfig {
-        &self.config
-    }
-
-    /// Returns this `Editor`'s active `LanguageId`.
-    pub fn get_syntax(&self) -> &LanguageId {
-        &self.syntax
-    }
-
-    //TODO: temporary, this should be tracked in config manager
-    pub(crate) fn set_syntax(&mut self, language: LanguageId) {
-        self.syntax = language;
     }
 
     // each outstanding plugin edit represents a rev_in_flight.
@@ -365,7 +335,7 @@ impl Editor {
         }
     }
 
-    fn delete_backward(&mut self, view: &View) {
+    fn delete_backward(&mut self, view: &View, config: &BufferItems) {
         // TODO: this function is workable but probably overall code complexity
         // could be improved by implementing a "backspace" movement instead.
         let mut builder = delta::Builder::new(self.text.len());
@@ -374,17 +344,17 @@ impl Editor {
                 region.min()
             } else {
                 // backspace deletes max(1, tab_size) contiguous spaces
-                let (_, c) = view.offset_to_line_col(&self.text,
-                                                     region.start);
-                let use_spaces = self.config.items.translate_tabs_to_spaces;
-                let use_tab_stops = self.config.items.use_tab_stops;
-                let tab_size = self.config.items.tab_size;
-                let tab_off = c & tab_size;
+                let (_, c) = view.offset_to_line_col(&self.text, region.start);
+
+                let tab_off = c & config.tab_size;
+                let tab_size = config.tab_size;
                 let tab_size = if tab_off == 0 { tab_size } else { tab_off };
                 let preceded_by_spaces = region.start > 0 &&
                     (region.start.saturating_sub(tab_size)..region.start)
                     .all(|i| self.text.byte_at(i) == b' ');
-                if preceded_by_spaces && use_spaces && use_tab_stops {
+                if preceded_by_spaces
+                    && config.translate_tabs_to_spaces
+                    && config.use_tab_stops {
                     region.start - tab_size
                 } else {
                     self.text.prev_grapheme_offset(region.end)
@@ -467,15 +437,15 @@ impl Editor {
         saved
     }
 
-    fn insert_newline(&mut self, view: &View) {
+    fn insert_newline(&mut self, view: &View, config: &BufferItems) {
         self.this_edit_type = EditType::InsertChars;
-        let text = self.config.items.line_ending.clone();
-        self.insert(view, &text);
+        //let text = self.config.items.line_ending.clone();
+        self.insert(view, &config.line_ending);
     }
 
-    fn insert_tab(&mut self, view: &View) {
+    fn insert_tab(&mut self, view: &View, config: &BufferItems) {
         let mut builder = delta::Builder::new(self.text.len());
-        let const_tab_text = self.get_tab_text(self.config.items.tab_size);
+        let const_tab_text = self.get_tab_text(config, None);
 
         for region in view.sel_regions() {
             let line_range = view.get_line_range(&self.text, region);
@@ -488,9 +458,9 @@ impl Editor {
                 }
             } else {
                 let (_, col) = view.offset_to_line_col(&self.text, region.start);
-                let mut tab_size = self.config.items.tab_size;
+                let mut tab_size = config.tab_size;
                 tab_size = tab_size - (col % tab_size);
-                let tab_text = self.get_tab_text(tab_size);
+                let tab_text = self.get_tab_text(config, Some(tab_size));
 
                 let iv = Interval::new_closed_open(region.min(), region.max());
                 builder.replace(iv, Rope::from(tab_text));
@@ -523,9 +493,10 @@ impl Editor {
     /// Preserves cursor position and current selection as much as possible.
     /// Tries to have behavior consistent with other editors like Atom,
     /// Sublime and VSCode, with non-caret selections not being modified.
-    fn modify_indent(&mut self, view: &View, direction: IndentDirection) {
+    fn modify_indent(&mut self, view: &View, config: &BufferItems,
+                     direction: IndentDirection) {
         let mut lines = BTreeSet::new();
-        let tab_text = self.get_tab_text(self.config.items.tab_size);
+        let tab_text = self.get_tab_text(config, None);
         for region in view.sel_regions() {
             let line_range = view.get_line_range(&self.text, region);
             for line in line_range {
@@ -572,8 +543,11 @@ impl Editor {
         self.add_delta(builder.build());
     }
 
-    fn get_tab_text(&self, tab_size: usize) -> &'static str {
-        let tab_text = if self.config.items.translate_tabs_to_spaces {
+    fn get_tab_text(&self, config: &BufferItems, tab_size: Option<usize>)
+        -> &'static str
+    {
+        let tab_size = tab_size.unwrap_or(config.tab_size);
+        let tab_text = if config.translate_tabs_to_spaces {
             n_spaces(tab_size)
         } else { "\t" };
 
@@ -691,21 +665,21 @@ impl Editor {
     }
 
     pub(crate) fn do_edit(&mut self, view: &mut View, kill_ring: &mut Rope,
-                          cmd: BufferEvent) {
+                          config: &BufferItems, cmd: BufferEvent) {
         use self::BufferEvent::*;
         match cmd {
             Delete { movement, kill } =>
                 self.delete_by_movement(view, movement, kill, kill_ring),
-            Backspace => self.delete_backward(view),
+            Backspace => self.delete_backward(view, config),
             Transpose => self.do_transpose(view),
             Undo => self.do_undo(),
             Redo => self.do_redo(),
             Uppercase => self.transform_text(view, |s| s.to_uppercase()),
             Lowercase => self.transform_text(view, |s| s.to_lowercase()),
-            Indent => self.modify_indent(view, IndentDirection::In),
-            Outdent => self.modify_indent(view, IndentDirection::Out),
-            InsertNewline => self.insert_newline(view),
-            InsertTab => self.insert_tab(view),
+            Indent => self.modify_indent(view, config, IndentDirection::In),
+            Outdent => self.modify_indent(view, config, IndentDirection::Out),
+            InsertNewline => self.insert_newline(view, config),
+            InsertTab => self.insert_tab(view, config),
             Insert(chars) => self.do_insert(view, &chars),
             Yank => self.yank(view, kill_ring),
         }

--- a/rust/core-lib/src/syntax.rs
+++ b/rust/core-lib/src/syntax.rs
@@ -65,8 +65,10 @@ impl Languages {
             .map(Arc::clone)
     }
 
-    pub fn language_for_name(&self, name: &str) -> Option<Arc<LanguageDefinition>> {
-        self.named.get(name).map(Arc::clone)
+    pub fn language_for_name<S>(&self, name: S) -> Option<Arc<LanguageDefinition>>
+        where S: AsRef<str>
+    {
+        self.named.get(name.as_ref()).map(Arc::clone)
     }
 
     /// Returns a Vec of any `LanguageDefinition`s which exist

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -207,17 +207,22 @@ impl CoreState {
 
     /// Sets (overwriting) the config for a given domain.
     fn set_config(&mut self, domain: ConfigDomain, table: Table) {
-        if let Err(e) = self.config_manager.set_user_config(domain, table) {
-            self.peer.alert(format!("{}", &e));
-        } else {
-            self.after_config_change();
+        match self.config_manager.set_user_config(domain, table) {
+            Err(e) => self.peer.alert(format!("{}", &e)),
+            Ok(changes) => self.handle_config_changes(changes),
         }
     }
 
     /// Notify editors/views/plugins of config changes.
-    fn after_config_change(&self) {
-        self.iter_groups()
-            .for_each(|mut ctx| ctx.config_changed(&self.config_manager))
+    fn handle_config_changes(&self, changes: Vec<(BufferId, Table)>) {
+        for (id, table) in changes {
+            let view_id = self.views.values()
+                .find(|v| v.borrow().get_buffer_id() == id)
+                .map(|v| v.borrow().get_view_id())
+                .unwrap();
+
+            self.make_context(view_id).unwrap().config_changed(&table)
+        }
     }
 }
 
@@ -237,12 +242,16 @@ impl CoreState {
             let editor = self.editors.get(&buffer_id).unwrap();
             let info = self.file_manager.get_info(buffer_id);
             let plugins = self.running_plugins.iter().collect::<Vec<_>>();
+            let config = self.config_manager.get_buffer_config(buffer_id);
+            let language = self.config_manager.get_buffer_language(buffer_id);
 
             EventContext {
                 view_id,
                 buffer_id,
                 view,
                 editor,
+                config: &config.items,
+                language,
                 info: info,
                 siblings: Vec::new(),
                 plugins: plugins,
@@ -339,22 +348,20 @@ impl CoreState {
         let view_id = self.next_view_id();
         let buffer_id = self.next_buffer_id();
 
-        let editor = match path {
-            Some(path) => self.new_with_file(&path, buffer_id)?,
-            None => self.new_empty_buffer(),
+        let rope = match path.as_ref() {
+            Some(p) => self.file_manager.open(p, buffer_id)?,
+            None => Rope::from(""),
         };
 
-        let mut view = View::new(view_id, buffer_id);
-
-        let wrap_width = editor.get_config().items.wrap_width;
-        view.rewrap(editor.get_buffer(), wrap_width);
-        view.set_dirty(editor.get_buffer());
-
-        let editor = RefCell::new(editor);
-        let view = RefCell::new(view);
+        let editor = RefCell::new(Editor::with_text(rope));
+        let view = RefCell::new(View::new(view_id, buffer_id));
 
         self.editors.insert(buffer_id, editor);
         self.views.insert(view_id, view);
+
+        self.config_manager.add_buffer(buffer_id,
+                                       path.as_ref().map(|p| p.as_path()));
+
         //NOTE: because this is a synchronous call, we have to return the
         //view_id before we can send any events to this view. We use mark the
         // viewa s pending and schedule the idle handler so that we can finish
@@ -363,25 +370,6 @@ impl CoreState {
         self.peer.schedule_idle(NEW_VIEW_IDLE_TOKEN);
 
         Ok(json!(view_id))
-    }
-
-    fn new_empty_buffer(&mut self) -> Editor {
-        let config = self.config_manager.default_buffer_config();
-        Editor::new(config)
-    }
-
-    fn new_with_file(&mut self, path: &Path, buffer_id: BufferId)
-        -> Result<Editor, RemoteError>
-    {
-        let rope = self.file_manager.open(path, buffer_id)?;
-        let syntax = self.config_manager.language_for_path(path);
-        let config = self.config_manager.get_buffer_config(syntax.clone(),
-                                                           buffer_id);
-        let mut editor = Editor::with_text(rope, config);
-        if let Some(syntax) = syntax {
-            editor.set_syntax(syntax);
-        }
-        Ok(editor)
     }
 
     fn do_save<P>(&mut self, view_id: ViewId, path: P)
@@ -397,25 +385,19 @@ impl CoreState {
 
         let ed = self.editors.get(&buffer_id).unwrap();
 
-        let result = self.file_manager.save(path, ed.borrow().get_buffer(),
-                                            buffer_id);
-        if let Err(e) = result {
+        if let Err(e) = self.file_manager.save(path, ed.borrow().get_buffer(),
+                                               buffer_id) {
             self.peer.alert(e.to_string());
             return;
         }
 
-        let syntax = self.config_manager.language_for_path(path);
-        let config = self.config_manager.get_buffer_config(syntax.clone(),
-                                                           buffer_id);
-        // TODO: keep track of syntax in config manager, not in editor
-        if let Some(syntax) = syntax {
-            ed.borrow_mut().set_syntax(syntax);
-        }
-        //TODO: rework how config changes are handled if a path changes.
-        //tldr; do the save first, then reload the config.
+        self.make_context(view_id).unwrap().after_save(path);
 
-        let mut event_ctx = self.make_context(view_id).unwrap();
-        event_ctx.after_save(path, config);
+        // update the config _after_ sending save related events
+        let changes = self.config_manager.update_buffer_path(buffer_id, path);
+        if let Some(changes) = changes {
+            self.make_context(view_id).unwrap().config_changed(&changes);
+        }
     }
 
     fn do_close_view(&mut self, view_id: ViewId) {
@@ -430,6 +412,7 @@ impl CoreState {
             if close_buffer {
                 self.editors.remove(&buffer_id);
                 self.file_manager.close(buffer_id);
+                self.config_manager.remove_buffer(buffer_id);
             }
         }
     }
@@ -446,7 +429,7 @@ impl CoreState {
         }
 
         self.iter_groups().for_each(|mut edit_ctx| {
-            edit_ctx.with_editor(|ed, view, _| {
+            edit_ctx.with_editor(|ed, view, _, _| {
                 ed.theme_changed(&self.style_map.borrow());
                 view.set_dirty(ed.get_buffer());
             });
@@ -475,8 +458,8 @@ impl CoreState {
 
     fn do_get_config(&self, view_id: ViewId) -> Result<Table, RemoteError> {
         let _t = trace_block("CoreState::get_config", &["core"]);
-        self.make_context(view_id)
-            .map(|mut ctx| ctx.with_editor(|ed, _, _| ed.get_config().to_table()))
+        self.views.get(&view_id).map(|v| v.borrow().get_buffer_id())
+            .map(|id| self.config_manager.get_buffer_config(id).to_table())
             .ok_or(RemoteError::custom(404, format!("missing {}", view_id), None))
     }
 


### PR DESCRIPTION
(includes #680, which should go in first.)

This is another batch of cleanup & refactoring. In pointform:

- the language assigned to a buffer is tracked in the ConfigManager
- the buffer's config is tracked in the ConfigManager. This means that
we don't need to have a config in order to init an `Editor`, which means
we now only have one code path for creating a new view.
- configs are passed into `Editor` and `View` as needed; this means the
`View` doesn't need to reach in to the `Editor` to access the config.

This will enable and/or simplify some additional feature work:
- allowing the client to set a view's language without saving
- implementing width wrapping via the config system
- auto launching plugins based on language (and other) tags