### PR TITLE
Handle plugin exit

### DIFF
--- a/rust/core-lib/src/core.rs
+++ b/rust/core-lib/src/core.rs
@@ -17,7 +17,7 @@ use std::io;
 
 use serde_json::Value;
 
-use xi_rpc::{RpcCtx, Handler, RemoteError, Error as RpcError};
+use xi_rpc::{RpcCtx, Handler, RemoteError, Error as RpcError, ReadError};
 use xi_trace;
 
 use plugin_rpc::{PluginCommand, PluginNotification, PluginRequest};
@@ -138,6 +138,13 @@ impl WeakXiCore {
     pub fn plugin_connect(&self, plugin: Result<Plugin, io::Error>) {
         if let Some(core) = self.upgrade() {
             core.inner().plugin_connect(plugin)
+        }
+    }
+
+    /// Called from a plugin runloop thread when the runloop exits.
+    pub fn plugin_exit(&self, plugin: PluginId, error: Result<(), ReadError>) {
+        if let Some(core) = self.upgrade() {
+            core.inner().plugin_exit(plugin, error)
         }
     }
 

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -106,7 +106,7 @@ impl Plugin {
     }
 
     pub fn update<F>(&self, update: &PluginUpdate, callback: F)
-where F: FnOnce(Result<Value, xi_rpc::Error>) + Send + 'static
+        where F: FnOnce(Result<Value, xi_rpc::Error>) + Send + 'static
     {
         self.peer.send_rpc_request_async("update", &json!(update),
                                          Box::new(callback))
@@ -123,8 +123,8 @@ where F: FnOnce(Result<Value, xi_rpc::Error>) + Send + 'static
     }
 
     pub fn config_changed(&self, view_id: ViewId, changes: &Table) {
-        self.peer.send_rpc_notification("config_changed", 
-                                        &json!({"view_id": view_id, 
+        self.peer.send_rpc_notification("config_changed",
+                                        &json!({"view_id": view_id,
                                                 "changes": changes}))
     }
 }
@@ -145,7 +145,7 @@ pub(crate) fn start_plugin_process(plugin_desc: Arc<PluginDescription>,
                 let mut looper = RpcLoop::new(child_stdin);
                 let peer: RpcPeer = Box::new(looper.get_raw_peer());
                 let name = plugin_desc.name.clone();
-peer.send_rpc_notification("ping", &Value::Array(Vec::new()));
+                peer.send_rpc_notification("ping", &Value::Array(Vec::new()));
                 let plugin = Plugin { peer, process: child, name, id };
 
                 // set tracing immediately
@@ -154,10 +154,10 @@ peer.send_rpc_notification("ping", &Value::Array(Vec::new()));
                 }
 
                 core.plugin_connect(Ok(plugin));
-                //TODO: we could be logging plugin exit results
                 let mut core = core;
-                let _ = looper.mainloop(|| BufReader::new(child_stdout),
-                                        &mut core);
+                let err = looper.mainloop(|| BufReader::new(child_stdout),
+                                          &mut core);
+                core.plugin_exit(id, err);
             }
             Err(err) => core.plugin_connect(Err(err)),
         }


### PR DESCRIPTION
This logs when a plugin exits, removes that plugin from the list of
running plugins, and notifies the client.

This patch also includes some minor cleanup in the edited files.