### PR TITLE
find_status

### DIFF
--- a/rust/core-lib/src/client.rs
+++ b/rust/core-lib/src/client.rs
@@ -124,6 +124,14 @@ impl Client {
         self.0.send_rpc_notification("def_style", &style)
     }
 
+    pub fn find_status(&self, view_id: ViewId, queries: &Value) {
+        self.0.send_rpc_notification("find_status",
+                                     &json!({
+                                         "view_id": view_id,
+                                         "queries": queries,
+                                     }));
+    }
+
     /// Ask front-end to measure widths of strings.
     pub fn measure_width(&self, reqs: &[WidthReq])
         -> Result<Vec<Vec<f64>>, xi_rpc::Error>

--- a/rust/core-lib/src/edit_types.rs
+++ b/rust/core-lib/src/edit_types.rs
@@ -34,6 +34,7 @@ pub(crate) enum ViewEvent {
     Drag(MouseAction),
     Gesture { line: u64, col: u64, ty: GestureType },
     GotoLine { line: u64 },
+    Find { chars: Option<String>, case_sensitive: bool },
     FindNext { wrap_around: Option<bool>, allow_same: Option<bool> },
     FindPrevious { wrap_around: Option<bool> },
     Cancel,
@@ -191,6 +192,8 @@ impl From<EditNotification> for EventDomain {
                 ViewEvent::Gesture { line, col, ty }.into(),
             Undo => BufferEvent::Undo.into(),
             Redo => BufferEvent::Redo.into(),
+            Find { chars, case_sensitive } =>
+                ViewEvent::Find { chars, case_sensitive }.into(),
             FindNext { wrap_around, allow_same } =>
                 ViewEvent::FindNext { wrap_around, allow_same }.into(),
             FindPrevious { wrap_around } =>

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -137,8 +137,11 @@ impl<'a> EventContext<'a> {
         let result = match cmd {
             Cut => Ok(self.with_editor(|ed, view, _| ed.do_cut(view))),
             Copy => Ok(self.with_editor(|ed, view, _| ed.do_copy(view))),
-            Find { chars, case_sensitive } => Ok(self.with_view(
-                |view, text| view.do_find(text, chars, case_sensitive))),
+            Find { chars, case_sensitive } => {
+                let result = Ok(self.with_view(|view, text| view.do_find(text, chars, case_sensitive)));
+                self.send_find_status();
+                result
+            },
             // Replace
         };
         self.after_edit("core");
@@ -410,6 +413,10 @@ impl<'a> EventContext<'a> {
         view.request_lines(ed.get_buffer(), self.client, self.style_map,
                            ed.get_layers().get_merged(), first, last,
                            ed.is_pristine())
+    }
+
+    fn send_find_status(&mut self) {
+        self.view.borrow_mut().send_find_status(&self.client)
     }
 }
 

--- a/rust/core-lib/src/find.rs
+++ b/rust/core-lib/src/find.rs
@@ -37,6 +37,8 @@ pub struct Find {
     search_string: Option<String>,
     /// The case matching setting for the currently active search
     case_matching: CaseMatching,
+    /// /// The search query should be considered as regular expression
+    is_regex: bool,
     /// The set of all known find occurrences (highlights)
     occurrences: Selection,
     /// Set of ranges that have already been searched for the currently active search string
@@ -49,6 +51,7 @@ impl Find {
             hls_dirty: true,
             search_string: None,
             case_matching: CaseMatching::CaseInsensitive,
+            is_regex: false,
             occurrences: Selection::new(),
             valid_search: IndexSet::new(),
         }
@@ -60,6 +63,18 @@ impl Find {
 
     pub fn hls_dirty(&self) -> bool {
         self.hls_dirty
+    }
+
+    pub fn search_string(&self) -> &Option<String> {
+        &self.search_string
+    }
+
+    pub fn is_case_sensitive(&self) -> bool {
+        self.case_matching == CaseMatching::Exact
+    }
+
+    pub fn is_regex(&self) -> bool {
+        self.is_regex
     }
 
     pub fn set_hls_dirty(&mut self, is_dirty: bool) {

--- a/rust/core-lib/src/find.rs
+++ b/rust/core-lib/src/find.rs
@@ -16,8 +16,6 @@
 
 use std::cmp::{min,max};
 
-use serde_json::Value;
-
 use index_set::IndexSet;
 use xi_rope::delta::{Delta, DeltaRegion};
 use xi_rope::find::{find, CaseMatching};
@@ -37,7 +35,7 @@ pub struct Find {
     search_string: Option<String>,
     /// The case matching setting for the currently active search
     case_matching: CaseMatching,
-    /// /// The search query should be considered as regular expression
+    /// The search query should be considered as regular expression
     is_regex: bool,
     /// The set of all known find occurrences (highlights)
     occurrences: Selection,
@@ -107,23 +105,18 @@ impl Find {
     }
 
     /// Set search parameters and executes the search.
-    pub fn do_find(&mut self, text: &Rope, search_string: Option<String>,
-                   case_sensitive: bool) -> Value {
+    pub fn do_find(&mut self, text: &Rope, search_string: Option<String>, case_sensitive: bool) {
         if search_string.is_none() {
             self.unset();
-            return Value::Null;
         }
 
         let search_string = search_string.unwrap();
         if search_string.len() == 0 {
             self.unset();
-            return Value::Null;
         }
 
         self.set_find(&search_string, case_sensitive);
         self.update_find(text, 0, text.len(), false);
-
-        Value::String(search_string.to_string())
     }
 
     /// Unsets the search and removes all highlights from the view.
@@ -135,8 +128,7 @@ impl Find {
     }
 
     /// Sets find parameters and search query.
-    fn set_find(&mut self, search_string: &str,
-                case_sensitive: bool) {
+    fn set_find(&mut self, search_string: &str, case_sensitive: bool) {
         let case_matching = if case_sensitive {
             CaseMatching::Exact
         } else {

--- a/rust/core-lib/src/find.rs
+++ b/rust/core-lib/src/find.rs
@@ -16,7 +16,6 @@
 
 use std::cmp::{min,max};
 
-use index_set::IndexSet;
 use xi_rope::delta::{Delta, DeltaRegion};
 use xi_rope::find::{find, CaseMatching};
 use xi_rope::rope::{Rope, LinesMetric, RopeInfo};
@@ -55,8 +54,6 @@ pub struct Find {
     is_regex: bool,
     /// The set of all known find occurrences (highlights)
     occurrences: Selection,
-    /// Set of ranges that have already been searched for the currently active search string
-    valid_search: IndexSet,
 }
 
 impl Find {
@@ -67,7 +64,6 @@ impl Find {
             case_matching: CaseMatching::CaseInsensitive,
             is_regex: false,
             occurrences: Selection::new(),
-            valid_search: IndexSet::new(),
         }
     }
 
@@ -104,11 +100,8 @@ impl Find {
     pub fn update_highlights(&mut self, text: &Rope, delta: &Delta<RopeInfo>) {
         // update search highlights for changed regions
         if self.search_string.is_some() {
-            self.valid_search = self.valid_search.apply_delta(delta);
-
             // invalidate occurrences around deletion positions
-            for DeltaRegion{ old_offset, new_offset, len } in delta.iter_deletions() {
-                self.valid_search.delete_range(new_offset, new_offset + len);
+            for DeltaRegion{ old_offset, new_offset: _, len } in delta.iter_deletions() {
                 self.occurrences.delete_range(old_offset, old_offset + len, false);
             }
 
@@ -116,13 +109,32 @@ impl Find {
 
             // invalidate occurrences around insert positions
             for DeltaRegion{ new_offset, len, .. } in delta.iter_inserts() {
-                self.valid_search.delete_range(new_offset, new_offset + len);
                 self.occurrences.delete_range(new_offset, new_offset + len, false);
             }
 
-            // update find for the whole delta (is going to only update invalid regions)
+            // update find for the whole delta and everything after
             let (iv, _) = delta.summary();
-            self.update_find(text, iv.start(), iv.end(), true);
+
+            // get last valid occurrence that was unaffected by the delta
+            let start = match self.occurrences.regions_in_range(0, iv.start()).last() {
+                Some(reg) => reg.end,
+                None => 0
+            };
+
+            // invalidate all search results from the point of the last valid search result until ...
+            let is_multi_line = LinesMetric::next(self.search_string.as_ref().unwrap(), 0).is_some();
+            if is_multi_line {
+                // ... the end of the file
+                self.occurrences.delete_range(iv.start(), text.len(), false);
+                self.update_find(text, start, text.len(), true);
+            } else {
+                // ... the end of the line
+                let mut cursor = Cursor::new(&text, iv.start());
+                if let Some(end_of_line) = cursor.next::<LinesMetric>() {
+                    self.occurrences.delete_range(iv.start(), end_of_line, false);
+                    self.update_find(text, start, end_of_line, true);
+                }
+            }
         }
     }
 
@@ -146,7 +158,6 @@ impl Find {
         self.search_string = None;
         self.occurrences = Selection::new();
         self.hls_dirty = true;
-        self.valid_search.clear();
     }
 
     /// Sets find parameters and search query.
@@ -177,28 +188,24 @@ impl Find {
             return;
         }
 
-        let text_len = text.len();
         // extend the search by twice the string length (twice, because case matching may increase
         // the length of an occurrence)
         let slop = if include_slop { self.search_string.as_ref().unwrap().len() * 2 } else { 0 };
-        let mut invalidate_from = None;
 
-        for (_start, end) in self.valid_search.minus_one_range(start, end) {
             let search_string = self.search_string.as_ref().unwrap();
 
             // expand region to be able to find occurrences around the region's edges
-            let from = max(0, slop) - slop;
+            let from = max(start, slop) - slop;
             let to = min(end + slop, text.len());
 
             // TODO: this interval might cut a unicode codepoint, make sure it is
             // aligned to codepoint boundaries.
-            let text = text.subseq(Interval::new_closed_open(0, to));
-            let mut cursor = Cursor::new(&text, from);
-            while let Some(start) = find(&mut cursor, self.case_matching, &search_string) {
-                let end = cursor.pos();
+            let sub_text = text.subseq(Interval::new_closed_open(0, to));
+            let mut find_cursor = Cursor::new(&sub_text, from);
+            while let Some(start) = find(&mut find_cursor, self.case_matching, &search_string) {
+                let end = find_cursor.pos();
 
                 let region = SelRegion::new(start, end);
-                let prev_len = self.occurrences.len();
                 let (_, e) = self.occurrences.add_range_distinct(region);
                 // in case of ambiguous search results (e.g. search "aba" in "ababa"),
                 // the search result closer to the beginning of the file wins
@@ -206,43 +213,12 @@ impl Find {
                     // Skip the search result and keep the occurrence that is closer to
                     // the beginning of the file. Re-align the cursor to the kept
                     // occurrence
-                    cursor.set(e);
+                    find_cursor.set(e);
                     continue;
                 }
-
-                // add_range_distinct() above removes ambiguous regions after the added
-                // region, if something has been deleted, everything thereafter is
-                // invalidated
-                if self.occurrences.len() != prev_len + 1 {
-                    invalidate_from = Some(end);
-                    self.occurrences.delete_range(end, text_len, false);
-                    break;
-                }
-            }
         }
 
-        if let Some(invalidate_from) = invalidate_from {
-            self.valid_search.union_one_range(start, invalidate_from);
-
-            // invalidate all search results from the point of the ambiguous search result until ...
-            let is_multi_line = LinesMetric::next(self.search_string.as_ref().unwrap(), 0).is_some();
-            if is_multi_line {
-                // ... the end of the file
-                self.valid_search.delete_range(invalidate_from, text_len);
-            } else {
-                // ... the end of the line
-                let mut cursor = Cursor::new(&text, invalidate_from);
-                if let Some(end_of_line) = cursor.next::<LinesMetric>() {
-                    self.valid_search.delete_range(invalidate_from, end_of_line);
-                }
-            }
-
-            // continue with the find for the current region
-            self.update_find(text, invalidate_from, end, false);
-        } else {
-            self.valid_search.union_one_range(start, end);
-            self.hls_dirty = true;
-        }
+        self.hls_dirty = true;
     }
 
     /// Return the occurrence closest to the provided selection `sel`. If searched is reversed then

--- a/rust/core-lib/src/find.rs
+++ b/rust/core-lib/src/find.rs
@@ -25,6 +25,22 @@ use xi_rope::interval::Interval;
 use selection::{Selection, SelRegion};
 use xi_rope::tree::Metric;
 
+/// Information about search queries and number of matches for find
+#[derive(Serialize, Deserialize, Debug)]
+pub struct FindStatus {
+    /// The current search query.
+    chars: Option<String>,
+
+    /// Whether the active search is case matching.
+    case_sensitive: Option<bool>,
+
+    /// Whether the search query is considered as regular expression.
+    is_regex: Option<bool>,
+
+    /// Total number of matches.
+    matches: usize
+}
+
 /// Contains logic to search text
 pub struct Find {
     // todo: link to search query so that search results can be correlated back to query
@@ -63,16 +79,13 @@ impl Find {
         self.hls_dirty
     }
 
-    pub fn search_string(&self) -> &Option<String> {
-        &self.search_string
-    }
-
-    pub fn is_case_sensitive(&self) -> bool {
-        self.case_matching == CaseMatching::Exact
-    }
-
-    pub fn is_regex(&self) -> bool {
-        self.is_regex
+    pub fn find_status(&self) -> FindStatus {
+        FindStatus {
+            chars: self.search_string.clone(),
+            case_sensitive: Some(self.case_matching == CaseMatching::Exact),
+            is_regex: Some(self.is_regex),
+            matches: self.occurrences.len(),
+        }
     }
 
     pub fn set_hls_dirty(&mut self, is_dirty: bool) {

--- a/rust/core-lib/src/find.rs
+++ b/rust/core-lib/src/find.rs
@@ -79,12 +79,21 @@ impl Find {
         self.hls_dirty
     }
 
-    pub fn find_status(&self) -> FindStatus {
-        FindStatus {
-            chars: self.search_string.clone(),
-            case_sensitive: Some(self.case_matching == CaseMatching::Exact),
-            is_regex: Some(self.is_regex),
-            matches: self.occurrences.len(),
+    pub fn find_status(&self, matches_only: bool) -> FindStatus {
+        if matches_only {
+            FindStatus {
+                chars: None,
+                case_sensitive: None,
+                is_regex: None,
+                matches: self.occurrences.len(),
+            }
+        } else {
+            FindStatus {
+                chars: self.search_string.clone(),
+                case_sensitive: Some(self.case_matching == CaseMatching::Exact),
+                is_regex: Some(self.is_regex),
+                matches: self.occurrences.len(),
+            }
         }
     }
 

--- a/rust/core-lib/src/find.rs
+++ b/rust/core-lib/src/find.rs
@@ -192,30 +192,30 @@ impl Find {
         // the length of an occurrence)
         let slop = if include_slop { self.search_string.as_ref().unwrap().len() * 2 } else { 0 };
 
-            let search_string = self.search_string.as_ref().unwrap();
+        let search_string = self.search_string.as_ref().unwrap();
 
-            // expand region to be able to find occurrences around the region's edges
-            let from = max(start, slop) - slop;
-            let to = min(end + slop, text.len());
+        // expand region to be able to find occurrences around the region's edges
+        let from = max(start, slop) - slop;
+        let to = min(end + slop, text.len());
 
-            // TODO: this interval might cut a unicode codepoint, make sure it is
-            // aligned to codepoint boundaries.
-            let sub_text = text.subseq(Interval::new_closed_open(0, to));
-            let mut find_cursor = Cursor::new(&sub_text, from);
-            while let Some(start) = find(&mut find_cursor, self.case_matching, &search_string) {
-                let end = find_cursor.pos();
+        // TODO: this interval might cut a unicode codepoint, make sure it is
+        // aligned to codepoint boundaries.
+        let sub_text = text.subseq(Interval::new_closed_open(0, to));
+        let mut find_cursor = Cursor::new(&sub_text, from);
+        while let Some(start) = find(&mut find_cursor, self.case_matching, &search_string) {
+            let end = find_cursor.pos();
 
-                let region = SelRegion::new(start, end);
-                let (_, e) = self.occurrences.add_range_distinct(region);
-                // in case of ambiguous search results (e.g. search "aba" in "ababa"),
-                // the search result closer to the beginning of the file wins
-                if e != end {
-                    // Skip the search result and keep the occurrence that is closer to
-                    // the beginning of the file. Re-align the cursor to the kept
-                    // occurrence
-                    find_cursor.set(e);
-                    continue;
-                }
+            let region = SelRegion::new(start, end);
+            let (_, e) = self.occurrences.add_range_distinct(region);
+            // in case of ambiguous search results (e.g. search "aba" in "ababa"),
+            // the search result closer to the beginning of the file wins
+            if e != end {
+                // Skip the search result and keep the occurrence that is closer to
+                // the beginning of the file. Re-align the cursor to the kept
+                // occurrence
+                find_cursor.set(e);
+                continue;
+            }
         }
 
         self.hls_dirty = true;

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -381,6 +381,12 @@ pub enum EditNotification {
     Gesture { line: u64, col: u64, ty: GestureType},
     Undo,
     Redo,
+    /// Searches the document for `chars`, if present, falling back on
+    /// the last selection region if `chars` is `None`.
+    ///
+    /// If `chars` is `None` and there is an active selection, returns
+    /// the string value used for the search, else returns `Null`.
+    Find { chars: Option<String>, case_sensitive: bool },
     FindNext { wrap_around: Option<bool>, allow_same: Option<bool> },
     FindPrevious { wrap_around: Option<bool> },
     DebugRewrap,
@@ -405,12 +411,6 @@ pub enum EditRequest {
     /// Copies the active selection, returning their contents or
     /// or `Null` if the selection was empty.
     Copy,
-    /// Searches the document for `chars`, if present, falling back on
-    /// the last selection region if `chars` is `None`.
-    ///
-    /// If `chars` is `None` and there is an active selection, returns
-    /// the string value used for the search, else returns `Null`.
-    Find { chars: Option<String>, case_sensitive: bool },
 }
 
 

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -78,7 +78,20 @@ pub struct View {
 
     /// Tracks whether there has been changes in find results or find parameters.
     /// This is used to determined whether FindStatus should be sent to the frontend.
-    find_changed: bool,
+    find_changed: FindStatusChange,
+}
+
+/// Indicates what changed in the find state.
+#[derive(PartialEq, Debug)]
+enum FindStatusChange {
+    /// None of the find parameters or number of matches changed.
+    None,
+
+    /// Find parameters and number of matches changed.
+    All,
+
+    /// Only number of matches changed
+    Matches
 }
 
 /// The visual width of the buffer for the purpose of word wrapping.
@@ -126,7 +139,7 @@ impl View {
             wrap_col: WrapWidth::None,
             lc_shadow: LineCacheShadow::default(),
             find: Vec::new(),
-            find_changed: false,
+            find_changed: FindStatusChange::None,
         }
     }
 
@@ -582,6 +595,12 @@ impl View {
     {
         if !self.lc_shadow.needs_render(plan) { return; }
 
+        // send updated find status only if there have been changes
+        if self.find_changed != FindStatusChange::None {
+            let matches_only = self.find_changed == FindStatusChange::Matches;
+            client.find_status(self.view_id, &json!(self.find_status(matches_only)));
+        }
+
         let mut b = line_cache_shadow::Builder::new();
         let mut ops = Vec::new();
         let mut line_num = 0;  // tracks old line cache
@@ -654,11 +673,11 @@ impl View {
 
     /// Determines the current number of find results and search parameters to send them to
     /// the frontend.
-    pub fn find_status(&mut self) -> Vec<FindStatus> {
-        self.find_changed = false;
+    pub fn find_status(&mut self, matches_only: bool) -> Vec<FindStatus> {
+        self.find_changed = FindStatusChange::None;
 
         self.find.iter().map(|find| {
-            find.find_status()
+            find.find_status(matches_only)
         }).collect::<Vec<FindStatus>>()
     }
 
@@ -810,11 +829,6 @@ impl View {
             find.update_highlights(text, delta);
         }
 
-        // send updated find status only if there have been changes
-        if self.find_changed {
-            client.find_status(self.view_id, &json!(self.find_status()));
-        }
-
         // Note: for committing plugin edits, we probably want to know the priority
         // of the delta so we can set the cursor before or after the edit, as needed.
         let new_sel = self.selection.apply_delta(delta, true, keep_selections);
@@ -837,7 +851,7 @@ impl View {
         };
 
         self.set_dirty(text);
-        self.find_changed = true;
+        self.find_changed = FindStatusChange::Matches;
 
         // todo: this will be changed once multiple queries are supported
         // todo: for now only a single search query is supported however in the future

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -644,6 +644,23 @@ impl View {
         }
     }
 
+    /// Determines the current number of find results and search parameters to send them to
+    /// the frontend.
+    pub fn send_find_status(&self, client: &Client) {
+        // todo: optional attributes
+
+        let find_status: Vec<Value> = self.find.iter().map(|find| {
+            json!({
+                "chars": find.search_string(),
+                "case_sensitive": find.is_case_sensitive(),
+                "is_regex": find.is_regex(),
+                "matches": find.occurrences().len(),
+            })
+        }).collect();
+
+        client.find_status(self.view_id, &json!(find_status));
+    }
+
     /// Update front-end with any changes to view since the last time sent.
     /// The `pristine` argument indicates whether or not the buffer has
     /// unsaved changes.
@@ -791,6 +808,7 @@ impl View {
         for find in &mut self.find {
             find.update_highlights(text, delta);
         }
+
 
         // Note: for committing plugin edits, we probably want to know the priority
         // of the delta so we can set the cursor before or after the edit, as needed.

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -829,6 +829,8 @@ impl View {
             find.update_highlights(text, delta);
         }
 
+        self.find_changed = FindStatusChange::Matches;
+
         // Note: for committing plugin edits, we probably want to know the priority
         // of the delta so we can set the cursor before or after the edit, as needed.
         let new_sel = self.selection.apply_delta(delta, true, keep_selections);

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -37,6 +37,7 @@ use width_cache::WidthCache;
 use word_boundaries::WordCursor;
 use find::Find;
 use linewrap;
+use internal::find::FindStatus;
 
 type StyleMap = RefCell<ThemeStyleMap>;
 
@@ -108,22 +109,6 @@ struct DragState {
 
     /// End of the region selected when drag was started.
     max: usize,
-}
-
-/// Information about search queries and number of matches for find
-#[derive(Serialize, Deserialize, Debug)]
-pub struct FindStatus {
-    /// The current search query.
-    chars: Option<String>,
-
-    /// Whether the active search is case matching.
-    case_sensitive: Option<bool>,
-
-    /// Whether the search query is considered as regular expression.
-    is_regex: Option<bool>,
-
-    /// Total number of matches.
-    matches: usize
 }
 
 impl View {
@@ -673,12 +658,7 @@ impl View {
         self.find_changed = false;
 
         self.find.iter().map(|find| {
-            FindStatus {
-                chars: find.search_string().clone(),
-                case_sensitive: Some(find.is_case_sensitive()),
-                is_regex: Some(find.is_regex()),
-                matches: find.occurrences().len(),
-            }
+            find.find_status()
         }).collect::<Vec<FindStatus>>()
     }
 

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -140,7 +140,7 @@ impl View {
         self.pending_render
     }
 
-    pub(crate) fn do_edit(&mut self, text: &Rope, cmd: ViewEvent) {
+    pub(crate) fn do_edit(&mut self, text: &Rope, cmd: ViewEvent, client: &Client) {
         use self::ViewEvent::*;
         match cmd {
             Move(movement) => self.do_move(text, movement, false),

--- a/rust/core-lib/tests/rpc.rs
+++ b/rust/core-lib/tests/rpc.rs
@@ -275,7 +275,7 @@ const OTHER_EDIT_RPCS: &str = r#"{"method":"edit","params":{"view_id":"view-id-1
 {"method":"edit","params":{"view_id":"view-id-1","method":"gesture","params":{"line": 1, "col": 2, "ty": "word_select"}}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"gesture","params":{"line": 1, "col": 2, "ty": "multi_line_select"}}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"gesture","params":{"line": 1, "col": 2, "ty": "multi_word_select"}}}
-{"id":4,"method":"edit","params":{"view_id":"view-id-1","method":"find","params":{"case_sensitive":false,"chars":"m"}}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"find","params":{"case_sensitive":false,"chars":"m"}}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"find_next","params":{"wrap_around":true}}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"find_previous","params":{"wrap_around":true}}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"debug_rewrap","params":[]}}

--- a/rust/rope/src/find.rs
+++ b/rust/rope/src/find.rs
@@ -78,6 +78,11 @@ pub fn find(cursor: &mut Cursor<RopeInfo>, cm: CaseMatching, pat: &str) -> Optio
 pub fn find_progress(cursor: &mut Cursor<RopeInfo>, cm: CaseMatching, pat: &str,
     num_steps: usize) -> FindResult
 {
+    // empty search string
+    if pat.is_empty() {
+        return FindResult::NotFound
+    }
+
     match cm {
         CaseMatching::Exact => {
             let b = pat.as_bytes()[0];


### PR DESCRIPTION
After the find status (search query, search options, ...) change the core will send `find_status` to the frontend. `find_status` provides information about the number of matches but also about the query stored in the core (this will allow to only store the query in the core and not in the frontend = future work).

I will also update the documentation to add `find_status` to the RPC commands after getting some feedback on this. 