### PR TITLE
Quickfix for the Makefile problem in LSP Plugin

### DIFF
--- a/rust/lsp-lib/Makefile
+++ b/rust/lsp-lib/Makefile
@@ -18,7 +18,7 @@ XI_PLUGIN_DIR ?= $(XI_CONFIG_DIR)/plugins
 $(PLUGIN_BIN):
 	cargo build  --bin xi-lsp-plugin --release
 
-install: manifest.toml target/release/$(PLUGIN_BIN)
+install: manifest.toml $(PLUGIN_BIN)
 	install -d $(XI_PLUGIN_DIR)/$(PLUGIN_NAME)/bin
 	install manifest.toml $(XI_PLUGIN_DIR)/$(PLUGIN_NAME)
 	install ../target/release/$(PLUGIN_BIN) $(XI_PLUGIN_DIR)/$(PLUGIN_NAME)/bin


### PR DESCRIPTION
The current makefile for LSP Plugin does not work due to changes introduced while adding Cargo Workspaces support. This fixes that.