### PR TITLE
Backspace now deletes up to tab_size spaces

### DIFF
--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -345,7 +345,7 @@ impl Editor {
                 // backspace deletes max(1, tab_size) contiguous spaces
                 let (_, c) = view.offset_to_line_col(&self.text, region.start);
 
-                let tab_off = c & config.tab_size;
+                let tab_off = c % config.tab_size;
                 let tab_size = config.tab_size;
                 let tab_size = if tab_off == 0 { tab_size } else { tab_off };
                 let tab_start = region.start.saturating_sub(tab_size);


### PR DESCRIPTION
This is an attempt to fix #716. 

Backspace should now have correct behavior, which is deleting up to config.tab_size at a time for each backspace press. Care was also taken not to regress #713/#714.
