### PR TITLE
Corrected UTF16 Code Units metric logic

### DIFF
--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -285,11 +285,11 @@ impl Metric<RopeInfo> for Utf16CodeUnitsMetric {
         let mut cur_len_utf16 = 0;
         let mut cur_len_utf8 = 0;
         for u in s.chars() {
-            cur_len_utf16 += u.len_utf16();
-            cur_len_utf8 += u.len_utf8();
             if cur_len_utf16 >= in_measured_units {
                 break;
             }
+            cur_len_utf16 += u.len_utf16();
+            cur_len_utf8 += u.len_utf8();
         }
         cur_len_utf8
     }


### PR DESCRIPTION
I think the logic for UTF-16 Metric to convert to base metric is incorrect in a sense that if `in_measured_units` is 0 then it will return the length of the first character in string in UTF-8.

However when I ran it to a test case like this

```rust
let rope = Rope::from("hi\ni'm\nfour\nlines");
let utf8_offset = rope.convert_metrics::<Utf16CodeUnitsMetric, BaseMetric>(0);
assert_eq!(utf8_offset, 0);
```

It passes for even the earlier logic but I am not sure if it should have been the case. In any case, the logic of the first is still wrong as per me.