### PR TITLE
Rename "split_selection_into_lines" to "selection_into_lines" in docs

### DIFF
--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -290,7 +290,7 @@ valid next occurrence. Supported options for `modify_selection` are:
 * `none`: the selection is not modified
 * `set`: the next/previous match will be set as the new selection
 * `add`: the next/previous match will be added to the current selection
-* `add_remove_current`: the previously added selection will be removed and the next/previous 
+* `add_remove_current`: the previously added selection will be removed and the next/previous
 match will be added to the current selection
 
 Selects the next/previous occurrence matching the search query.
@@ -340,9 +340,9 @@ Replaces the next matching occurrence with the replacement string.
 
 Replaces all matching occurrences with the replacement string.
 
-#### split_selection_into_lines
+#### selection_into_lines
 
-`split_selection_into_lines { }`
+`selection_into_lines { }`
 
 Splits all current selections into lines.
 


### PR DESCRIPTION
According to [this](https://github.com/google/xi-editor/blob/2f8710088313ecd4480ad72b0095d149ffbe42de/rust/core-lib/src/edit_types.rs#L47)