### PR TITLE
WIP basic completions support in core

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -953,6 +953,7 @@ dependencies = [
  "xi-core-lib 0.2.0",
  "xi-plugin-lib 0.1.0",
  "xi-rope 0.2.0",
+ "xi-rpc 0.2.0",
  "xi-trace 0.1.0",
 ]
 

--- a/rust/core-lib/src/client.rs
+++ b/rust/core-lib/src/client.rs
@@ -20,6 +20,7 @@ use serde_json::{self, Value};
 use xi_rpc::{self, RpcPeer};
 
 use tabs::ViewId;
+use completions::ClientCompletionItem;
 use config::Table;
 use styles::ThemeSettings;
 use plugins::rpc::ClientPluginInfo;
@@ -153,6 +154,24 @@ impl Client {
 
     pub fn alert<S: AsRef<str>>(&self, msg: S) {
         self.0.send_rpc_notification("alert", &json!({ "msg": msg.as_ref() }));
+    }
+
+    /// if `completions` is present but empty, a 'no completions available' message
+    /// should be shown.
+    pub fn completions(&self, view_id: ViewId, pos: usize, selected: usize,
+                       completions: Vec<ClientCompletionItem>) {
+        self.0.send_rpc_notification("completions",
+                                     &json!({
+                                         "view_id": view_id,
+                                         "pos": pos,
+                                         "selected": selected,
+                                         "items": completions,
+                                     }))
+    }
+
+    pub fn hide_completions(&self, view_id: ViewId) {
+        self.0.send_rpc_notification("hide_completions",
+                                     &json!({"view_id": view_id}))
     }
 
     pub fn add_status_item(&self, view_id: ViewId, source: &str, key: &str, value: &str, alignment: &str) {

--- a/rust/core-lib/src/completions.rs
+++ b/rust/core-lib/src/completions.rs
@@ -1,0 +1,150 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{HashMap, HashSet};
+
+use xi_rpc::RemoteError;
+
+use plugins::PluginId;
+use plugins::rpc::{CompletionItem, CompletionResponse};
+
+#[derive(Debug)]
+struct CompletionSource {
+    id: PluginId,
+    is_incomplete: bool,
+    can_resolve: bool,
+}
+
+/// A representation of the state of an autocomplete dialog.
+///
+/// This state is updated as results are returned from various sources,
+/// and as the user continues to type. When the state has changes it
+/// marks itself as dirty, indicating that the client should be updated.
+#[derive(Debug)]
+pub(crate) struct CompletionState {
+    /// threaded through with requests, to ensure we don't handle stale
+    /// responses.
+    pub(crate) id: usize,
+    pub(crate) is_dirty: bool,
+    /// offset of cursor at rev of original request
+    pub(crate) pos: usize,
+    pub(crate) is_cancelled: bool,
+    sources: HashMap<PluginId, CompletionSource>,
+    /// rev of original request?
+    rev: u64,
+    /// sorted
+    items: Vec<(CompletionItem, PluginId)>,
+    selected: usize,
+    /// outstanding requests related to this completion
+    pending: HashSet<PluginId>,
+}
+
+impl CompletionState {
+    pub(crate) fn new(id: usize, pos: usize, rev: u64) -> Self {
+        CompletionState {
+            id,
+            is_dirty: false,
+            sources: HashMap::new(),
+            rev,
+            pos,
+            items: Vec::new(),
+            selected: 0,
+            pending: HashSet::new(),
+            is_cancelled: false,
+        }
+    }
+
+    pub(crate) fn add_pending(&mut self, plugin: PluginId) {
+        self.pending.insert(plugin);
+    }
+
+    pub(crate) fn cancel(&mut self) {
+        self.is_cancelled = true;
+        self.is_dirty = true
+    }
+
+    pub(crate) fn handle_response(&mut self, plugin: PluginId,
+                                  response: Result<CompletionResponse, RemoteError>)
+    {
+        let is_last_response = self.pending.remove(&plugin)
+            && self.pending.is_empty();
+        match response {
+            Ok(response) => {
+                let source = CompletionSource {
+                    id: plugin,
+                    is_incomplete: response.is_incomplete,
+                    can_resolve: response.can_resolve,
+                };
+                self.sources.insert(plugin, source);
+                eprintln!("got completions {:?}", response.items.iter().map(|i| i.label.clone()).collect::<Vec<_>>());
+                self.items.extend(response.items.into_iter().map(|i| (i, plugin)));
+                self.sort_items();
+                self.is_dirty = true;
+            }
+            Err(e) => {
+                eprintln!("completions error: {:?}: {:?}", plugin, e);
+                if is_last_response {
+                    self.is_dirty = true;
+                }
+            }
+        }
+    }
+
+    /// The bits of our state that are used when updating the client:
+    /// The start offset of the text being completed, the index of the selected
+    /// completion item, and the completions themselves.
+    pub(crate) fn client_completions(&self) -> (usize, usize, Vec<ClientCompletionItem>) {
+        let items = self.items.iter()
+            .map(|(item, _)| item.get_client_item())
+            .collect::<Vec<_>>();
+        (self.pos, self.selected, items)
+    }
+
+    fn sort_items(&mut self) {
+        //TODO: update any non-zero selection
+        self.items.sort_by(|a, b| a.0.sort_key().cmp(b.0.sort_key()))
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ClientCompletionItem<'a> {
+    label: &'a str,
+    //kind: Option<usize>,
+    detail: Option<&'a str>,
+    documentation: Option<&'a str>,
+}
+
+impl CompletionItem {
+    // just for testing
+    pub fn with_label<S: AsRef<str>>(label: S) -> Self {
+        let mut item = CompletionItem::default();
+        item.label = label.as_ref().into();
+        item
+    }
+
+    fn sort_key(&self) -> &str {
+        self.sort_text.as_ref()
+            .map(String::as_str)
+            .unwrap_or(self.label.as_str())
+    }
+
+    fn get_client_item(&self) -> ClientCompletionItem {
+        ClientCompletionItem {
+            label: self.label.as_str(),
+            //kind: self.kind.clone(),
+            detail: self.detail.as_ref().map(|s| s.as_str()),
+            documentation: self.documentation.as_ref().map(|s| s.as_str()),
+        }
+    }
+}

--- a/rust/core-lib/src/edit_types.rs
+++ b/rust/core-lib/src/edit_types.rs
@@ -39,6 +39,7 @@ pub(crate) enum ViewEvent {
     FindNext { wrap_around: bool, allow_same: bool, modify_selection: SelectionModifier },
     FindPrevious { wrap_around: bool, allow_same: bool, modify_selection: SelectionModifier },
     FindAll,
+    CompletionsCancel,
     Cancel,
     HighlightFind { visible: bool },
     SelectionForFind { case_sensitive: bool },
@@ -64,6 +65,7 @@ pub(crate) enum BufferEvent {
     Yank,
     ReplaceNext,
     ReplaceAll,
+    CompletionsInsert { index: usize },
 }
 
 /// An event that needs special handling
@@ -71,6 +73,8 @@ pub(crate) enum SpecialEvent {
     DebugRewrap,
     DebugWrapWidth,
     DebugPrintSpans,
+    CompletionsShow,
+    CompletionsSelect { index: usize },
     Resize(Size),
     RequestLines(LineRange),
     RequestHover { request_id: usize, position: Option<Position> },
@@ -216,6 +220,12 @@ impl From<EditNotification> for EventDomain {
             DebugRewrap => SpecialEvent::DebugRewrap.into(),
             DebugWrapWidth => SpecialEvent::DebugWrapWidth.into(),
             DebugPrintSpans => SpecialEvent::DebugPrintSpans.into(),
+            CompletionsShow => SpecialEvent::CompletionsShow.into(),
+            CompletionsCancel => ViewEvent::CompletionsCancel.into(),
+            CompletionsSelect { index } =>
+                SpecialEvent::CompletionsSelect { index }.into(),
+            CompletionsInsert { index } =>
+                BufferEvent::CompletionsInsert { index }.into(),
             CancelOperation => ViewEvent::Cancel.into(),
             Uppercase => BufferEvent::Uppercase.into(),
             Lowercase => BufferEvent::Lowercase.into(),

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -708,6 +708,8 @@ impl Editor {
             Yank => self.yank(view, kill_ring),
             ReplaceNext => self.replace(view, false),
             ReplaceAll => self.replace(view, true),
+            CompletionsInsert { index } =>
+                eprintln!("completions insert ({})", index),
         }
     }
 

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -69,6 +69,7 @@ use ledger_includes::*;
 #[path=""]
 pub mod internal {
     pub mod client;
+    pub mod completions;
     pub mod core;
     pub mod tabs;
     pub mod editor;
@@ -98,6 +99,7 @@ pub mod internal {
 pub mod rpc;
 
 use internal::tabs;
+use internal::completions;
 use internal::core;
 use internal::client;
 use internal::edit_types;

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -134,6 +134,15 @@ impl Plugin {
                                                 "request_id": request_id,
                                                 "position": position}))
     }
+
+    pub fn completions(&self, view_id: ViewId, request_id: usize, pos: usize) {
+        self.peer.send_rpc_notification("completions",
+                                         &json!({
+                                             "view_id": view_id,
+                                             "pos": pos,
+                                             "request_id": request_id,
+                                         }))
+    }
 }
 
 pub(crate) fn start_plugin_process(plugin_desc: Arc<PluginDescription>,

--- a/rust/core-lib/src/plugins/rpc.rs
+++ b/rust/core-lib/src/plugins/rpc.rs
@@ -23,6 +23,7 @@ use serde_json::{self, Value};
 
 use xi_rope::rope::{RopeDelta, Rope, LinesMetric};
 use xi_rpc::RemoteError;
+
 use super::PluginPid;
 use syntax::LanguageId;
 use tabs::{BufferIdentifier, ViewId};
@@ -110,6 +111,7 @@ pub enum HostNotification {
     NewBuffer { buffer_info: Vec<PluginBufferInfo> },
     DidClose { view_id: ViewId },
     GetHover { view_id: ViewId, request_id: usize, position: usize },
+    Completions { view_id: ViewId, request_id: usize, pos: usize },
     Shutdown(EmptyStruct),
     TracingConfig {enabled: bool},
 }
@@ -163,6 +165,55 @@ pub enum TextUnit {
     Line,
 }
 
+/// A suggestion to be displayed in the autocomplete menu.
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct CompletionItem {
+    /// A token used to identify this completion item to its source.
+    /// This is passed back to the source when a 'resolve' request occurs.
+    pub id: usize,
+
+    /// The label of this completion item. By default
+    /// also the text that is inserted when selecting
+    /// this completion.
+    pub label: String,
+
+    //TODO: we want something like this at some point, but let's hold off for now
+    ///// The kind of this completion item. Based of the kind
+    ///// an icon is chosen by the editor.
+    //pub kind: Option<usize>,
+
+    /// A human-readable string with additional information
+    /// about this item, like type or symbol information.
+    pub detail: Option<String>,
+
+    /// A human-readable string that represents a doc-comment.
+    pub documentation: Option<String>,
+
+    /// A string that shoud be used when comparing this item
+    /// with other items.
+    pub sort_text: Option<String>,
+
+    /// A string that should be used when filtering a set of
+    /// completion items.
+    pub filter_text: Option<String>,
+
+    /// An optional delta that will be applied when this item is accepted.
+    /// If present, this will be used instead of `insert_text` or `label`.
+    pub edit: Option<RopeDelta>,
+}
+
+
+/// Returned from a plugin in response to a `completions` RPC.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CompletionResponse {
+    /// if `true`, this plugin should be requeried as the user types.
+    pub is_incomplete: bool,
+    /// If `true`, the plugin should be sent a 'resolve' request when the user
+    /// selects a completion item.
+    pub can_resolve: bool,
+    pub items: Vec<CompletionItem>,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "method", content = "params")]
@@ -173,8 +224,7 @@ pub enum PluginRequest {
     GetSelections,
 }
 
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "method", content = "params")]
 /// RPC commands sent from plugins.
@@ -182,6 +232,7 @@ pub enum PluginNotification {
     AddScopes { scopes: Vec<Vec<String>> },
     UpdateSpans { start: usize, len: usize, spans: Vec<ScopeSpan>, rev: u64 },
     Edit { edit: PluginEdit },
+    Completions { request_id: usize, response: Result<CompletionResponse, RemoteError> },
     Alert { msg: String },
     AddStatusItem { key: String, value: String, alignment: String },
     UpdateStatusItem { key: String, value: String  },

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -434,6 +434,10 @@ pub enum EditNotification {
     DebugWrapWidth,
     /// Prints the style spans present in the active selection.
     DebugPrintSpans,
+    CompletionsShow,
+    CompletionsCancel,
+    CompletionsSelect { index: usize },
+    CompletionsInsert { index: usize },
     CancelOperation,
     Uppercase,
     Lowercase,

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -751,10 +751,10 @@ impl<'a, I> Iterator for Iter<'a, I> where I: Iterator<Item=&'a ViewId> {
 }
 
 #[derive(Debug, Default)]
-struct Counter(Cell<usize>);
+pub(crate) struct Counter(Cell<usize>);
 
 impl Counter {
-    fn next(&self) -> usize {
+    pub(crate) fn next(&self) -> usize {
         let n = self.0.get();
         self.0.set(n + 1);
         n + 1

--- a/rust/plugin-lib/src/dispatch.rs
+++ b/rust/plugin-lib/src/dispatch.rs
@@ -117,6 +117,11 @@ impl<'a, P: 'a + Plugin> Dispatcher<'a, P> {
         self.views.remove(&view_id);
     }
 
+    fn do_completions(&mut self, view_id: ViewId, request_id: usize, pos: usize) {
+        let v = bail!(self.views.get_mut(&view_id), "completions", self.pid, view_id);
+        self.plugin.completions(v, request_id, pos)
+    }
+
     fn do_shutdown(&mut self) {
         eprintln!("rust plugin lib does not shutdown");
         //TODO: handle shutdown
@@ -186,6 +191,8 @@ impl<'a, P: Plugin> RpcHandler for Dispatcher<'a, P> {
                 self.do_new_buffer(ctx, buffer_info),
             DidClose { view_id } =>
                 self.do_close(view_id),
+            Completions { view_id, request_id, pos } =>
+                self.do_completions(view_id, request_id, pos),
             Shutdown ( .. ) =>
                 self.do_shutdown(),
             TracingConfig { enabled } =>

--- a/rust/plugin-lib/src/lib.rs
+++ b/rust/plugin-lib/src/lib.rs
@@ -142,6 +142,10 @@ pub trait Plugin {
                       view: &mut View<Self::Cache>,
                       changes: &ConfigTable);
 
+    #[allow(unused_variables)]
+    fn completions(&mut self, view: &mut View<Self::Cache>,
+                   request_id: usize, pos: usize) { }
+
     /// Called when the runloop is idle, if the plugin has previously
     /// asked to be scheduled via `View::schedule_idle()`. Plugins that
     /// are doing things like full document analysis can use this mechanism
@@ -150,7 +154,6 @@ pub trait Plugin {
     fn idle(&mut self, view: &mut View<Self::Cache>) { }
 
     /// Language Plugins specific methods
-    
     #[allow(unused_variables)]
     fn get_hover(&mut self, view: &mut View<Self::Cache>, request_id: usize, position: usize) { }
 }

--- a/rust/sample-plugin/Cargo.toml
+++ b/rust/sample-plugin/Cargo.toml
@@ -21,3 +21,6 @@ path = "../rope"
 
 [dependencies.xi-trace]
 path = "../trace"
+
+[dependencies.xi-rpc]
+path = "../rpc"


### PR DESCRIPTION
This is intended as a starting point for ongoing completions work. I think it would be nice if we could try and wrap up a _basic_ proof of concept for completions next week, as a nice marker for the summer's GSoC work. This will entail some coordination between @betterclever, @nangtrongvuon and myself, and I thought this PR might make a good platform for that work. @betterclever, we can try something new here and use this branch as a feature branch, and you can submit PRs against it.

## Basic Autocomplete Todos:

This will require work on three fronts.

### Language Plugins

The LSP plugin will need to:
- [ ] handle the `completions` RPC from core
- [ ] handle the response, converting it into a core-appropriate format
- [ ] return the result or error to the core.

### Core

Much of the completions work will be in core. Core must collect results from the (possibly multiple) plugin(s), and also filter and sort the results in response to client input, while keeping the client updated. Almost all of the state for a given completions request lives in core. Most of the following RPCs are in place, but may not have real implementations yet.

- [ ] implement client->core `completions_show` RPC
- [ ] implement client->core `completions_cancel` RPC, (probably); 
- [ ] implement client->core `completion_select` RPC, for when the client navigates up and down the completions list; this will be used to fetch additional completion information from the plugin if necessary.
- [ ] implement client->core `completion_insert` RPC, for when the client actually choses a completion; this will apply the completion's edit.
- [ ] implement the logic for applying the edit
- [ ] implement a _basic_ filtering/sorting mechanism, and calling it appropriately when the client enters text while completions are active


### Client

- [ ] send `completions`  RPC in response to some debug hotkey
- [ ] display list of completions when receiving `completions` response
- [ ] allow navigation between items in the list, sending `select_completion` RPC as selection changes
- [ ] update existing completions when receiving new `completions` calls.
- [ ] send `insert_completion` when the user selects a completion.

This can all  be very barebones. In particular, I don't want to spend much time on the sorting/filtering functions in core, and I don't want to worry about displaying documentation or extra details in the client; let's just try and get the plumbing in place, and we can go from there?