### PR TITLE
Tweak CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,5 @@ cache:
 script:
   - cd rust
   - export CARGO_TARGET_DIR=/tmp/target
-  - cargo build || exit
-  - cargo build --manifest-path syntect-plugin/Cargo.toml || exit
-  - for MANIFEST in Cargo.toml */Cargo.toml; do cargo test --manifest-path $MANIFEST || exit; done
+  - cargo build --all || exit
+  - cargo test --all || exit

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,3 +16,17 @@ path = "core-lib"
 
 [dependencies.xi-rpc]
 path = "rpc"
+
+[workspace]
+members = [
+  "core-lib",
+  "lsp-lib",
+  "plugin-lib",
+  "rope",
+  "rpc",
+  "sample-plugin",
+  "syntect-plugin",
+  "trace",
+  "trace-dump",
+  "unicode",
+]


### PR DESCRIPTION
By leveraging `--all` flag so everything can be executed in parallel.

It makes CI builds about 2 times faster from ~10 minutes to ~5 minutes.