### PR TITLE
Make themes dir when making config dir

### DIFF
--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -673,6 +673,7 @@ pub(crate) fn init_config_dir(dir: &Path) -> io::Result<()> {
     let builder = fs::DirBuilder::new();
     builder.create(dir)?;
     builder.create(dir.join("plugins"))?;
+    builder.create(dir.join("themes"))?;
     Ok(())
 }
 


### PR DESCRIPTION
Users who already have a config directory will need to manually create the 'themes' directory, but this will create it for new installs.