### PR TITLE
update Makefiles to use cargo workspace

### DIFF
--- a/rust/lsp-lib/Makefile
+++ b/rust/lsp-lib/Makefile
@@ -14,12 +14,13 @@ XDG_CONFIG_HOME ?= $(HOME)/.config
 XI_CONFIG_DIR ?= $(XDG_CONFIG_HOME)/xi
 XI_PLUGIN_DIR ?= $(XI_CONFIG_DIR)/plugins
 
-target/release/$(PLUGIN_BIN):
+.PHONY: $(PLUGIN_BIN)
+$(PLUGIN_BIN):
 	cargo build  --bin xi-lsp-plugin --release
 
 install: manifest.toml target/release/$(PLUGIN_BIN)
 	install -d $(XI_PLUGIN_DIR)/$(PLUGIN_NAME)/bin
 	install manifest.toml $(XI_PLUGIN_DIR)/$(PLUGIN_NAME)
-	install target/release/$(PLUGIN_BIN) $(XI_PLUGIN_DIR)/$(PLUGIN_NAME)/bin
+	install ../target/release/$(PLUGIN_BIN) $(XI_PLUGIN_DIR)/$(PLUGIN_NAME)/bin
 
 .PHONY: install

--- a/rust/sample-plugin/Makefile
+++ b/rust/sample-plugin/Makefile
@@ -14,12 +14,13 @@ XDG_CONFIG_HOME ?= $(HOME)/.config
 XI_CONFIG_DIR ?= $(XDG_CONFIG_HOME)/xi
 XI_PLUGIN_DIR ?= $(XI_CONFIG_DIR)/plugins
 
-out/$(PLUGIN_NAME): target/release/$(PLUGIN_BIN)
+out/$(PLUGIN_NAME): $(PLUGIN_BIN)
 	mkdir -p out/$(PLUGIN_NAME)/bin
-	cp target/release/$(PLUGIN_BIN) out/$(PLUGIN_NAME)/bin
+	cp ../target/release/$(PLUGIN_BIN) out/$(PLUGIN_NAME)/bin
 	cp manifest.toml out/$(PLUGIN_NAME)/manifest.toml
 
-target/release/$(PLUGIN_BIN): src/*.rs Cargo.toml Cargo.lock
+.PHONY: $(PLUGIN_BIN)
+$(PLUGIN_BIN):
 	cargo build --release
 
 install: manifest.toml out/$(PLUGIN_NAME)

--- a/rust/syntect-plugin/Makefile
+++ b/rust/syntect-plugin/Makefile
@@ -6,13 +6,14 @@ XI_PLUGIN_DIR ?= $(XI_CONFIG_DIR)/plugins
 
 lang_configs = assets/*.toml
 
-out/syntect: $(lang_configs) target/release/xi-syntect-plugin
+out/syntect: $(lang_configs) xi-syntect-plugin
 	mkdir -p out/syntect/bin
 	cp $(lang_configs) out/syntect
-	cp target/release/xi-syntect-plugin out/syntect/bin
+	cp ../target/release/xi-syntect-plugin out/syntect/bin
 	cp manifest.toml out/syntect/manifest.toml
 
-target/release/xi-syntect-plugin: src/*.rs Cargo.toml Cargo.lock
+.PHONY: xi-syntect-plugin
+xi-syntect-plugin:
 	cargo build --release
 
 install: out/syntect


### PR DESCRIPTION
Additionally makes the cargo build targets `.PHONY` so that `cargo`
controls rebuilds.