### PR TITLE
Added Initialize method to Plugin Trait

### DIFF
--- a/rust/plugin-lib/src/core_proxy.rs
+++ b/rust/plugin-lib/src/core_proxy.rs
@@ -1,0 +1,31 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A proxy for the methods on Core
+
+use xi_rpc::{RpcCtx, RpcPeer};
+
+#[derive(Clone)]
+pub struct CoreProxy {
+    peer: RpcPeer
+}
+
+impl CoreProxy {
+
+    pub fn new(rpc_ctx: &RpcCtx) -> Self {
+        CoreProxy {
+            peer: rpc_ctx.get_peer().clone()
+        }
+    }
+}

--- a/rust/plugin-lib/src/dispatch.rs
+++ b/rust/plugin-lib/src/dispatch.rs
@@ -21,6 +21,7 @@ use xi_core::{ViewIdentifier, PluginPid, ConfigTable};
 use xi_core::plugin_rpc::{PluginBufferInfo, PluginUpdate, HostRequest, HostNotification};
 use xi_rpc::{RpcCtx, RemoteError, Handler as RpcHandler};
 use xi_trace::{self, trace, trace_block, trace_block_payload};
+use core_proxy::CoreProxy;
 
 use super::{Plugin, View};
 
@@ -72,6 +73,10 @@ impl<'a, P: 'a + Plugin> Dispatcher<'a, P> {
         assert!(self.pid.is_none(), "initialize rpc received with existing pid");
         eprintln!("Initializing plugin {:?}", plugin_id);
         self.pid = Some(plugin_id);
+
+        let core_proxy = CoreProxy::new(ctx);
+        self.plugin.initialize(core_proxy);
+        
         self.do_new_buffer(ctx, buffers);
     }
 

--- a/rust/plugin-lib/src/lib.rs
+++ b/rust/plugin-lib/src/lib.rs
@@ -30,6 +30,7 @@ mod state_cache;
 mod base_cache;
 mod view;
 mod dispatch;
+mod core_proxy;
 
 use std::io;
 use std::path::Path;
@@ -44,6 +45,7 @@ use self::dispatch::Dispatcher;
 pub use view::View;
 pub use state_cache::StateCache;
 pub use base_cache::ChunkCache;
+pub use core_proxy::CoreProxy;
 
 /// Abstracts getting data from the peer. Mainly exists for mocking in tests.
 pub trait DataSource {
@@ -108,6 +110,12 @@ pub trait Cache {
 /// Users of this library must implement this trait for some type.
 pub trait Plugin {
     type Cache: Cache;
+
+    /// Called when the Plugin is initialized. The plugin receives CoreProxy
+    /// object that is a wrapper around the RPC Peer and can be used to call
+    /// related methods on the Core in a type-safe manner.
+    #[allow(unused_variables)]
+    fn initialize(&mut self, core: CoreProxy) {}
 
     /// Called when an edit has occurred in the remote view. If the plugin wishes
     /// to add its own edit, it must do so using asynchronously via the edit notification.


### PR DESCRIPTION
Added an Initialize method to the Plugin Trait. The Plugin can use this method to stash the RpcCtx to send 
RPCs asynchronously. 

An example use case is Language Server Plugin. The Language Server sends diagnostics to the Plugin asynchronously as JSON RPC Spec 2.0 Notifications, they must be forwarded to Core -> Client for it to display. But currently RPCs can be sent only using View Proxy that holds an RpcPeer reference which is in scope when the specified methods for new view/ update are dispatched by the Dispatcher. 
But plugin needs raw access to RPC peer to send notifications asynchronously as they arrive. So it can now stash a reference to the RPC Peer in the initialize method.