### PR TITLE
Track view size and use for word wrapping

### DIFF
--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -125,6 +125,14 @@ region is used to compute movement distance for page up and page down
 commands, and also controls the size of the fragment sent in the
 `update` method.
 
+#### resize
+
+`resize {width: 420, height: 400}`
+
+Notifies the backend that the size of the view has changed. This is
+used for word wrapping, if enabled. Width and height are specified
+in px units / points, not display pixels.
+
 #### click
 
 `click [42,31,0,1]`

--- a/rust/core-lib/assets/client_example.toml
+++ b/rust/core-lib/assets/client_example.toml
@@ -33,3 +33,6 @@ scroll_past_end = false
 
 # If non-zero, indicates the column at which lines will be wrapped.
 wrap_width = 0
+
+# If true, wraps lines at the edge of the view. Overrides 'wrap_width'.
+word_wrap = false

--- a/rust/core-lib/assets/defaults.toml
+++ b/rust/core-lib/assets/defaults.toml
@@ -22,3 +22,5 @@ auto_indent = false
 scroll_past_end = false
 
 wrap_width = 0
+
+word_wrap = false

--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -164,6 +164,7 @@ pub struct BufferItems {
     pub auto_indent: bool,
     pub scroll_past_end: bool,
     pub wrap_width: usize,
+    pub word_wrap: bool,
 }
 
 pub type BufferConfig = Config<BufferItems>;

--- a/rust/core-lib/src/edit_types.rs
+++ b/rust/core-lib/src/edit_types.rs
@@ -19,7 +19,8 @@
 //! the editor or view as appropriate.
 
 use movement::Movement;
-use ::rpc::{GestureType, LineRange, EditNotification, MouseAction};
+use rpc::{GestureType, LineRange, EditNotification, MouseAction};
+use view::Size;
 
 
 /// Events that only modify view state
@@ -63,6 +64,7 @@ pub(crate) enum SpecialEvent {
     DebugRewrap,
     DebugWrapWidth,
     DebugPrintSpans,
+    Resize(Size),
     RequestLines(LineRange),
 }
 
@@ -183,6 +185,7 @@ impl From<EditNotification> for EventDomain {
             AddSelectionAbove => ViewEvent::AddSelectionAbove.into(),
             AddSelectionBelow => ViewEvent::AddSelectionBelow.into(),
             Scroll(range) => ViewEvent::Scroll(range).into(),
+            Resize(size) => SpecialEvent::Resize(size).into(),
             GotoLine { line } => ViewEvent::GotoLine { line }.into(),
             RequestLines(range) => SpecialEvent::RequestLines(range).into(),
             Yank => BufferEvent::Yank.into(),

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -25,9 +25,10 @@ use serde_json::{self, Value};
 use serde::de::{self, Deserialize, Deserializer};
 use serde::ser::{self, Serialize, Serializer};
 
-use tabs::ViewId;
-use plugins::PlaceholderRpc;
 use config::{Table, ConfigDomainExternal};
+use plugins::PlaceholderRpc;
+use tabs::ViewId;
+use view::Size;
 
 // =============================================================================
 //  Command types
@@ -372,6 +373,7 @@ pub enum EditNotification {
     AddSelectionAbove,
     AddSelectionBelow,
     Scroll(LineRange),
+    Resize(Size),
     GotoLine { line: u64 },
     RequestLines(LineRange),
     Yank,

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -99,7 +99,7 @@ enum FindStatusChange {
     Matches
 }
 
-/// A size, in pixels.
+/// A size, in pixel units (not display pixels).
 #[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct Size {
     pub width: f64,
@@ -262,7 +262,6 @@ impl View {
     }
 
     pub fn set_size(&mut self, size: Size) {
-        eprintln!("set size {:?}", size);
         self.size = size;
     }
 


### PR DESCRIPTION
(based off of #682; this PR is really just 8abe978)
 
This adds an rpc, `resize`, which sets the size of the view (I don't like this name, and I'm not sure if this RPC shouldn't be combined with 'scroll' or something; for discussion).

It also adds a 'word_wrap' config setting; when set to `true`, the width of the view is used for determining line breaks.

It also deprecates the `debug_wrap_width` and `debug_rewrap` methods.

todos:
- [x] docs