### PR TITLE
Include plugin name with AddStatusItem RPC

### DIFF
--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -380,11 +380,9 @@ this writing, the following is valid json for a `Command` object:
 
 #### add_status_item
 
-`add_status_item { plugin, key: "my_key", value: "hello", alignment: "left" }`
+`add_status_item { source: "status_example", key: "my_key", value: "hello", alignment: "left" }`
 
-Adds a status item, which will be displayed on the frontend's status bar. The alignment key dictates whether this item appears on the left side or the right side of the bar. This alignment can only be set when the item is added.
-
-When sent, the RPC also sends the plugin name for which the status item belongs to. 
+Adds a status item, which will be displayed on the frontend's status bar. Status items have a reference to whichever plugin added them. The alignment key dictates whether this item appears on the left side or the right side of the bar. This alignment can only be set when the item is added.
 
 #### update_status_item
 

--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -380,7 +380,7 @@ this writing, the following is valid json for a `Command` object:
 
 #### add_status_item
 
-`add_status_item { key: "my_key", value: "hello", alignment: "left" }`
+`add_status_item { plugin, key: "my_key", value: "hello", alignment: "left" }`
 
 Adds a status item, which will be displayed on the frontend's status bar. The alignment key dictates whether this item appears on the left side or the right side of the bar. This alignment can only be set when the item is added.
 

--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -384,6 +384,8 @@ this writing, the following is valid json for a `Command` object:
 
 Adds a status item, which will be displayed on the frontend's status bar. The alignment key dictates whether this item appears on the left side or the right side of the bar. This alignment can only be set when the item is added.
 
+When sent, the RPC also sends the plugin name for which the status item belongs to. 
+
 #### update_status_item
 
 `update_status_item { key: "my_key", value: "hello"}`

--- a/rust/core-lib/src/TEST
+++ b/rust/core-lib/src/TEST
@@ -1,1 +1,0 @@
-  2. Press  v  and move the cursor to the fifth item below.  Notice that the

--- a/rust/core-lib/src/TEST
+++ b/rust/core-lib/src/TEST
@@ -1,0 +1,1 @@
+  2. Press  v  and move the cursor to the fifth item below.  Notice that the

--- a/rust/core-lib/src/client.rs
+++ b/rust/core-lib/src/client.rs
@@ -19,7 +19,7 @@ use std::time::Instant;
 use serde_json::{self, Value};
 use xi_rpc::{self, RpcPeer};
 
-use tabs::{ViewId};
+use tabs::ViewId;
 use config::Table;
 use styles::ThemeSettings;
 use plugins::rpc::ClientPluginInfo;

--- a/rust/core-lib/src/client.rs
+++ b/rust/core-lib/src/client.rs
@@ -147,10 +147,10 @@ impl Client {
         self.0.send_rpc_notification("alert", &json!({ "msg": msg.as_ref() }));
     }
 
-    pub fn add_status_item(&self, view_id: ViewId, plugin: &str, key: &str, value: &str, alignment: &str) {
+    pub fn add_status_item(&self, view_id: ViewId, source: &str, key: &str, value: &str, alignment: &str) {
         self.0.send_rpc_notification("add_status_item", &json!(
             {   "view_id": view_id,
-                "plugin": plugin,
+                "source": source,
                 "key": key,
                 "value": value,
                 "alignment": alignment

--- a/rust/core-lib/src/client.rs
+++ b/rust/core-lib/src/client.rs
@@ -19,7 +19,7 @@ use std::time::Instant;
 use serde_json::{self, Value};
 use xi_rpc::{self, RpcPeer};
 
-use tabs::ViewId;
+use tabs::{ViewId};
 use config::Table;
 use styles::ThemeSettings;
 use plugins::rpc::ClientPluginInfo;
@@ -147,9 +147,10 @@ impl Client {
         self.0.send_rpc_notification("alert", &json!({ "msg": msg.as_ref() }));
     }
 
-    pub fn add_status_item(&self, view_id: ViewId, key: &str, value: &str, alignment: &str) {
+    pub fn add_status_item(&self, view_id: ViewId, plugin: &str, key: &str, value: &str, alignment: &str) {
         self.0.send_rpc_notification("add_status_item", &json!(
             {   "view_id": view_id,
+                "plugin": plugin,
                 "key": key,
                 "value": value,
                 "alignment": alignment

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -164,9 +164,8 @@ impl<'a> EventContext<'a> {
                 |ed, _, _, _| ed.apply_plugin_edit(edit)),
             Alert { msg } => self.client.alert(&msg),
             AddStatusItem { key, value, alignment }  => {
-            let plugin_name = &self.plugins.iter().find(|p| p.id == plugin).unwrap().name;
-            self.client.add_status_item(
-                                                        self.view_id, plugin_name, &key, &value, &alignment);
+            	let plugin_name = &self.plugins.iter().find(|p| p.id == plugin).unwrap().name;
+            	self.client.add_status_item(self.view_id, plugin_name, &key, &value, &alignment);
             }
             UpdateStatusItem { key, value } => self.client.update_status_item(
                                                         self.view_id, &key, &value),

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -163,8 +163,11 @@ impl<'a> EventContext<'a> {
             Edit { edit } => self.with_editor(
                 |ed, _, _, _| ed.apply_plugin_edit(edit)),
             Alert { msg } => self.client.alert(&msg),
-            AddStatusItem { key, value, alignment }  => self.client.add_status_item(
-                                                        self.view_id, &key, &value, &alignment),
+            AddStatusItem { key, value, alignment }  => {
+            let plugin_name = &self.plugins.iter().find(|p| p.id == plugin).unwrap().name;
+            self.client.add_status_item(
+                                                        self.view_id, plugin_name, &key, &value, &alignment);
+            }
             UpdateStatusItem { key, value } => self.client.update_status_item(
                                                         self.view_id, &key, &value),
             RemoveStatusItem { key } => self.client.remove_status_item(self.view_id, &key)


### PR DESCRIPTION
This PR makes adding the status item include the plugin name from which it originates, so that client can manage items that come from the same plugin.

companion to xi-mac [#210](https://github.com/google/xi-mac/pull/210)