### PR TITLE
 Improve EditType and undo grouping

### DIFF
--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -106,7 +106,16 @@ inner methods described below:
 
 `insert {"chars":"A"}`
 
-Inserts the `chars` string at the current cursor location.
+Inserts the `chars` string at the current cursor locations.
+
+#### paste
+
+`paste {"chars": "password"}`
+
+Inserts the `chars` string at the current cursor locations. If there are
+multiple cursors and `chars` has the same number of lines as there are
+cursors, one line will be inserted at each cursor, in order; otherwise the full
+string will be inserted at each cursor.
 
 #### cancel_operation
 

--- a/rust/core-lib/src/edit_types.rs
+++ b/rust/core-lib/src/edit_types.rs
@@ -58,6 +58,7 @@ pub(crate) enum BufferEvent {
     Indent,
     Outdent,
     Insert(String),
+    Paste(String),
     InsertNewline,
     InsertTab,
     Yank,
@@ -104,6 +105,8 @@ impl From<EditNotification> for EventDomain {
         match src {
             Insert { chars } =>
                 BufferEvent::Insert(chars).into(),
+            Paste { chars } =>
+                BufferEvent::Paste(chars).into(),
             DeleteForward =>
                 BufferEvent::Delete {
                     movement: Movement::Right,

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -804,10 +804,9 @@ pub enum EditType {
 impl EditType {
     /// Checks whether a new undo group should be created between two edits.
     fn breaks_undo_group(self, previous: EditType) -> bool {
-        if self == EditType::Other || self == EditType::Transpose {
-            return true;
-        }
-        self != previous
+        self == EditType::Other
+        || self == EditType::Transpose
+        || self != previous
     }
 }
 

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -18,7 +18,7 @@ use std::collections::BTreeSet;
 
 use serde_json::Value;
 
-use xi_rope::rope::{Rope, RopeInfo, LinesMetric};
+use xi_rope::rope::{Rope, RopeInfo, LinesMetric, count_newlines};
 use xi_rope::interval::Interval;
 use xi_rope::delta::{self, Delta, Transformer};
 use xi_rope::engine::{Engine, RevId, RevToken};
@@ -536,11 +536,24 @@ impl Editor {
         tab_text
     }
 
-    // TODO: insert from keyboard or input method shouldn't break undo group,
-    // but paste should.
     fn do_insert(&mut self, view: &View, chars: &str) {
         self.this_edit_type = EditType::InsertChars;
         self.insert(view, chars);
+    }
+
+    fn do_paste(&mut self, view: &View, chars: &str) {
+        if view.sel_regions().len() == 1
+            || view.sel_regions().len() != count_lines(chars)
+        {
+            self.insert(view, chars);
+        } else {
+            let mut builder = delta::Builder::new(self.text.len());
+            for (sel, line) in view.sel_regions().iter().zip(chars.lines()) {
+                let iv = Interval::new_closed_open(sel.min(), sel.max());
+                builder.replace(iv, line.into());
+            }
+            self.add_delta(builder.build());
+        }
     }
 
     pub(crate) fn do_cut(&mut self, view: &mut View) -> Value {
@@ -684,6 +697,7 @@ impl Editor {
             InsertNewline => self.insert_newline(view, config),
             InsertTab => self.insert_tab(view, config),
             Insert(chars) => self.do_insert(view, &chars),
+            Paste(chars) => self.do_paste(view, &chars),
             Yank => self.yank(view, kill_ring),
             ReplaceNext => self.replace(view, false),
             ReplaceAll => self.replace(view, true),
@@ -797,4 +811,13 @@ fn n_spaces(n: usize) -> &'static str {
     let spaces = "                                ";
     assert!(n <= spaces.len());
     &spaces[..n]
+}
+
+/// Counts the number of lines in the string, not including any trailing newline.
+fn count_lines(s: &str) -> usize {
+    let mut newlines = count_newlines(s);
+    if s.as_bytes().last() == Some(&0xa) {
+        newlines -= 1;
+    }
+    1 + newlines
 }

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -139,8 +139,8 @@ impl Editor {
         self.engine.get_head_rev_id().token()
     }
 
-    pub(crate) fn get_edit_type(&self) -> &str {
-        self.this_edit_type.json_string()
+    pub(crate) fn get_edit_type(&self) -> EditType {
+        self.this_edit_type
     }
 
     pub(crate) fn get_active_undo_group(&self) -> usize {
@@ -210,9 +210,7 @@ impl Editor {
         let head_rev_id = self.engine.get_head_rev_id();
         let undo_group;
 
-        if self.this_edit_type == self.last_edit_type
-            && self.this_edit_type != EditType::Other
-            && self.this_edit_type != EditType::Transpose
+        if !self.this_edit_type.breaks_undo_group(self.last_edit_type)
             && !self.live_undos.is_empty()
         {
             undo_group = *self.live_undos.last().unwrap();
@@ -439,18 +437,27 @@ impl Editor {
     }
 
     fn insert_newline(&mut self, view: &View, config: &BufferItems) {
-        self.this_edit_type = EditType::InsertChars;
+        self.this_edit_type = EditType::InsertNewline;
         self.insert(view, &config.line_ending);
     }
 
     fn insert_tab(&mut self, view: &View, config: &BufferItems) {
+        self.this_edit_type = EditType::InsertChars;
         let mut builder = delta::Builder::new(self.text.len());
         let const_tab_text = self.get_tab_text(config, None);
+
+        if view.sel_regions().len() > 1 {
+            // if we indent multiple regions or multiple lines (below),
+            // we treat this as an indentation adjustment; otherwise it is
+            // just inserting text.
+            self.this_edit_type = EditType::Indent;
+        }
 
         for region in view.sel_regions() {
             let line_range = view.get_line_range(&self.text, region);
 
             if line_range.len() > 1 {
+                self.this_edit_type = EditType::Indent;
                 for line in line_range {
                     let offset = view.line_col_to_offset(&self.text, line, 0);
                     let iv = Interval::new_closed_open(offset, offset);
@@ -466,7 +473,6 @@ impl Editor {
                 builder.replace(iv, Rope::from(tab_text));
             }
         }
-        self.this_edit_type = EditType::InsertChars;
         self.add_delta(builder.build());
     }
 
@@ -477,6 +483,7 @@ impl Editor {
     /// Sublime and VSCode, with non-caret selections not being modified.
     fn modify_indent(&mut self, view: &View, config: &BufferItems,
                      direction: IndentDirection) {
+        self.this_edit_type = EditType::Indent;
         let mut lines = BTreeSet::new();
         let tab_text = self.get_tab_text(config, None);
         for region in view.sel_regions() {
@@ -775,10 +782,19 @@ impl Editor {
     }
 }
 
-#[derive(PartialEq, Eq, Clone, Copy)]
-enum EditType {
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EditType {
+    /// A catchall for edits that don't fit elsewhere, and which should
+    /// always have their own undo groups; used for things like cut/copy/paste.
     Other,
+    /// An insert from the keyboard/IME (not a paste or a yank).
+    #[serde(rename = "insert")]
     InsertChars,
+    #[serde(rename = "newline")]
+    InsertNewline,
+    /// An indentation adjustment.
+    Indent,
     Delete,
     Undo,
     Redo,
@@ -786,17 +802,15 @@ enum EditType {
 }
 
 impl EditType {
-    pub fn json_string(&self) -> &'static str {
-        match *self {
-            EditType::InsertChars => "insert",
-            EditType::Delete => "delete",
-            EditType::Undo => "undo",
-            EditType::Redo => "redo",
-            EditType::Transpose => "transpose",
-            _ => "other",
+    /// Checks whether a new undo group should be created between two edits.
+    fn breaks_undo_group(self, previous: EditType) -> bool {
+        if self == EditType::Other || self == EditType::Transpose {
+            return true;
         }
+        self != previous
     }
 }
+
 
 fn last_selection_region(regions: &[SelRegion]) -> Option<&SelRegion> {
     for region in regions.iter().rev() {

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -213,10 +213,9 @@ impl<'a> EventContext<'a> {
         let undo_group = ed.get_active_undo_group();
         //TODO: we want to just put EditType on the wire, but don't want
         //to update the plugin lib quite yet.
-        let edit_type_str = serde_json::to_string(&ed.get_edit_type())
-            .unwrap()
-            .trim_matches('"')
-            .to_string();
+        let v: Value = serde_json::to_value(&ed.get_edit_type()).unwrap();
+        let edit_type_str = v.as_str().unwrap().to_string();
+
         let update = PluginUpdate::new(
                 self.view_id,
                 ed.get_head_rev_token(),

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -211,6 +211,12 @@ impl<'a> EventContext<'a> {
         let delta = if approx_size > MAX_SIZE_LIMIT { None } else { Some(delta) };
 
         let undo_group = ed.get_active_undo_group();
+        //TODO: we want to just put EditType on the wire, but don't want
+        //to update the plugin lib quite yet.
+        let edit_type_str = serde_json::to_string(&ed.get_edit_type())
+            .unwrap()
+            .trim_matches('"')
+            .to_string();
         let update = PluginUpdate::new(
                 self.view_id,
                 ed.get_head_rev_token(),
@@ -218,7 +224,7 @@ impl<'a> EventContext<'a> {
                 new_len,
                 nb_lines,
                 Some(undo_group),
-                ed.get_edit_type().to_owned(),
+                edit_type_str,
                 author.into());
 
 

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -128,6 +128,7 @@ use apps_ledger_services_public::Ledger_Proxy;
 
 pub use config::{BufferItems as BufferConfig, Table as ConfigTable};
 pub use core::{XiCore, WeakXiCore};
+pub use editor::EditType;
 pub use plugins::rpc as plugin_rpc;
 pub use plugins::manifest as plugin_manifest;
 pub use plugins::PluginPid;

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -346,6 +346,7 @@ impl Default for SelectionModifier {
 #[serde(tag = "method", content = "params")]
 pub enum EditNotification {
     Insert { chars: String },
+    Paste { chars: String },
     DeleteForward,
     DeleteBackward,
     DeleteWordForward,

--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -328,7 +328,7 @@ impl Metric<RopeInfo> for Utf16CodeUnitsMetric {
 
 // Low level functions
 
-fn count_newlines(s: &str) -> usize {
+pub fn count_newlines(s: &str) -> usize {
     bytecount::count(s.as_bytes(), b'\n')
 }
 


### PR DESCRIPTION
This is based on #747, which should be approved first.

EditType now has distinct members for 'insert newline' and 'adjust
indentation', and we now use serde instead of a manual fn when putting
EditType on the wire.

closes #742

