### PR TITLE
Fix incorrectly treating last offset as OOB

### DIFF
--- a/rust/core-lib/src/plugins/rpc.rs
+++ b/rust/core-lib/src/plugins/rpc.rs
@@ -306,7 +306,7 @@ impl TextUnit {
         let text = text.borrow();
         match *self {
             TextUnit::Utf8 => {
-                if offset >= text.len() {
+                if offset > text.len() {
                     None
                 } else {
                     if text.is_codepoint_boundary(offset) {


### PR DESCRIPTION
This bug would manifest if a plugin had no cache and the user attempted
to resolve the line containing the last (EOF) offset.